### PR TITLE
Fix for issue where Get-AgeInDays swaps day and month when parsing $dateString parameter.

### DIFF
--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -182,11 +182,11 @@ process {
 
                 function Get-AgeInDays {
                     param ( $dateString )
-                    if ( $dateString ){
+                    if ( $dateString -and $dateString -as [DateTime] ){
                         [System.Globalization.CultureInfo]$provider = [System.Globalization.CultureInfo]::InvariantCulture
                         $CURTIME = Get-Date
                         $age = $CURTIME.Subtract($dateString)
-                        return $age.TotalDays.ToString("N2")
+                        return $age.TotalDays.ToString("N1")
                     }
                     return ""
                 }

--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -181,17 +181,13 @@ process {
                 }
 
                 function Get-AgeInDays {
-                    param (
-                        [string]
-                        $dateString
-                    )
-
-                    $date = [DateTime]::MinValue
-                    if ([DateTime]::TryParse($dateString, [ref]$date)) {
-                        $age = [DateTime]::Now - $date
-                        return $age.TotalDays.ToString("N1")
+                    param ( $dateString )
+                    if ( $dateString ){
+                        [System.Globalization.CultureInfo]$provider = [System.Globalization.CultureInfo]::InvariantCulture
+                        $CURTIME = Get-Date
+                        $age = $CURTIME.Subtract($dateString)
+                        return $age.TotalDays.ToString("N2")
                     }
-
                     return ""
                 }
 


### PR DESCRIPTION
**Issue:**
The Get-AgeInDays function swapped month and date during the TryParse causing incorrect age calculation.
The OS had LCID = 1044.
Eg. dateString input  "07.02.2021 17.00.46", time format string "dd.mm.yyyy HH.MM.ss"

**Reason:**
Improving the age calculation function when ran locally on the exchange server.

**Fix:**
Removed the String conversion of the parameter, so it does not convert to string.
Checks if the variable contains data and is of type [DateTime]. If not it returns an empty string.
If DateTime, it grabs the current timestamp (Get-Date) and subtracts the supplied parameter value from the current timestamp. Then returns the age in TotalDays as a string with 1 decimal point.
Uses the CultureInfo to set a default LCID

**Validation:**
Tested on a system with LCID 1044, which fixed the age calculation error.