### PR TITLE
Save results by default

### DIFF
--- a/Security/README.md
+++ b/Security/README.md
@@ -17,9 +17,9 @@ To check the local server only, just run the script:
 
 `.\Test-ProxyLogon.ps1 -OutPath $home\desktop\logs`
 
-To display the results without saving them, drop the -Outpath parameter from either example above:
+To display the results without saving them, pass -DisplayOnly:
 
-`.\Test-ProxyLogon.ps1`
+`.\Test-ProxyLogon.ps1 -DisplayOnly`
 
 ## BackendCookieMitigation.ps1
 


### PR DESCRIPTION
First, this change actually fixes #96. We missed a spot.

This change also alters the syntax. There are three ways to
run the script:

This works as before:

`.\Test-ProxyLogon.ps1 -OutPath`

This sets -OutPath to $PSScriptRoot\Test-ProxyLogonLogs:

`.\Test-ProxyLogon.ps1`

This only displays results and does not save them:

`.\Test-ProxyLogon.ps1 -DisplayOnly`
