### PR TITLE
Fix single hit problem for 26855 test

### DIFF
--- a/Security/src/Test-ProxyLogon.ps1
+++ b/Security/src/Test-ProxyLogon.ps1
@@ -258,7 +258,7 @@ begin {
 
                 [PSCustomObject]@{
                     ComputerName = $env:COMPUTERNAME
-                    Cve26855     = @(Get-Cve26855)
+                    Cve26855     = Get-Cve26855
                     Cve26857     = @(Get-Cve26857)
                     Cve26858     = @(Get-Cve26858)
                     Cve27065     = @(Get-Cve27065)


### PR DESCRIPTION
PR #184 introduced a single hit bug on the 26855 test. Prior to this
PR, Get-Cve26855 returned a collection, and because we wrapped the
call in @(), it was still a collection even if only one object was
returned. With this PR, Get-Cve26855 now returns a PSCustomObject,
and that means wrapping the result in @() actually _causes_ a
single hit problem.
