### PR TITLE
Add LastWriteTimeUtc to object info of dump files

### DIFF
--- a/Security/Test-ProxyLogon.ps1
+++ b/Security/Test-ProxyLogon.ps1
@@ -201,6 +201,7 @@ begin {
                                 Type         = 'LsassDump'
                                 Path         = $_.FullName
                                 Name         = $_.Name
+                                LastWrite    = $_.LastWriteTimeUtc
                             }
                         }
 
@@ -212,6 +213,7 @@ begin {
                                     Type         = 'SuspiciousArchive'
                                     Path         = $_.FullName
                                     Name         = $_.Name
+                                    LastWrite    = $_.LastWriteTimeUtc
                                 }
                             }
                         }


### PR DESCRIPTION
Useful information for admins to determine how long the files have been there etc. Older the file, the less likely the zip is related to an IOC.