### PR TITLE
Quick & dirty -WhatIf support for CopyMissingDlls.ps1

### DIFF
--- a/Setup/src/CopyMissingDlls.ps1
+++ b/Setup/src/CopyMissingDlls.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess = $True)]
 param(
     [Parameter(Mandatory = $true, ParameterSetName = "CopyMissingDllsFromIso")]
     [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
**Issue:**
The script has currently no "read-only" mode or any other way to preview changes made to the binaries.

**Reason:**
Manual copying of binaries should require caution, so it would be great to have a preview before actually copying any files. Binaries may get messed up e.g. if a wrong .iso version is mounted and used in the script.

**Fix:**
Add "SupportsShouldProcess" to CmdletBinding as in https://devblogs.microsoft.com/scripting/weekend-scripter-easily-add-whatif-support-to-your-powershell-functions/

**Validation:**
