### PR TITLE
Make docs look more consistent

### DIFF
--- a/docs/Hybrid/Test-HMAEAS/index.md
+++ b/docs/Hybrid/Test-HMAEAS/index.md
@@ -1,8 +1,8 @@
-# Validating Hybrid Modern Authentication setup for Outlook for iOS and Android
+## Validating Hybrid Modern Authentication setup for Outlook for iOS and Android
+
+Download the latest release: [Test-HMAEAS.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-HMAEAS.ps1)
 
 This script allows you to check and see if your on-premises Exchange environment is configured correctly to use Hybrid Modern Authentication (HMA) with Outlook for iOS and Android. For this to work correctly, you will need to enable HMA and follow HMA Outlook for iOS and Android guidance to configure this feature properly.
-
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-HMAEAS.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-HMAEAS.ps1)
 
 To run the script, at minimum you will need a valid SMTP Address for a user that is located on-premises.
 

--- a/docs/M365/DLT365Groupsupgrade/index.md
+++ b/docs/M365/DLT365Groupsupgrade/index.md
@@ -1,10 +1,10 @@
-# [DLT365Groupsupgrade.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1)
+## DLT365Groupsupgrade.ps1
+
+Download the latest release: [DLT365Groupsupgrade.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1)
 
 ## Validating Distribution group eligibility for upgrade to O365 Group
 
 This script allows you to check Distribution to O365 Group migration eligibility for a specific distribution group SMTP, for more information over the Distribution to O365 Group migration blockers please check: https://docs.microsoft.com/en-us/microsoft-365/admin/manage/upgrade-distribution-lists?view=o365-worldwide
-
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1)
 
 The script will prompt for global administrator username & password to connect to EXO
 Then the script will ask for required group smtp

--- a/docs/Performance/ExPerfAnalyzer/index.md
+++ b/docs/Performance/ExPerfAnalyzer/index.md
@@ -1,3 +1,7 @@
+## ExPerfAnalyzer.ps1
+
+Download the latest release: [ExPerfAnalyzer.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ExPerfAnalyzer.ps1)
+
 ## Running the script
     .\ExPerfAnalyzer.ps1 .\EXSERVER01_FULL_000001.BLG
 
@@ -28,6 +32,3 @@ This script was inspired by [Performance Analysis of Logs (PAL)](https://github.
 - **Do you accept pull requests? Can I contribute to the script?**
 
     Of course!
-
-## Contributing
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/PublicFolders/SourceSideValidations/index.md
+++ b/docs/PublicFolders/SourceSideValidations/index.md
@@ -1,4 +1,6 @@
-## [SourceSideValidations.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SourceSideValidations.ps1)
+## SourceSideValidations.ps1
+
+Download the latest release: [SourceSideValidations.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SourceSideValidations.ps1)
 
 This script performs pre-migration public folder checks for Exchange 2013, 2016, and 2019. For Exchange 2010, please use previous script found [here](https://www.microsoft.com/en-us/download/details.aspx?id=100414).
 

--- a/docs/PublicFolders/ValidateMailEnabledPublicFolders/index.md
+++ b/docs/PublicFolders/ValidateMailEnabledPublicFolders/index.md
@@ -1,3 +1,5 @@
-## [ValidateMailEnabledPublicFolders.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ValidateMailEnabledPublicFolders.ps1)
+## ValidateMailEnabledPublicFolders.ps1
+
+Download the latest release: [ValidateMailEnabledPublicFolders.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ValidateMailEnabledPublicFolders.ps1)
 
 This script performs pre-migration checks on mail-enabled folders on Exchange 2010 and up. Note that these checks are also included in the new SourceSideValidations.ps1 shown above for 2013 and up.

--- a/docs/Retention/Get-MRMDetails/index.md
+++ b/docs/Retention/Get-MRMDetails/index.md
@@ -1,8 +1,8 @@
 # Get-MRMDetails
 
-This script will gather the MRM configuration for a given user. It will collect the current MRM Policy and Tags for the Exchange Organization, the current MRM Policy and Tags applied to the user, the current Exchange Diagnostics Logs for the user, and Exchange Audit logs for the mailbox selected.  The resulting data will allow you to see what tags are applied to the user and when the Managed Folder Assistant has run against the user. It also will grab the Admin Audit log so that we can tell if the Tags or Polices have been modified and who modified them.
+Download the latest release: [Get-MRMDetails.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Get-MRMDetails.ps1)
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/Get-MRMDetails.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Get-MRMDetails.ps1)
+This script will gather the MRM configuration for a given user. It will collect the current MRM Policy and Tags for the Exchange Organization, the current MRM Policy and Tags applied to the user, the current Exchange Diagnostics Logs for the user, and Exchange Audit logs for the mailbox selected.  The resulting data will allow you to see what tags are applied to the user and when the Managed Folder Assistant has run against the user. It also will grab the Admin Audit log so that we can tell if the Tags or Polices have been modified and who modified them.
 
 To run the script, at minimum you will need a valid SMTP Address for a user. Then you can review the associated logs that are generated from the script.
 

--- a/docs/Search/Troubleshoot-ModernSearch/index.md
+++ b/docs/Search/Troubleshoot-ModernSearch/index.md
@@ -1,6 +1,6 @@
-# [Troubleshoot-ModernSearch.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Troubleshoot-ModernSearch.ps1)
+# Troubleshoot-ModernSearch.ps1
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/Troubleshoot-ModernSearch.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Troubleshoot-ModernSearch.ps1)
+Download the latest release: [Troubleshoot-ModernSearch.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Troubleshoot-ModernSearch.ps1)
 
 This script is still in development. However, this should be able to quickly determine if an item is indexed or not and why it isn't indexed. Just provide the full message subject and the mailbox identity and it will dump out the information needed to determine if the message is indexed or not.
 

