### PR TITLE
Release as draft

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,3 +89,4 @@ steps:
       dist\*.zip
       dist\*.txt
     addChangeLog: true
+    isDraft: true


### PR DESCRIPTION
The releases are so large now, it is taking 5-10 minutes to upload
everything. During this time, the release can be viewed with only
partial files, and this may cause unexpected results from
CompareExchangeHashes.

This change causes the releases to be saved as a Draft, which can
then be released with a click, causing all assets to go live at
the same time.