### PR TITLE
Update http-vuln-cve2021-26855.nse to work for 2013

### DIFF
--- a/Security/http-vuln-cve2021-26855.nse
+++ b/Security/http-vuln-cve2021-26855.nse
@@ -61,8 +61,9 @@ Exchange 2013 Versions < 15.00.1497.012, Exchange 2016 CU18 < 15.01.2106.013, Ex
   }
 
   local response = http.generic_request(host, port, method, path, { header = header })
+  local target = response.header['x-calculatedbetarget']
   
-  if response and response.status == 500 and response.body:find('NegotiateSecurityContext', 1, true) then
+  if response and response.status == 500 and string.match(target,'localhost') then
     vuln.state = vulns.STATE.VULN
   end
 


### PR DESCRIPTION
Fix NSE script to work for Exchange 2013

**Issue:**
Describe what the issue is you are addressing

**Reason:**
Describe what the reason is for making the change

**Fix:**
Short description of the fix

**Validation:**
Provide if applicable