--- a/docs/Security/EOMT/index.md
+++ b/docs/Security/EOMT/index.md
@@ -1,4 +1,7 @@
-## [Exchange On-premises Mitigation Tool (EOMT)](https://github.com/microsoft/CSS-Exchange/releases/latest/download/EOMT.ps1)
+## Exchange On-premises Mitigation Tool (EOMT)
+
+Download the latest release: [EOMT.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/EOMT.ps1)
+
 This script contains mitigations to help address the following vulnerabilities.
 
 * CVE-2021-26855

--- a/docs/Security/ExchangeMitigations/index.md
+++ b/docs/Security/ExchangeMitigations/index.md
@@ -1,4 +1,7 @@
-## [ExchangeMitigations.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ExchangeMitigations.ps1)
+## ExchangeMitigations.ps1
+
+Download the latest release: [ExchangeMitigations.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ExchangeMitigations.ps1)
+
 This script contains 4 mitigations to help address the following vulnerabilities:
 
 * CVE-2021-26855

--- a/docs/Security/Test-ProxyLogon/index.md
+++ b/docs/Security/Test-ProxyLogon/index.md
@@ -1,10 +1,8 @@
-## [Test-ProxyLogon.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-ProxyLogon.ps1)
+## Test-ProxyLogon.ps1
+
+Download the latest release: [Test-ProxyLogon.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-ProxyLogon.ps1)
 
 Formerly known as Test-Hafnium, this script automates all four of the commands found in the [Hafnium blog post](https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/). It also has a progress bar and some performance tweaks to make the CVE-2021-26855 test run much faster.
-
-Download the latest release here:
-
-[Download Test-ProxyLogon.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-ProxyLogon.ps1)
 
 ### Usage
 

--- a/docs/Security/http-vuln-cve2021-26855/index.md
+++ b/docs/Security/http-vuln-cve2021-26855/index.md
@@ -1,8 +1,6 @@
-## [http-vuln-cve2021-26855.nse](https://github.com/microsoft/CSS-Exchange/releases/latest/download/http-vuln-cve2021-26855.nse)
+## http-vuln-cve2021-26855.nse
+
+Download the latest release: [http-vuln-cve2021-26855.nse](https://github.com/microsoft/CSS-Exchange/releases/latest/download/http-vuln-cve2021-26855.nse)
 
 This file is for use with nmap. It detects whether the specified URL is vulnerable to the Exchange Server SSRF Vulnerability (CVE-2021-26855).
 For usage information, please read the top of the file.
-
-Download the latest release here:
-
-[Download http-vuln-cve2021-26855.nse](https://github.com/microsoft/CSS-Exchange/releases/latest/download/http-vuln-cve2021-26855.nse)

--- a/docs/Setup/CopyMissingDlls/index.md
+++ b/docs/Setup/CopyMissingDlls/index.md
@@ -1,6 +1,6 @@
-# [CopyMissingDlls.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/CopyMissingDlls.ps1)
+## CopyMissingDlls.ps1
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/CopyMissingDlls.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/CopyMissingDlls.ps1)
+Download the latest release: [CopyMissingDlls.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/CopyMissingDlls.ps1)
 
 This script is used to copy over missing dlls that might have occurred during a CU install. This script has a mapping of the location of where the .dll should be on the server and where it should be on the ISO and will attempt to copy it over if the file is detected to be missing on the install location.
 

--- a/docs/Setup/FixInstallerCache/index.md
+++ b/docs/Setup/FixInstallerCache/index.md
@@ -1,6 +1,6 @@
-# [FixInstallerCache.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/FixInstallerCache.ps1)
+## FixInstallerCache.ps1
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/FixInstallerCache.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/FixInstallerCache.ps1)
+Download the latest release: [FixInstallerCache.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/FixInstallerCache.ps1)
 
 This script is used to copy over the missing MSI files from the installer cache.
 

--- a/docs/Setup/SetupAssist/index.md
+++ b/docs/Setup/SetupAssist/index.md
@@ -1,6 +1,6 @@
-# [SetupAssist.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1)
+## SetupAssist.ps1
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1)
+Download the latest release: [SetupAssist.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1)
 
 This script is meant to be run on the system where you are running setup from. It currently checks and displays the following when just running it:
 

--- a/docs/Setup/SetupLogReviewer/index.md
+++ b/docs/Setup/SetupLogReviewer/index.md
@@ -1,6 +1,6 @@
-# [SetupLogReviewer.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupLogReviewer.ps1)
+## SetupLogReviewer.ps1
 
-Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupLogReviewer.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupLogReviewer.ps1)
+Download the latest release: [SetupLogReviewer.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupLogReviewer.ps1)
 
 This script is meant to be run against the Exchange Setup Logs located at `C:\ExchangeSetupLogs\ExchangeSetup.log`. You can run this on the server, or on a personal computer.
 


### PR DESCRIPTION
The goal here is:

* Every page starts with ## ScriptName (or Title in a few cases). We use two hashes because the top of the page is always # CSS-Exchange, so the script name needs to be smaller than that and without the large divider.
* The script name is no longer a download link. In the context of a Page it feels like clicking the title might navigate somewhere, so clicking that and getting a download doesn't seem like a good experience.
* Every page has a very obvious download link as the first thing below the scriptname/title.