### PR TITLE
Stop releasing baseline files

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -163,15 +163,6 @@ foreach ($script in $scriptVersions) {
 
 $scriptVersions | Export-Csv -Path "$distFolder\ScriptVersions.csv" -NoTypeInformation
 
-$csvHashFiles = Get-ChildItem -Path "$repoRoot\Security\src\Baselines" -Filter *.csv
-
-$csvHashFiles | ForEach-Object {
-    $zipFilePath = "$distFolder\$($_.BaseName).zip"
-    Compress-Archive -Path $_.FullName -DestinationPath $zipFilePath
-    $hash = Get-Item $zipFilePath | Get-FileHash
-    $hash.Hash | Out-File "$distFolder\$($_.BaseName).checksum.txt"
-}
-
 $otherFiles = Get-ChildItem -Path $repoRoot -Directory |
     Where-Object { $_.Name -ne ".build" } |
     ForEach-Object { Get-ChildItem -Path $_.FullName *.nse -Recurse } |

--- a/Security/src/CompareExchangeHashes.ps1
+++ b/Security/src/CompareExchangeHashes.ps1
@@ -547,9 +547,9 @@ function LoadFromGitHub($url, $filename, $installed_versions) {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
         # this file is only used for network connectivity test
-        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/microsoft/CSS-Exchange/releases/latest/download/baseline_15.0.1044.25.checksum.txt" | Out-Null
+        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/microsoft/CSS-Exchange/releases/download/v21.04.15.1409/baseline_15.0.1044.25.checksum.txt" | Out-Null
     } catch {
-        Write-Error "Cannot reach out to https://github.com/microsoft/CSS-Exchange/releases/latest, please download baseline files for $installed_versions from https://github.com/microsoft/CSS-Exchange/releases/latest manually to $(GetCurrDir), then rerun this script from $(GetCurrDir)."
+        Write-Error "Cannot reach out to https://github.com/microsoft/CSS-Exchange/releases/, please download baseline files for $installed_versions from https://github.com/microsoft/CSS-Exchange/releases/v21.04.15.1409 manually to $(GetCurrDir), then rerun this script from $(GetCurrDir)."
     }
 
     try {
@@ -638,7 +638,7 @@ function LoadBaseline($installed_versions) {
 
         if (-not (Test-Path $zip_file)) {
             Write-Host "Can't find local baseline for $version"
-            $zip_file_url = "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$zip_file_name"
+            $zip_file_url = "https://github.com/microsoft/CSS-Exchange/releases/download/v21.04.15.1409/$zip_file_name"
             LoadFromGitHub -url $zip_file_url -filename $zip_file -installed_versions $installed_versions
         }
 


### PR DESCRIPTION
This is a proposed change to stop releasing all the baseline files. Since Compare-ExchangeHashes.ps1 is deprecated, and the baseline files are no longer being updated, it is not necessary to continue releasing these.

This change updates Compare-ExchangeHashes.ps1 so that it is frozen in time. It points at the last release that had baseline files, and it downloads any needed files from that release specifically, instead of looking at the latest release.

This change also removes the associated build code that zipped and released the baseline files.

With this change, we can save quite a bit of build time and space by not releasing all these files for a deprecated script.