### PR TITLE
Fix version check to not report E2016CU20 and E19CU9 as vulnerable

### DIFF
--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -587,7 +587,7 @@ function Get-ServerVulnStatus {
         $LatestCU = "15.2.000.0000" #version higher than 15.0 to trigger SecurityHotfix check for E15
     }
 
-    if ([version]$LatestCU -ge [version]$Version) {
+    if ([version]$LatestCU -gt [version]$Version) {
 
         $SecurityHotfix = Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\* `
         | Where-Object displayname -Like "*KB5000871*" `


### PR DESCRIPTION
**Issue:**
EOMT still reports E2016CU20/E2019CU9 as vulnerable

**Reason:**
EOMT should report latest CU which includes the patches as not vulnerable

**Fix:**
Changes "if patchedversion >= currentversion" to "if patchedversion > currentversion"

**Validation:**
Provide if applicable