### PR TITLE
New test added: Test-ExpiredCertificateInUse

### DIFF
--- a/Setup/src/SetupLogReviewer.ps1
+++ b/Setup/src/SetupLogReviewer.ps1
@@ -404,6 +404,19 @@ Function Test-KnownLdifErrors {
     return $false
 }
 
+Function Test-ExpiredCertificateInUse {
+    $certificateOutdated = Select-String "\[ERROR\] The certificate is expired." $SetupLog | Select-Object -Last 1
+    $outdatedCertificateInfo = Select-String "Installing certificate signed by '(.*)' for site '(.*)'.  Certificate is valid from (\d{1,2}\/\d{1,2}\/\d{4} \d{2}:\d{2}:\d{2} \w\w) until (\d{1,2}\/\d{1,2}\/\d{4} \d{2}:\d{2}:\d{2} \w\w)" $SetupLog | Select-Object -Last 1
+
+    if (($null -ne $certificateOutdated) -and ($null -ne $outdatedCertificateInfo)) {
+        Write-ActionPlan("Certificate: {0} expired on: {1}. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value,
+        $outdatedCertificateInfo.Matches.Groups[4].Value)
+        return $true
+    }
+
+    return $false
+}
+
 Function Main {
     try {
 
@@ -431,7 +444,8 @@ Function Main {
         $Script:SetupBuildNumber = Select-String "Setup version: (.+)\." $SetupLog | Select-Object -Last 1
         $runDate = [DateTime]::Parse(
             $SetupBuildNumber.Line.Substring(1,
-                $SetupBuildNumber.Line.IndexOf("]") - 1)
+                $SetupBuildNumber.Line.IndexOf("]") - 1),
+            [System.Globalization.DateTimeFormatInfo]::InvariantInfo
         )
 
         $color = "Gray"
@@ -497,6 +511,10 @@ Function Main {
         }
 
         if (Test-KnownLdifErrors) {
+            return
+        }
+
+        if (Test-ExpiredCertificateInUse) {
             return
         }
 

--- a/Setup/src/SetupLogReviewer.ps1
+++ b/Setup/src/SetupLogReviewer.ps1
@@ -408,9 +408,13 @@ Function Test-ExpiredCertificateInUse {
     $certificateOutdated = Select-String "\[ERROR\] The certificate is expired." $SetupLog | Select-Object -Last 1
     $outdatedCertificateInfo = Select-String "Installing certificate signed by '(.*)' for site '(.*)'.  Certificate is valid from (\d{1,2}\/\d{1,2}\/\d{4} \d{2}:\d{2}:\d{2} \w\w) until (\d{1,2}\/\d{1,2}\/\d{4} \d{2}:\d{2}:\d{2} \w\w)" $SetupLog | Select-Object -Last 1
 
-    if (($null -ne $certificateOutdated) -and ($null -ne $outdatedCertificateInfo)) {
-        Write-ActionPlan("Certificate: {0} expired on: {1}. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value,
-        $outdatedCertificateInfo.Matches.Groups[4].Value)
+    if ($null -ne $certificateOutdated) {
+        if ($null -ne $outdatedCertificateInfo.Matches.Groups[4].Value) {
+            Write-ActionPlan("Certificate: {0} expired on: {1}. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value,
+            $outdatedCertificateInfo.Matches.Groups[4].Value)
+        } else {
+            Write-ActionPlan("Certificate: {0} has expired. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value)
+        }
         return $true
     }
 

--- a/Setup/src/SetupLogReviewer.ps1
+++ b/Setup/src/SetupLogReviewer.ps1
@@ -411,7 +411,7 @@ Function Test-ExpiredCertificateInUse {
     if ($null -ne $certificateOutdated) {
         if ($null -ne $outdatedCertificateInfo.Matches.Groups[4].Value) {
             Write-ActionPlan("Certificate: {0} expired on: {1}. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value,
-            $outdatedCertificateInfo.Matches.Groups[4].Value)
+                $outdatedCertificateInfo.Matches.Groups[4].Value)
         } else {
             Write-ActionPlan("Certificate: {0} has expired. `r`n`tPlease replace it, reboot the server and run setup again." -f $outdatedCertificateInfo.Matches.Groups[2].Value)
         }

--- a/Setup/src/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/src/Tests/SetupLogReviewer.Tests.ps1
@@ -109,5 +109,11 @@ Describe "Testing SetupLogReviewer" {
             Assert-MockCalled -Exactly 1 -CommandName Write-Host `
                 -ParameterFilter { $Object -like "*We failed to have the correct permissions to write ACE to 'CN=Microsoft Exchange System Objects,DC=Solo,DC=local' as the current user SOLO\Han*" }
         }
+
+        It "Certificate has expired" {
+            & $sr -SetupLog "$here\KnownIssues\ExchangeSetup_Certificate_Expired.log"
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "Certificate: CN=mail.Solo.dom, OU=IT, O=John Doe, L=Pester, C=DE expired on: 3/20/2020 12:00:00 PM.*" }
+        }
     }
 }


### PR DESCRIPTION
**Issue:**
Exchange CU setup will fail when an invalid (expired) certificate is assigned to IIS.

```
[03/22/2021 15:11:55.0655] [1] 0.  ErrorRecord: System.Security.Cryptography.CryptographicException: The certificate is expired.
   at Microsoft.Exchange.Configuration.Tasks.Task.ThrowError(Exception exception, ErrorCategory errorCategory, Object target, String helpUrl)
   at Microsoft.Exchange.Management.SystemConfigurationTasks.InstallExchangeCertificate.InternalProcessRecord()
   at Microsoft.Exchange.Configuration.Tasks.Task.<ProcessRecord>b__91_1()
   at Microsoft.Exchange.Configuration.Tasks.Task.InvokeRetryableFunc(String funcName, Action func, Boolean terminatePipelineIfFailed)
[03/22/2021 15:11:55.0659] [1] [ERROR] The following error was generated when "$error.Clear(); 
          Install-ExchangeCertificate -services IIS -DomainController $RoleDomainController
          if ($RoleIsDatacenter -ne $true -And $RoleIsPartnerHosted -ne $true)
          {
            Install-AuthCertificate -DomainController $RoleDomainController
          }
        " was run: "System.Security.Cryptography.CryptographicException: The certificate is expired.
   at Microsoft.Exchange.Configuration.Tasks.Task.ThrowError(Exception exception, ErrorCategory errorCategory, Object target, String helpUrl)
   at Microsoft.Exchange.Management.SystemConfigurationTasks.InstallExchangeCertificate.InternalProcessRecord()
   at Microsoft.Exchange.Configuration.Tasks.Task.<ProcessRecord>b__91_1()
   at Microsoft.Exchange.Configuration.Tasks.Task.InvokeRetryableFunc(String funcName, Action func, Boolean terminatePipelineIfFailed)".
[03/22/2021 15:11:55.0659] [1] [ERROR] The certificate is expired.
```

**Reason:**
To improve the scripts issue detection and inform customers to replace the expired certificate which is assigned to IIS before re-running setup.

**Fix:**
We check for the following string `[ERROR] The certificate is expired`. We then show the following action plan:
`Certificate: {0} expired on: {1}. Please replace it, reboot the server and run setup again.`

or when we're unable to find the matching expiration datetime (different regional settings than en-US)

`Certificate: {0} has expired. Please replace it, reboot the server and run setup again.`

**Validation:**
Added `Certificate has expired` to unit test. Anyway, I was not able to get any of the unit tests running successfully on my local machine. 