### PR TITLE
Improvements to Get-Cve26855

### DIFF
--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -117,7 +117,6 @@ process {
                     $sw = New-Object System.Diagnostics.Stopwatch
                     $sw.Start()
 
-                    # Start you loop here:
                     For ( $i = 0; $i -lt $files.Count; ++$i ) {
                         if ($sw.ElapsedMilliseconds -gt 500) {
                             Write-Progress -Activity $Activity -Status "$i / $($files.Count)" -PercentComplete ($i * 100 / $files.Count)
@@ -133,8 +132,6 @@ process {
                             ForEach-Object{
                                 [Void]$allResults.Hits.Add( $_ )
                             }
-
-
                         }
                     }
 

--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -96,34 +96,49 @@ process {
                         return
                     }
 
-                    Write-Progress -Activity "Checking for CVE-2021-26855 in the HttpProxy logs"
+                    $HttpProxyPath = Join-Path -Path $exchangePath -ChildPath "Logging\HttpProxy"
+                    $Activity = "Checking for CVE-2021-26855 in the HttpProxy logs"
 
-                    $files = (Get-ChildItem -Recurse -Path "$exchangePath\Logging\HttpProxy" -Filter '*.log').FullName
-                    $count = 0
+                    $outProps = @(
+                        "DateTime", "RequestId", "ClientIPAddress", "UrlHost",
+                        "UrlStem", "RoutingHint", "UserAgent", "AnchorMailbox",
+                        "HttpStatus"
+                    )
+
+                    $files = (Get-ChildItem -Recurse -Path $HttpProxyPath -Filter '*.log').FullName
+
                     $allResults = @{
-                        Hits     = @()
-                        FileList = @()
+                        Hits     = [System.Collections.ArrayList]@()
+                        FileList = [System.Collections.ArrayList]@()
                     }
+
+                    Write-Progress -Activity $Activity
+
                     $sw = New-Object System.Diagnostics.Stopwatch
                     $sw.Start()
-                    $files | ForEach-Object {
-                        $count++
 
+                    # Start you loop here:
+                    For ( $i = 0; $i -lt $files.Count; ++$i ) {
                         if ($sw.ElapsedMilliseconds -gt 500) {
-                            Write-Progress -Activity "Checking for CVE-2021-26855 in the HttpProxy logs" -Status "$count / $($files.Count)" -PercentComplete ($count * 100 / $files.Count)
+                            Write-Progress -Activity $Activity -Status "$i / $($files.Count)" -PercentComplete ($i * 100 / $files.Count)
                             $sw.Restart()
                         }
 
-                        if ((Get-ChildItem $_ -ErrorAction SilentlyContinue | Select-String "ServerInfo~").Count -gt 0) {
-                            $allResults.FileList += $_
-                            $fileResults = @(Import-Csv -Path $_ -ErrorAction SilentlyContinue | Where-Object { $_.AuthenticatedUser -eq '' -and $_.AnchorMailbox -Like 'ServerInfo~*/*' } | Select-Object -Property DateTime, RequestId, ClientIPAddress, UrlHost, UrlStem, RoutingHint, UserAgent, AnchorMailbox, HttpStatus)
-                            $fileResults | ForEach-Object {
-                                $allResults.Hits += $_
+                        if ( ( Test-Path $files[$i] ) -and ( Select-String -Path $files[$i] -Pattern "ServerInfo~" -Quiet ) ) {
+                            [Void]$allResults.FileList.Add( $files[$i] )
+
+                            Import-Csv -Path $files[$i] -ErrorAction SilentlyContinue |
+                            Where-Object { $_.AuthenticatedUser -eq '' -and $_.AnchorMailbox -Like 'ServerInfo~*/*' } |
+                            Select-Object -Property $outProps |
+                            ForEach-Object{
+                                [Void]$allResults.Hits.Add( $_ )
                             }
+
+
                         }
                     }
 
-                    Write-Progress -Activity "Checking for CVE-2021-26855 in the HttpProxy logs" -Completed
+                    Write-Progress -Activity $Activity -Completed
 
                     return $allResults
                 }


### PR DESCRIPTION
**Issue:**
Improve performance of Get-Cve26855

**Reason:**
1) using Select-String as a bool doesn't require reading the whole file.
2) Using Get-ChildItem to test file existence and prevent downstream errors is comparatively slow compared to other methods.
3) Using += to incrementally add to an array is slow. Especially if repeated.

**Fix:**
1) Use -Quiet switch to limit file read to the first match.
2) Use Test-Path to validate file before attempting to run Select-String
3) Use [ArrayList] in place of typical arrays.

**Other**

- Use variable with Join-Path to avoid extra "\" in the log path
- assign output properties to an array to cleanup Select-Object command.
- Removing unnecessary $filelist variable and array subexpression wrapping.

**Validation:**
Ran against files with spoofed bad entries and results looked ok...