### PR TITLE
Allow exporting functions

### DIFF
--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -70,13 +70,12 @@ process {
 		Scans all exchange servers in the organization for ProxyLogon vulnerability compromises
 #>
         [CmdletBinding()]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "", Justification = "It's a PSCredential, not plain text")]
         param (
             [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
             [string[]]
             $ComputerName,
 
-            [object]
+            [System.Management.Automation.PSCredential]
             $Credential
         )
         begin {


### PR DESCRIPTION
- Drop version requirement to 3
- Remove hard PSCredential requirement
- Allow exporting functions so objects can be retrieved and
  piped for further processing.

![image](https://user-images.githubusercontent.com/4518572/110517112-0cb9fb00-80d0-11eb-9612-1cff5ea41f1d.png)

See #108 for discussion.