### PR TITLE
Build system updates

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -10,7 +10,7 @@ $filesFailed = $false
 
 foreach ($file in $scriptFiles) {
 
-    $scriptFormatter = .\Invoke-CodeFormatter.ps1 -ScriptLocation $file -CodeFormattingLocation .\CodeFormatting.psd1 -ScriptAnalyzer -ExcludeRules PSAvoidUsingWriteHost
+    $scriptFormatter = & $PSScriptRoot\Invoke-CodeFormatter.ps1 -ScriptLocation $file -CodeFormattingLocation $PSScriptRoot\CodeFormatting.psd1 -ScriptAnalyzer -ExcludeRules PSAvoidUsingWriteHost
 
     if ($scriptFormatter.StringContent -ne $scriptFormatter.FormattedScript -or
         $null -ne $scriptFormatter.AnalyzedResults) {
@@ -22,7 +22,7 @@ foreach ($file in $scriptFiles) {
             Write-Host ("Failed to follow the same format defined in the repro")
             git diff ($($scriptFormatter.StringContent) | git hash-object -w --stdin) ($($scriptFormatter.FormattedScript) | git hash-object -w --stdin)
         }
-        
+
         if ($null -ne $scriptFormatter.AnalyzedResults) {
             Write-Host ("Failed Results from Invoke-PSScriptAnalyzer:")
             $scriptFormatter.AnalyzedResults | Format-Table -AutoSize

--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -12,13 +12,13 @@ foreach ($file in $scriptFiles) {
 
     $scriptFormatter = & $PSScriptRoot\Invoke-CodeFormatter.ps1 -ScriptLocation $file -CodeFormattingLocation $PSScriptRoot\CodeFormatting.psd1 -ScriptAnalyzer -ExcludeRules PSAvoidUsingWriteHost
 
-    if ($scriptFormatter.StringContent -ne $scriptFormatter.FormattedScript -or
+    if ($scriptFormatter.StringContent -cne $scriptFormatter.FormattedScript -or
         $null -ne $scriptFormatter.AnalyzedResults) {
 
         $filesFailed = $true
         Write-Host ("{0}:" -f $file)
 
-        if ($scriptFormatter.StringContent -ne $scriptFormatter.FormattedScript) {
+        if ($scriptFormatter.StringContent -cne $scriptFormatter.FormattedScript) {
             Write-Host ("Failed to follow the same format defined in the repro")
             git diff ($($scriptFormatter.StringContent) | git hash-object -w --stdin) ($($scriptFormatter.FormattedScript) | git hash-object -w --stdin)
         }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": false,
     "powershell.codeFormatting.whitespaceInsideBrace": true,
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/Backups/VSSTester.ps1
+++ b/Backups/VSSTester.ps1
@@ -453,7 +453,7 @@ function createDiskShadowFile {
     #	add the volumes for the included database
     #	-----------------------------------------
     #gets a list of mount points on local server
-    $mpvolumes = get-wmiobject -query "select name, deviceid from win32_volume where drivetype=3 AND driveletter=NULL"
+    $mpvolumes = Get-WmiObject -Query "select name, deviceid from win32_volume where drivetype=3 AND driveletter=NULL"
     $deviceIDs = @()
 
     #if selected database is a mailbox database, get mailbox paths

--- a/PublicFolders/SourceSideValidations/Get-BadPermission.ps1
+++ b/PublicFolders/SourceSideValidations/Get-BadPermission.ps1
@@ -1,4 +1,4 @@
-function Get-BadPermissions {
+function Get-BadPermission {
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -15,7 +15,7 @@ function Get-BadPermissions {
         $folderData.IpmSubtreeByMailbox | ForEach-Object {
             $argumentList = $FolderData.MailboxToServerMap[$_.Name], $_.Name, $_.Group
             $name = $_.Name
-            $scriptBlock = ${Function:Get-BadPermissionsJob}
+            $scriptBlock = ${Function:Get-BadPermissionJob}
             Add-JobQueueJob @{
                 ArgumentList = $argumentList
                 Name         = "$name Permissions Check"
@@ -23,7 +23,7 @@ function Get-BadPermissions {
             }
         }
 
-        $completedJobs = Wait-QueuedJobs
+        $completedJobs = Wait-QueuedJob
         foreach ($job in $completedJobs) {
             if ($job.BadPermissions.Count -gt 0) {
                 $badPermissions = $badPermissions + $job.BadPermissions
@@ -32,7 +32,7 @@ function Get-BadPermissions {
     }
 
     end {
-        Write-Host "Get-BadPermissions duration" ((Get-Date) - $startTime)
+        Write-Host "Get-BadPermission duration" ((Get-Date) - $startTime)
         return $badPermissions
     }
 }

--- a/PublicFolders/SourceSideValidations/Get-BadPermissionJob.ps1
+++ b/PublicFolders/SourceSideValidations/Get-BadPermissionJob.ps1
@@ -1,4 +1,4 @@
-function Get-BadPermissionsJob {
+function Get-BadPermissionJob {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Incorrect rule result')]
     param (

--- a/PublicFolders/SourceSideValidations/Get-BadPermissions.ps1
+++ b/PublicFolders/SourceSideValidations/Get-BadPermissions.ps1
@@ -12,7 +12,7 @@ function Get-BadPermissions {
     }
 
     process {
-        $folderData.IpmSubtreeByMailbox | Foreach-Object {
+        $folderData.IpmSubtreeByMailbox | ForEach-Object {
             $argumentList = $FolderData.MailboxToServerMap[$_.Name], $_.Name, $_.Group
             $name = $_.Name
             $scriptBlock = ${Function:Get-BadPermissionsJob}

--- a/PublicFolders/SourceSideValidations/Get-ItemCount.ps1
+++ b/PublicFolders/SourceSideValidations/Get-ItemCount.ps1
@@ -1,4 +1,4 @@
-function Get-ItemCounts {
+function Get-ItemCount {
     <#
     .SYNOPSIS
         Populates the ItemCount property on our PSCustomObjects.
@@ -40,6 +40,6 @@ function Get-ItemCounts {
             $FolderData.IpmSubtree | Export-Csv $PSScriptRoot\IpmSubtree.csv
         }
 
-        Write-Host "Get-ItemCounts duration" ((Get-Date) - $startTime)
+        Write-Host "Get-ItemCount duration" ((Get-Date) - $startTime)
     }
 }

--- a/PublicFolders/SourceSideValidations/JobQueue.ps1
+++ b/PublicFolders/SourceSideValidations/JobQueue.ps1
@@ -20,7 +20,7 @@ function Add-JobQueueJob {
     }
 }
 
-function Wait-QueuedJobs {
+function Wait-QueuedJob {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     param (

--- a/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
+++ b/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
@@ -7,11 +7,11 @@ param (
 
 . .\Get-IpmSubtree.ps1
 . .\Get-NonIpmSubtree.ps1
-. .\Get-ItemCounts.ps1
+. .\Get-ItemCount.ps1
 . .\Get-LimitsExceeded.ps1
 . .\Get-BadDumpsterMappings.ps1
-. .\Get-BadPermissions.ps1
-. .\Get-BadPermissionsJob.ps1
+. .\Get-BadPermission.ps1
+. .\Get-BadPermissionJob.ps1
 . .\JobQueue.ps1
 
 $startTime = Get-Date
@@ -62,7 +62,7 @@ if ($script:anyDatabaseDown) {
     return
 }
 
-Get-ItemCounts -FolderData $FolderData
+Get-ItemCount -FolderData $FolderData
 
 # Now we're ready to do the checks
 
@@ -70,7 +70,7 @@ $badDumpsters = Get-BadDumpsterMappings -FolderData $folderData
 
 $limitsExceeded = Get-LimitsExceeded -FolderData $folderData
 
-$badPermissions = Get-BadPermissions -FolderData $folderData
+$badPermissions = Get-BadPermission -FolderData $folderData
 
 # Output the results
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,50 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+# Development
+
+It is recommended to use Visual Studio Code when developing scripts for this project. Opening VSCode at
+the root of this repo will ensure that VSCode uses the settings in the repro to enforce most of the
+formatting rules.
+
+Before committing, .build\CodeFormatter.ps1 should be run. This script will apply PSScriptAnalyzer
+formatting rules, and will show any required changes in the form of a diff output. It's a good idea to
+set the following setting to avoid erroneous ^M characters in the diff output:
+
+`git config core.whitespace cr-at-eol`
+
+# Building
+
+This repo uses a unique and fairly simple build system to create a single release script from a multi-file
+script project. You can check the output of this system by running the `.build\Build.ps1` script and
+checking the `dist` folder. There are currently two things the build system looks for.
+
+## Including a script in another script
+
+Dot-sourcing a script inside another script embeds the target script into the source script. For example,
+placing the following line inside of Script1.ps1 causes Script2.ps1 to be embedded at that point in Script1.
+Script2 is then excluded from release:
+
+`. .\Script2.ps1`
+
+You can embed any number of scripts. These could be in the same folder or in a child folder. See the
+`SourceSideValidation.ps1` script in this repo for an example of this.
+
+Because dot-sourcing works normally at development time, the multi-file script can be run and debugged
+without building at dev time.
+
+## Including other file types in a script
+
+Non-script files can be embedded in a script as well. This is accomplished with the following syntax:
+
+`$someVarName = Get-Content .\someresource.txt -AsByteStream -Raw`
+
+This command populates $someVarName with the binary content of the target file. You can then use that
+data however you like, such as converting it to text or processing it some other way. See the `ExTRA.ps1`
+script in this repo, which embeds a .txt and .html file in this way.
+
+Again, things work normally at dev time and can be debugged without building. However, note that
+-AsByteStream is only available in PowerShell Core, so PowerShell Core must be used at dev time for
+this type of script. The PowerShell Core requirement goes away in the release version since the file
+is then embedded in the script.


### PR DESCRIPTION
* Make CodeFormatter work without changing into the .build folder.
* Update VSCode settings to auto trim whitespace on save, to avoid having to fix this manually when CodeFormatter flags it.
* Make CodeFormatter enforce case changes in formatting.
* Flesh out the README to explain our build system.
* Fix pluralization issues for PSUseSingluarNouns which will soon be enforced in Powershell Core.