### PR TITLE
Formatting updates

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -5,7 +5,7 @@ param(
 $repoRoot = Get-Item "$PSScriptRoot\.."
 
 $scriptFiles = Get-ChildItem -Path $repoRoot -Directory | Where-Object { $_.Name -ne ".build" -and
-    $_.Name -ne "dist"} | ForEach-Object { Get-ChildItem -Path $_.FullName *.ps1 -Recurse } | ForEach-Object { $_.FullName }
+    $_.Name -ne "dist" } | ForEach-Object { Get-ChildItem -Path $_.FullName -Include "*.ps1", "*.psm1" -Recurse } | ForEach-Object { $_.FullName }
 $filesFailed = $false
 
 foreach ($file in $scriptFiles) {

--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -1,5 +1,7 @@
 [CmdletBinding()]
 param(
+    [Switch]
+    $Save
 )
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
@@ -21,6 +23,11 @@ foreach ($file in $scriptFiles) {
         if ($scriptFormatter.StringContent -cne $scriptFormatter.FormattedScript) {
             Write-Host ("Failed to follow the same format defined in the repro")
             git diff ($($scriptFormatter.StringContent) | git hash-object -w --stdin) ($($scriptFormatter.FormattedScript) | git hash-object -w --stdin)
+
+            if ($Save) {
+                Set-Content -Path $file -Value $scriptFormatter.FormattedScript -Encoding utf8BOM
+                Write-Host "Saved $file with formatting corrections."
+            }
         }
 
         if ($null -ne $scriptFormatter.AnalyzedResults) {


### PR DESCRIPTION
* Include .psm1 files in format checks.
* Add a -Save switch to tell CodeFormatter to save the fixed format instead of having to do it manually:

![image](https://user-images.githubusercontent.com/4518572/110243716-2406b600-7f21-11eb-955a-a0559f820341.png)
