### PR TITLE
Return collections so we don't error on a single file

### DIFF
--- a/Security/Test-Hafnium.ps1
+++ b/Security/Test-Hafnium.ps1
@@ -63,8 +63,8 @@ function Get-27065() {
 
 function Get-SuspiciousFiles() {
     Write-Host "`r`nChecking for suspicious files"
-    $lsassFiles = Get-ChildItem -Recurse -Path "$env:WINDIR\temp\lsass.*dmp"
-    $lsassFiles += Get-ChildItem -Recurse -Path "c:\root\lsass.*dmp"
+    $lsassFiles = @(Get-ChildItem -Recurse -Path "$env:WINDIR\temp\lsass.*dmp")
+    $lsassFiles += @(Get-ChildItem -Recurse -Path "c:\root\lsass.*dmp")
     if ($lsassFiles.Count -gt 0) {
         Write-Warning "lsass.exe dumps found, please verify these are expected:"
         $lsassFiles.FullName


### PR DESCRIPTION
If it finds nothing on the first line, then the second line fails when it tries to add to null. We should generally wrap these Get-ChildItem calls in @() if we're going to treat the result like a collection.