### PR TITLE
Proper Check for Admin

### DIFF
--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -718,7 +718,7 @@ Microsoft saved several files to your system to "$EOMTDir". The only files that 
 }
 
 if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    Write-Host "Unable to launch EOMT.ps1: please re-run as administrator." -ForegroundColor Red
+    Write-Error "Unable to launch EOMT.ps1: please re-run as administrator."
     exit
 }
 

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -717,6 +717,11 @@ Microsoft saved several files to your system to "$EOMTDir". The only files that 
     $summary | Out-File -FilePath $SummaryFile -Encoding ascii -Force
 }
 
+if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    Write-Host "Unable to launch EOMT.ps1: please re-run as administrator." -ForegroundColor Red
+    exit
+}
+
 # Main
 try {
     $Stage = "EOMTStart"
@@ -728,14 +733,6 @@ try {
     $Message = "Starting EOMT.ps1 on $env:computername"
     $RegMessage = "Starting EOMT.ps1"
     Set-LogActivity -Stage $Stage -RegMessage $RegMessage -Message $Message
-
-    #IsAdmin?
-    if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-        $Message = "Unable to launch EOMT.ps1: please re-run as administrator."
-        $RegMessage = "Insufficient permissions"
-        Set-LogActivity -Error -Stage $Stage -RegMessage $RegMessage -Message $Message
-        throw
-    }
 
     #IsPS3 or later?
     if ($PSVersionTable.PSVersion.Major -lt 3) {


### PR DESCRIPTION
Can't have a failed admin check call into ` Set-LogActivity ` as this sets values in the registry. Can't set values in the registry without being an Admin.

Running without Admin before fix:

![image](https://user-images.githubusercontent.com/22776718/111215695-6d01de80-85a1-11eb-94c8-b968e1184039.png)


After fix:

![image](https://user-images.githubusercontent.com/22776718/111215737-7a1ecd80-85a1-11eb-83d7-b4f89d3e7abe.png)
