### PR TITLE
Test-Hafnium progress bar tweaks

### DIFF
--- a/Security/Test-Hafnium.ps1
+++ b/Security/Test-Hafnium.ps1
@@ -7,10 +7,13 @@ function Get-26855() {
     $files = (Get-ChildItem -Recurse -Path "$exchangePath\Logging\HttpProxy" -Filter '*.log').FullName
     $count = 0
     $allResults = @()
+    $sw = New-Object System.Diagnostics.Stopwatch
+    $sw.Start()
     $files | ForEach-Object {
         $count++
-        if ($count % 10 -eq 0) {
+        if ($sw.ElapsedMilliseconds -gt 500) {
             Write-Progress -Activity "Checking for CVE-2021-26855 in the HttpProxy logs" -Status "$count / $($files.Count)" -PercentComplete ($count * 100 / $files.Count)
+            $sw.Restart()
         }
         if ((Get-ChildItem $_ -ErrorAction SilentlyContinue | Select-String "ServerInfo~").Count -gt 0) {
             $fileResults = @(Import-Csv -Path $_ -ErrorAction SilentlyContinue | Where-Object { $_.AnchorMailbox -like 'ServerInfo~*/*' })
@@ -19,6 +22,8 @@ function Get-26855() {
             }
         }
     }
+
+    Write-Progress -Activity "Checking for CVE-2021-26855 in the HttpProxy logs" -Completed
 
     if ($allResults.Length -gt 0) {
         Write-Warning "Suspicious entries found in $exchangePath\Logging\HttpProxy.  Check the .\CVE-2021-26855.csv log for specific entries."


### PR DESCRIPTION
- Only report progress every 500 milliseconds. This shaves off about
  12 seconds from the time it takes to run in my lab.
- Make sure progress bar is hidden with -Completed when done.