### PR TITLE
typo in patternsyntax

### DIFF
--- a/Security/ExchangeMitigations.ps1
+++ b/Security/ExchangeMitigations.ps1
@@ -340,7 +340,7 @@ Function BackendCookieMitigation {
                 }
 
 
-                Add-WebConfigurationProperty -PSPath $site -filter $root -name '.' -value @{name = $name; patterSyntax = 'Regular Expressions'; stopProcessing = 'False' }
+                Add-WebConfigurationProperty -PSPath $site -filter $root -name '.' -value @{name = $name; patternSyntax = 'Regular Expressions'; stopProcessing = 'False' }
                 Set-WebConfigurationProperty -PSPath $site -filter "$filter/match" -name 'url' -value $inbound
                 Set-WebConfigurationProperty -PSPath $site -filter "$filter/conditions" -name '.' -value @{input = $HttpCookieInput; matchType = '0'; pattern = $pattern; ignoreCase = 'True'; negate = 'False' }
                 Set-WebConfigurationProperty -PSPath $site -filter "$filter/action" -name 'type' -value 'AbortRequest'


### PR DESCRIPTION
**Issue:**
patterSyntax -> patternSyntax

**Reason:**
Make syntax explicitly correct. (Defaults to patternSyntax -> Regex anyway)

**Fix:**
Add an n

**Validation:**
Tested on IIS 10 - original and typo fix produce identical outcomes.