### PR TITLE
Need be able to find $PSScriptRoot for dot loaded files

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -75,11 +75,7 @@ $scriptFiles | ForEach-Object {
     # Expand dot-sourced files
     for ($i = 0; $i -lt $scriptContent.Count; $i++) {
         $line = $scriptContent[$i].Trim()
-        $m = $line | Select-String "\. \.\\(.*).ps1"
-
-        if ($null -eq $m) {
-            $m = $line | Select-String "\. \`$PSScriptRoot\\(.*).ps1"
-        }
+        $m = $line | Select-String "\. (?:\.|\`$PSScriptRoot)\\(.*).ps1"
 
         if ($m.Matches.Count -gt 0) {
             $parentPath = [IO.Path]::GetDirectoryName($_)

--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -77,6 +77,10 @@ $scriptFiles | ForEach-Object {
         $line = $scriptContent[$i].Trim()
         $m = $line | Select-String "\. \.\\(.*).ps1"
 
+        if ($null -eq $m) {
+            $m = $line | Select-String "\. \`$PSScriptRoot\\(.*).ps1"
+        }
+
         if ($m.Matches.Count -gt 0) {
             $parentPath = [IO.Path]::GetDirectoryName($_)
             $dotloadedScriptPath = [IO.Path]::Combine($parentPath, $m.Matches[0].Groups[1].Value + ".ps1")


### PR DESCRIPTION
In order for Pester to work correct needed to use $PSScriptRoot otherwise it will fail out.
