### PR TITLE
Fixes file extension regex

### DIFF
--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -161,7 +161,7 @@ process {
                             Name         = $file.Name
                         }
                     }
-                    foreach ($file in Get-ChildItem -Recurse -Path $env:ProgramData -ErrorAction SilentlyContinue | Where-Object Extension -Match ".7z$|.zip$|.rar$") {
+                    foreach ($file in Get-ChildItem -Recurse -Path $env:ProgramData -ErrorAction SilentlyContinue | Where-Object Extension -Match "\.7z$|\.zip$|\.rar$") {
                         [PSCustomObject]@{
                             ComputerName = $env:COMPUTERNAME
                             Type         = 'SuspiciousArchive'


### PR DESCRIPTION
**Issue:**
False positives are being reported due to overly broad file extension regex, for example: 

C:\ProgramData\[cut]2020-02-25T23-49-38.297Z

**Reason:**
Restrict the file extension matching regex to only match files that end with .7z, .zip, or .rar

**Fix:**
Escapes the period in the matching regex.

**Validation:**
```
> foreach($file in Get-ChildItem -Recurse -Path $env:ProgramData -ErrorAction SilentlyContinue | Where-Object Extension -Match ".7z$|.zip$|.rar$"){ 
    Write-Output($file.Name)
}
foo.asdfasdf7Z
New Compressed (zipped) Folder.zip

> foreach($file in Get-ChildItem -Recurse -Path $env:ProgramData -ErrorAction SilentlyContinue | Where-Object Extension -Match "\.7z$|\.zip$|\.rar$"){ 
    Write-Output($file.Name)
}
New Compressed (zipped) Folder.zip 
```