### PR TITLE
Improve otherWellKnownObjects parsing

### DIFF
--- a/Setup/SetupAssist.ps1
+++ b/Setup/SetupAssist.ps1
@@ -11,6 +11,8 @@ param(
     [switch]$OtherWellKnownObjects
 )
 
+. $PSScriptRoot\Utils\ConvertFrom-Ldif.ps1
+
 function IsAdministrator {
     $ident = [System.Security.Principal.WindowsIdentity]::GetCurrent()
     $prin = New-Object System.Security.Principal.WindowsPrincipal($ident)
@@ -203,70 +205,45 @@ Function Test-OtherWellKnownObjects {
     $rootDSE = [ADSI]("LDAP://RootDSE")
     $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
 
-    ldifde -d $exchangeContainerPath -p Base -l otherWellKnownObjects -f ExchangeContainerOriginal.txt
+    ldifde -d $exchangeContainerPath -p Base -l otherWellKnownObjects -f $PSScriptRoot\ExchangeContainerOriginal.txt
 
-    [array]$content = Get-Content .\ExchangeContainerOriginal.txt
+    $ldifObjects = @(Get-Content $PSScriptRoot\ExchangeContainerOriginal.txt | ConvertFrom-Ldif)
 
-    if ($null -eq $content -or
-        $content.Count -eq 0) {
+    if ($ldifObjects.Length -lt 1) {
         throw "Failed to export ExchangeContainerOriginal.txt file"
     }
 
-    $owkoLine = "otherWellKnownObjects:"
-    $inOwkoLine = $false
-    $outputLines = New-Object 'System.Collections.Generic.List[string]'
-    $outputLines.Add($content[0])
-    $outputLines.Add("changeType: modify")
-    $outputLines.Add("replace: otherWellKnownObjects")
-
-    $index = 0
-    while ($index -lt $content.Count) {
-        $line = $content[$index++]
-
-        if ($line.Trim() -eq $owkoLine) {
-
-            if ($null -ne $testStringLine -and
-                $null -ne $possibleAdd) {
-
-                if (!($testStringLine -like "*CN=Deleted Objects*")) {
-                    $outputLines.AddRange($possibleAdd)
-                } else {
-                    Write-Host "Found object to remove: $testStringLine"
-                }
-            }
-            $inOwkoLine = $true
-            $possibleAdd = New-Object 'System.Collections.Generic.List[string]'
-            $possibleAdd.Add($line)
-            [string]$testStringLine = $line
-            continue
-        }
-
-        if ($inOwkoLine) {
-            $possibleAdd.Add($line)
-            $testStringLine += $line
-        }
-
-        if ($index -eq $content.Count) {
-
-            if (!($testStringLine -like "*CN=Deleted Objects*")) {
-                $outputLines.AddRange($possibleAdd)
-            } else {
-                Write-Host "Found object to remove: $testStringLine"
-            }
-        }
+    if ($ldifObjects.Length -gt 1) {
+        throw "Unexpected LDIF data."
     }
 
-    if ([string]::IsNullOrEmpty($outputLines[-1])) {
-        $outputLines[-1] = "-"
-    } else {
+    $exchangeContainer = $ldifObjects[0]
+    $badValues = @($exchangeContainer.otherWellKnownObjects | Where-Object { $_ -like "*CN=Deleted Objects*" })
+    if ($badValues.Length -gt 0) {
+        Write-Host
+        Write-Warning "otherWellKnownObjects contains the following deleted objects:"
+        Write-Host
+        $badValues | ForEach-Object { Write-Host $_ }
+
+        $outputLines = New-Object 'System.Collections.Generic.List[string]'
+        $outputLines.Add("dn: " + $exchangeContainer.dn[0])
+        $outputLines.Add("changeType: modify")
+        $outputLines.Add("replace: otherWellKnownObjects")
+
+        $goodValues = @($exchangeContainer.otherWellKnownObjects | Where-Object { $_ -notlike "*CN=Deleted Objects*" })
+        $goodValues | ForEach-Object { $outputLines.Add("otherWellKnownObjects: " + $_) }
         $outputLines.Add("-")
+        $outputLines.Add("")
+        $outputLines | Out-File -FilePath "ExchangeContainerImport.txt"
+
+        Write-Host("`r`nVerify the results in ExchangeContainerImport.txt. Then run the following command:")
+        Write-Host("`r`n`tldifde -i -f ExchangeContainerImport.txt")
+        Write-Host("`r`nThen, run Setup.exe /PrepareAD to recreate the deleted groups.")
+        Write-Host
+    } else {
+        Write-Host "No bad values found in otherWellKnownObjects."
     }
 
-    $outputLines | Out-File -FilePath "ExchangeContainerImport.txt"
-
-    Write-Host("`r`nVerify the results in ExchangeContainerImport.txt. Then run the following command:")
-    Write-Host("`r`n`tldifde -i -f ExchangeContainerImport.txt")
-    Write-Host("`r`nRun Setup.exe again afterwards.")
     return
 }
 

--- a/Setup/Utils/ConvertFrom-Ldif.ps1
+++ b/Setup/Utils/ConvertFrom-Ldif.ps1
@@ -1,0 +1,84 @@
+function ConvertFrom-Ldif {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        [string[]]
+        $LdifData
+    )
+
+    begin {
+        $allLines = @()
+    }
+
+    process {
+        foreach ($line in $LdifData) {
+            $allLines += $line
+        }
+    }
+
+    end {
+        $unfoldedLdif = Get-UnfoldedLdif -LdifData $allLines
+        Get-LdifObjects -UnfoldedLdifData $unfoldedLdif
+    }
+}
+
+function Get-UnfoldedLdif {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param (
+        [Parameter()]
+        [string[]]
+        $LdifData
+    )
+
+    process {
+        $unfolded = @()
+
+        for ($i = 0; $i -lt $LdifData.Length; $i++) {
+            $line = $LdifData[$i]
+            if ($line.StartsWith(" ")) {
+                $unfolded[$unfolded.Length - 1] += $line.Substring(1)
+            } else {
+                $unfolded += $line
+            }
+        }
+
+        $unfolded
+    }
+}
+
+function Get-LdifObjects {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param (
+        [Parameter()]
+        [string[]]
+        $UnfoldedLdifData
+    )
+
+    process {
+        [PSCustomObject[]]$objects = @()
+
+        $currentObject = @{}
+
+        for ($i = 0; $i -lt $UnfoldedLdifData.Length; $i++) {
+            $line = $UnfoldedLdifData[$i]
+            if ($line.Length -lt 1) {
+                if ($null -ne $currentObject["dn"]) {
+                    $objects += $currentObject
+                    $currentObject = @{}
+                }
+            } else {
+                $propName = $line.Substring(0, $line.IndexOf(":"))
+                $propValue = $line.Substring($line.IndexOf(":") + 2)
+                if ($null -eq $currentObject[$propName]) {
+                    $currentObject[$propName] = @()
+                }
+
+                $currentObject[$propName] += $propValue
+            }
+        }
+
+        $objects
+    }
+}


### PR DESCRIPTION
New experience:

![image](https://user-images.githubusercontent.com/4518572/110737762-98787800-81f3-11eb-8cd0-9f8cbace2570.png)

We correctly handle wrapped Deleted Objects values with the new ConvertFrom-Ldif function, which unwraps the entire export and returns it as an array of PSCustomObjects.