### PR TITLE
Fixed urls to use archive.org as  blog removed

### DIFF
--- a/Backups/README.md
+++ b/Backups/README.md
@@ -4,8 +4,7 @@ The script is self-explanatory. You can test run diskshadow on a single Exchange
 ![Start Screen](/Backups/Images/start_screen.PNG "Start Screen")
 
 ## More information
-* https://blogs.technet.microsoft.com/exchange/2013/04/29/troubleshoot-your-exchange-2010-database-backup-functionality-with-vsstester-script/
-* https://blogs.technet.microsoft.com/exchange/2015/03/26/vsstester-script-updated-troubleshoot-exchange-2013-and-2010-database-backups/
-  
+* https://web.archive.org/web/20190420161703/https://blogs.technet.microsoft.com/exchange/2013/04/29/troubleshoot-your-exchange-2010-database-backup-functionality-with-vsstester-script/
+* https://web.archive.org/web/20190419210725/https://blogs.technet.microsoft.com/exchange/2015/03/26/vsstester-script-updated-troubleshoot-exchange-2013-and-2010-database-backups/
 ## Contributing
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
**Issue:**
URLs in the readme refer to the now defunct You Had Me at Helo blog. The links just redirect to the default Exchange community blog as opposed to the specific blog post

**Reason:**
Updating links so that an archived copy of the original blog post is viewable so the users can read about the scripts purpose

**Fix:**
Updated links to go to archive.org's copy of the original blog post. 

**Validation:**
Links in readme.md work.