### PR TITLE
Fix CVE-2021-27065 reference

### DIFF
--- a/Security/Test-Hafnium.ps1
+++ b/Security/Test-Hafnium.ps1
@@ -51,7 +51,7 @@ function Get-26857() {
 }
 
 function Get-27065() {
-    Write-Host "`r`nChecking for CVE-2021-26857 in the ECP Logs"
+    Write-Host "`r`nChecking for CVE-2021-27065 in the ECP Logs"
     $logs = Get-ChildItem -Recurse -Path "$exchangePath\Logging\ECP\Server\*.log" | Select-String "Set-.*VirtualDirectory" -List | Select-Object Path
     if ($logs.Path.Count -gt 0) {
         Write-Warning "Suspicious virtual directory modifications found in the following logs, please review them for `"Set-*VirtualDirectory`" entries:"


### PR DESCRIPTION
**Issue:**
Typo in output for CVE-2021-27065 output

