### PR TITLE
Use basic parsing for IWR.

### DIFF
--- a/Security/src/CompareExchangeHashes.ps1
+++ b/Security/src/CompareExchangeHashes.ps1
@@ -534,14 +534,14 @@ function LoadFromGitHub($url, $filename, $installed_versions) {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
         # this file is only used for network connectivity test
-        Invoke-WebRequest -Uri "https://github.com/microsoft/CSS-Exchange/releases/latest/download/baseline_15.0.1044.25.checksum.txt" | Out-Null
+        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/microsoft/CSS-Exchange/releases/latest/download/baseline_15.0.1044.25.checksum.txt" | Out-Null
     } catch {
         Write-Error "Cannot reach out to https://github.com/microsoft/CSS-Exchange/releases/latest, please download baseline files for $installed_versions from https://github.com/microsoft/CSS-Exchange/releases/latest manually to $(GetCurrDir), then rerun this script from $(GetCurrDir)."
     }
 
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest -Uri $url -OutFile $filename | Out-Null
+        Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $filename | Out-Null
     } catch {
         Write-Error "$filename not found... please open issue on https://github.com/microsoft/CSS-Exchange/issues, we will work on it"
     }


### PR DESCRIPTION
**Issue:**
Download of Baselines fails if the Internet Explorer is not configured.

**Reason:**
Powershell uses parts of the Internet Explorer to parse responses of Invoke-WebRequest. For new accounts the Internet Explorer is possibly not configured. 

**Fix:**
Add `-UseBasicParsing` to `Invoke-WebRequest` calls. As the downloaded files are either plain text or Zip archives, no parsing whatsoever is required anyway.

**Validation:**
Before:

```
[03/11/2021 18:11:21] Started...
Found exchange version: 15.0.1497.2
Can't find local baseline for 15.0.995.28
Downloading baseline file from GitHub to C:\Users\exchadmin\Desktop\CSS-Exchange
-21.03.11.1408\Security\src\Baselines\baseline_15.0.995.28.zip
LoadFromGitHub : Cannot reach out to
https://github.com/microsoft/CSS-Exchange/releases/latest, please download
baseline files for 15.0.995.28 15.0.516.30 15.0.1104.5 15.0.1473.5 15.0.1497.0
15.0.1497.2 15.0.1473.3 15.0.1497.12 15.0.620.29 15.0.1497.6 15.0.1395.4
15.0.995.32 15.0.712.23 15.0.1263.5 from
https://github.com/microsoft/CSS-Exchange/releases/latest manually to
C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security\src\Baselines,
then rerun this script from
C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security\src\Baselines.
In C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security\src\CompareEx
changeHashes.ps1:629 Zeichen:13
+             LoadFromGitHub -url $zip_file_url -filename $zip_file -in ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,LoadFromGitHub
```

After adding flag (there is still an error, because the zip file does not exist on Github; the connection test by downloading a text file succeeds):

```
PS C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security\src> .\Compare
ExchangeHashes.ps1
[03/11/2021 18:28:22] Started...
Found exchange version: 15.0.1497.2
Can't find local baseline for 15.0.995.28
Downloading baseline file from GitHub to C:\Users\exchadmin\Desktop\CSS-Exchange
-21.03.11.1408\Security\src\baseline_15.0.995.28.zip
LoadFromGitHub : C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security
\src\baseline_15.0.995.28.zip not found... please open issue on
https://github.com/microsoft/CSS-Exchange/issues, we will work on it
In C:\Users\exchadmin\Desktop\CSS-Exchange-21.03.11.1408\Security\src\CompareEx
changeHashes.ps1:629 Zeichen:13
+             LoadFromGitHub -url $zip_file_url -filename $zip_file -in ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,LoadFromGitHub
```