### PR TITLE
Fix Exchange versions on UM mitigation

### DIFF
--- a/Security/src/ExchangeMitigations.ps1
+++ b/Security/src/ExchangeMitigations.ps1
@@ -434,7 +434,8 @@ Function UnifiedMessagingMitigation {
 
     # UM doesn't apply to Exchange Server 2019
     $exchangeVersion = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup\')
-    if ($exchangeVersion.OwaVersion -notlike "15.0.*") {
+    if ($exchangeVersion.OwaVersion -notmatch "15\.[01]") {
+        Write-Verbose "[INFO] Skipping UM Mitigation for Exchange 2019"
         return
     }
 


### PR DESCRIPTION
**Issue:**
Code contains a comment that UM mitigation is skipped for Exchange 2019. That code specifically seeks Exchange 2013 and skips Exchange 2016.

**Reason:**
As per version listing:

https://docs.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019

Exchange 2016 is 15.1.x. The existing "not like 15.0" check meant UM would not apply. The fact it does so silently is a problem for troubleshooting.

**Fix:**
Replace with a match on 15.0 and 15.1. Added a verbose log.

**Validation:**
I have run this on an Exchange 2016 (15.1.2176.9) server.