### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,24 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Development
+
+## Quick Start
+
+* Have PowerShell 7 or later installed.
+* Open the root of the repository with VSCode.
+* Make the desired changes, using Shift-Alt-F to apply the repository formatting rules.
+* From PS7, run `.build\CodeFormatter.ps1 -Save` and fix any PSScriptAnalyzer issues.
+* From PS7, run `.build\Build.ps1`. Test the resulting script in `dist/`.
+* Commit the changes on your own branch and open a Pull Request.
 
 It is recommended to use Visual Studio Code when developing scripts for this project. Opening VSCode at
 the root of this repo will ensure that VSCode uses the settings in the repro to enforce most of the
 formatting rules.
 
-Before committing, .build\CodeFormatter.ps1 should be run. This script will apply PSScriptAnalyzer
-formatting rules, and will show any required changes in the form of a diff output. It's a good idea to
-set the following setting to avoid erroneous ^M characters in the diff output:
+Before committing, .build\CodeFormatter.ps1 should be run. When running CodeFormatter from PowerShell 7
+or newer, the -Save argument can be used to save the required formatting changes automatically. CodeFormatter
+will also apply PSScriptAnalyzer formatting rules, and will show any required changes in the form of a diff
+output. It's a good idea to set the following setting to avoid erroneous ^M characters in the diff output:
 
 `git config core.whitespace cr-at-eol`
 
@@ -42,7 +51,9 @@ set the following setting to avoid erroneous ^M characters in the diff output:
 
 This repo uses a unique and fairly simple build system to create a single release script from a multi-file
 script project. You can check the output of this system by running the `.build\Build.ps1` script and
-checking the `dist` folder. This system provides two ways to combine files into a single .ps1.
+checking the `dist` folder. Note that Build.ps1 requires PowerShell 7 or newer.
+
+This system provides two ways to combine files into a single .ps1.
 
 ### Including a script in another script
 
@@ -50,9 +61,13 @@ Dot-sourcing a script inside another script embeds the target script into the so
 placing the following line inside of Script1.ps1 causes Script2.ps1 to be embedded at that point in Script1.
 Script2 is then excluded from release:
 
-`. .\Script2.ps1`
+`. $PSScriptRoot\Script2.ps1`
 
-You can embed any number of scripts. These could be in the same folder or in a child folder. See the
+We recommend dot-sourcing using a path starting with $PSScriptRoot to ensure the script can be run
+from different working directories at development time.
+
+Any number of scripts can be embedded, and those scripts can reside in the same folder, a subfolder, or
+somewhere else in the repository, such as the Shared folder at the root. See the
 `SourceSideValidation.ps1` script in this repo for an example of this.
 
 Because dot-sourcing works normally at development time, the multi-file script can be run and debugged
@@ -62,7 +77,7 @@ without building at dev time.
 
 Non-script files can be embedded in a script as well. This is accomplished with the following syntax:
 
-`$someVarName = Get-Content .\someresource.txt -AsByteStream -Raw`
+`$someVarName = Get-Content $PSScriptRoot\someresource.txt -AsByteStream -Raw`
 
 This command populates $someVarName with the binary content of the target file. You can then use that
 data however you like, such as converting it to text or processing it some other way. See the `ExTRA.ps1`


### PR DESCRIPTION
* Provide a Quick Start section.
* Call out the PowerShell 7 requirement for the build scripts.
* Change examples to show dot-sourcing using `. $PSScriptRoot\` rather than `. .\`