### PR TITLE
Update EX19 CU9 Build Version

### DIFF
--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -575,7 +575,7 @@ function Get-ServerVulnStatus {
 
     $Version = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup\').OwaVersion
     $FutureCUs = @{
-        E19CU9  = "15.2.858.5"
+        E19CU9  = "15.2.858.2"
         E16CU20 = "15.1.2242.4"
     }
 


### PR DESCRIPTION
**Issue:**
While performing the EOMT Script at EX19 CU9 the script everytime returned that you need to install the KB5000871 for long term prevention but its always include into the the CU9 Update.


**Reason:**
to prevent wrong results while EOMT Script is performing

**Fix:**
Changed EX19 CU9 buildnumber in line 596 from  15.2.858.5 -> 15.2.858.2

**Validation:**
Provide if applicable