### PR TITLE
Enforce BOM at release and at dev time

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param (
 
 )
@@ -100,7 +100,7 @@ $scriptFiles | ForEach-Object {
     $expandedScript.Insert(0, "")
     $expandedScript.InsertRange(0, $disclaimer)
 
-    Set-Content -Path (Join-Path $distFolder $scriptName) -Value $expandedScript
+    Set-Content -Path (Join-Path $distFolder $scriptName) -Value $expandedScript -Encoding utf8BOM
     $scriptVersions += [PSCustomObject]@{
         File    = $scriptName
         Version = $buildVersionString

--- a/.build/BuildFunctions/Get-DotSourcedScriptName.ps1
+++ b/.build/BuildFunctions/Get-DotSourcedScriptName.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns the dot-sourced script path from this line of PowerShell
     script, if any.

--- a/.build/BuildFunctions/Get-EmbeddedFile.ps1
+++ b/.build/BuildFunctions/Get-EmbeddedFile.ps1
@@ -1,4 +1,4 @@
-. $PSScriptRoot\Get-DotSourcedScriptName.ps1
+﻿. $PSScriptRoot\Get-DotSourcedScriptName.ps1
 . $PSScriptRoot\Get-EmbeddedFileInfo.ps1
 
 <#

--- a/.build/BuildFunctions/Get-EmbeddedFileInfo.ps1
+++ b/.build/BuildFunctions/Get-EmbeddedFileInfo.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Returns the embedded data file info from this line of PowerShell
     script, including the file path and variable name it is assigned to.

--- a/.build/BuildFunctions/Get-EmbeddedFileList.ps1
+++ b/.build/BuildFunctions/Get-EmbeddedFileList.ps1
@@ -1,4 +1,4 @@
-. $PSScriptRoot\Get-EmbeddedFile.ps1
+﻿. $PSScriptRoot\Get-EmbeddedFile.ps1
 
 <#
 .SYNOPSIS

--- a/.build/BuildFunctions/Get-ExpandedScriptContent.ps1
+++ b/.build/BuildFunctions/Get-ExpandedScriptContent.ps1
@@ -1,4 +1,4 @@
-. $PSScriptRoot\Get-DotSourcedScriptName.ps1
+﻿. $PSScriptRoot\Get-DotSourcedScriptName.ps1
 . $PSScriptRoot\Get-EmbeddedFileInfo.ps1
 
 <#

--- a/.build/BuildFunctions/Get-ScriptProjectMostRecentCommit.ps1
+++ b/.build/BuildFunctions/Get-ScriptProjectMostRecentCommit.ps1
@@ -1,4 +1,4 @@
-. $PSScriptRoot\Get-EmbeddedFileList.ps1
+﻿. $PSScriptRoot\Get-EmbeddedFileList.ps1
 
 <#
 .SYNOPSIS

--- a/.build/Pester.ps1
+++ b/.build/Pester.ps1
@@ -1,4 +1,4 @@
-$root = Get-Item "$PSScriptRoot\.."
+﻿$root = Get-Item "$PSScriptRoot\.."
 $scripts = @(Get-ChildItem -Recurse $root |
         Where-Object { $_.Name -like "*.Tests.ps1" }).FullName
 

--- a/Databases/Analyze-SpaceDump.ps1
+++ b/Databases/Analyze-SpaceDump.ps1
@@ -1,4 +1,4 @@
-# This script reports the space taken up by various tables based on a database space dump.
+﻿# This script reports the space taken up by various tables based on a database space dump.
 # The space dump must be obtained while the database is dismounted, or on a suspended copy
 # if the issue is happening there. To obtain the space dump, use the following syntax:
 #

--- a/Databases/Compare-MailboxStatistics.ps1
+++ b/Databases/Compare-MailboxStatistics.ps1
@@ -1,4 +1,4 @@
-# This script compares two sets of mailbox statistics from the same database and highlights mailbox growth
+﻿# This script compares two sets of mailbox statistics from the same database and highlights mailbox growth
 # that occurred between the two snapshots.
 #
 # For a growing database, a typical approach would be to start by exporting the statistics for the database:

--- a/Databases/VSSTester/DiskShadow/Invoke-DiskShadow.ps1
+++ b/Databases/VSSTester/DiskShadow/Invoke-DiskShadow.ps1
@@ -1,4 +1,4 @@
-function Invoke-DiskShadow {
+﻿function Invoke-DiskShadow {
     Write-Host " " $nl
     Get-Date
     Write-Host "Starting DiskShadow copy of Exchange database: $selDB" -ForegroundColor Green $nl

--- a/Databases/VSSTester/DiskShadow/Invoke-RemoveExposedDrives.ps1
+++ b/Databases/VSSTester/DiskShadow/Invoke-RemoveExposedDrives.ps1
@@ -1,4 +1,4 @@
-function Invoke-RemoveExposedDrives {
+﻿function Invoke-RemoveExposedDrives {
 
     function Out-removeDHSFile {
         param ([string]$fileline)

--- a/Databases/VSSTester/ExchangeInformation/Get-CopyStatus.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-CopyStatus.ps1
@@ -1,4 +1,4 @@
-function Get-CopyStatus {
+﻿function Get-CopyStatus {
     if ((($databases[$dbToBackup]).IsMailboxDatabase) -eq "True") {
         Get-Date
         Write-Host "Status of '$selDB' and its replicas (if any)" -ForegroundColor Green $nl

--- a/Databases/VSSTester/ExchangeInformation/Get-Databases.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-Databases.ps1
@@ -1,4 +1,4 @@
-function Get-Databases {
+﻿function Get-Databases {
     Get-Date
     Write-Host "Getting databases on server: $serverName" -ForegroundColor Green $nl
     Write-Host "--------------------------------------------------------------------------------------------------------------"

--- a/Databases/VSSTester/ExchangeInformation/Get-DbToBackup.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-DbToBackup.ps1
@@ -1,4 +1,4 @@
-function Get-DBtoBackup {
+﻿function Get-DBtoBackup {
     $maxDbIndexRange = $script:databases.length - 1
     $matchCondition = "^([0-9]|[1-9][0-9])$"
     Write-Debug "matchCondition: $matchCondition"

--- a/Databases/VSSTester/ExchangeInformation/Get-ExchangeVersion.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-ExchangeVersion.ps1
@@ -1,4 +1,4 @@
-function Get-ExchangeVersion {
+﻿function Get-ExchangeVersion {
     Get-Date
     Write-Host "Verifying Exchange version..." -ForegroundColor Green $nl
     Write-Host "--------------------------------------------------------------------------------------------------------------"

--- a/Databases/VSSTester/Logging/Get-VSSWritersAfter.ps1
+++ b/Databases/VSSTester/Logging/Get-VSSWritersAfter.ps1
@@ -1,4 +1,4 @@
-function Get-VSSWritersAfter {
+﻿function Get-VSSWritersAfter {
     " "
     Get-Date
     Write-Host "Checking VSS Writer Status: (after backup)" -ForegroundColor Green $nl

--- a/Databases/VSSTester/Logging/Get-VSSWritersBefore.ps1
+++ b/Databases/VSSTester/Logging/Get-VSSWritersBefore.ps1
@@ -1,4 +1,4 @@
-function Get-VSSWritersBefore {
+﻿function Get-VSSWritersBefore {
     " "
     Get-Date
     Write-Host "Checking VSS Writer Status: (All Writers must be in a Stable state before running this script)" -ForegroundColor Green $nl

--- a/Databases/VSSTester/Logging/Get-WindowsEventLogs.ps1
+++ b/Databases/VSSTester/Logging/Get-WindowsEventLogs.ps1
@@ -1,4 +1,4 @@
-
+﻿
 function Get-WindowsEventLogs {
 
     Function Get-WindowEventsPerServer {

--- a/Databases/VSSTester/Logging/Invoke-CreateExtraTracingConfig.ps1
+++ b/Databases/VSSTester/Logging/Invoke-CreateExtraTracingConfig.ps1
@@ -1,4 +1,4 @@
-function Invoke-CreateExTRATracingConfig {
+﻿function Invoke-CreateExTRATracingConfig {
 
     function Out-ExTRAConfigFile {
         param ([string]$fileline)

--- a/Databases/VSSTester/Logging/Invoke-DisableDiagnosticsLogging.ps1
+++ b/Databases/VSSTester/Logging/Invoke-DisableDiagnosticsLogging.ps1
@@ -1,4 +1,4 @@
-function Invoke-DisableDiagnosticsLogging {
+﻿function Invoke-DisableDiagnosticsLogging {
 
     Write-Host " "  $nl
     Get-Date

--- a/Databases/VSSTester/Logging/Invoke-DisableExtraTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-DisableExtraTracing.ps1
@@ -1,4 +1,4 @@
-function Invoke-DisableExTRATracing {
+﻿function Invoke-DisableExTRATracing {
     " "
     Get-Date
     Write-Host "Disabling ExTRA Tracing..." -ForegroundColor Green $nl

--- a/Databases/VSSTester/Logging/Invoke-DisableVSSTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-DisableVSSTracing.ps1
@@ -1,4 +1,4 @@
-function Invoke-DisableVSSTracing {
+﻿function Invoke-DisableVSSTracing {
     " "
     Get-Date
     Write-Host "Disabling VSS Tracing..." -ForegroundColor Green $nl

--- a/Databases/VSSTester/Logging/Invoke-EnableDiagnosticsLogging.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableDiagnosticsLogging.ps1
@@ -1,4 +1,4 @@
-function Invoke-EnableDiagnosticsLogging {
+﻿function Invoke-EnableDiagnosticsLogging {
     " "
     Get-Date
     Write-Host "Enabling Diagnostics Logging..." -ForegroundColor green $nl

--- a/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
@@ -1,4 +1,4 @@
-function Invoke-EnableExTRATracing {
+﻿function Invoke-EnableExTRATracing {
 
     Function Invoke-ExtraTracingCreate {
         param(

--- a/Databases/VSSTester/Logging/Invoke-EnableVSSTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableVSSTracing.ps1
@@ -1,4 +1,4 @@
-function Invoke-EnableVSSTracing {
+﻿function Invoke-EnableVSSTracing {
     " "
     Get-Date
     Write-Host "Enabling VSS Tracing..." -ForegroundColor Green $nl

--- a/Databases/VSSTester/VSSTester.ps1
+++ b/Databases/VSSTester/VSSTester.ps1
@@ -1,4 +1,4 @@
-#################################################################################
+﻿#################################################################################
 # Purpose:
 # This script will allow you to test VSS functionality on Exchange server using DiskShadow.
 # The script will automatically detect active and passive database copies running on the server.

--- a/Diagnostics/ExTRA/ExTRA.ps1
+++ b/Diagnostics/ExTRA/ExTRA.ps1
@@ -1,4 +1,4 @@
-$tagFileBytes = Get-Content "$PSScriptRoot\tags2016.txt" -AsByteStream -Raw
+﻿$tagFileBytes = Get-Content "$PSScriptRoot\tags2016.txt" -AsByteStream -Raw
 
 $htmlFileBytes = Get-Content "$PSScriptRoot\ui.html" -AsByteStream -Raw
 

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All Parameters are used in other functions of the script')]
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All Parameters are used in other functions of the script')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Value is used')]
 [CmdletBinding()]
 Param (

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-DAGInformation.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-DAGInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-DAGInformation {
+﻿Function Get-DAGInformation {
     param(
         [Parameter(Mandatory = $true)][string]$DAGName
     )

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeBasicServerObject {
+﻿Function Get-ExchangeBasicServerObject {
     param(
         [Parameter(Mandatory = $true)][string]$ServerName,
         [Parameter(Mandatory = $false)][bool]$AddGetServerProperty = $false

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
@@ -1,4 +1,4 @@
-Function Get-ServerObjects {
+﻿Function Get-ServerObjects {
     param(
         [Parameter(Mandatory = $true)][Array]$ValidServers
     )

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -1,4 +1,4 @@
-Function Get-TransportLoggingInformationPerServer {
+﻿Function Get-TransportLoggingInformationPerServer {
     param(
         [string]$Server,
         [int]$Version,

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
@@ -1,4 +1,4 @@
-Function Get-VirtualDirectoriesLdap {
+﻿Function Get-VirtualDirectoriesLdap {
 
     $authTypeEnum = @"
     namespace AuthMethods

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -1,4 +1,4 @@
-Function Get-ArgumentList {
+﻿Function Get-ArgumentList {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'TODO: Change this')]
     param(
         [Parameter(Mandatory = $true)][array]$Servers

--- a/Diagnostics/ExchangeLogCollector/Helpers/Invoke-ServerRootZipAndCopy.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Invoke-ServerRootZipAndCopy.ps1
@@ -1,4 +1,4 @@
-#This function is to handle all root zipping capabilities and copying of the data over.
+﻿#This function is to handle all root zipping capabilities and copying of the data over.
 Function Invoke-ServerRootZipAndCopy {
     param(
         [bool]$RemoteExecute = $true

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
@@ -1,4 +1,4 @@
-Function Test-DiskSpace {
+﻿Function Test-DiskSpace {
     param(
         [Parameter(Mandatory = $true)][array]$Servers,
         [Parameter(Mandatory = $true)][string]$Path,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -1,4 +1,4 @@
-Function Test-NoSwitchesProvided {
+﻿Function Test-NoSwitchesProvided {
     if ($EWSLogs -or
         $IISLogs -or
         $DailyPerformanceLogs -or

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -1,4 +1,4 @@
-Function Test-PossibleCommonScenarios {
+﻿Function Test-PossibleCommonScenarios {
 
     #all possible logs
     if ($AllPossibleLogs) {

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-RemoteExecutionOfServers.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-RemoteExecutionOfServers.ps1
@@ -1,4 +1,4 @@
-Function Test-RemoteExecutionOfServers {
+﻿Function Test-RemoteExecutionOfServers {
     param(
         [Parameter(Mandatory = $true)][Array]$ServerList
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Add-ServerNameToFileName.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Add-ServerNameToFileName.ps1
@@ -1,4 +1,4 @@
-Function Add-ServerNameToFileName {
+﻿Function Add-ServerNameToFileName {
     param(
         [Parameter(Mandatory = $true)][string]$FilePath
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
@@ -1,4 +1,4 @@
-Function Get-IISLogDirectory {
+﻿Function Get-IISLogDirectory {
     Write-ScriptDebug("Function Enter: Get-IISLogDirectory")
 
     Function Get-IISDirectoryFromGetWebSite {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ItemsSize.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ItemsSize.ps1
@@ -1,4 +1,4 @@
-Function Get-ItemsSize {
+﻿Function Get-ItemsSize {
     param(
         [Parameter(Mandatory = $true)][array]$FilePaths
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-StringDataForNotEnoughFreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-StringDataForNotEnoughFreeSpace.ps1
@@ -1,4 +1,4 @@
-Function Get-StringDataForNotEnoughFreeSpaceFile {
+﻿Function Get-StringDataForNotEnoughFreeSpaceFile {
     param(
         [Parameter(Mandatory = $true)][hashtable]$hasher
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-BulkItems.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-BulkItems.ps1
@@ -1,4 +1,4 @@
-Function Copy-BulkItems {
+﻿Function Copy-BulkItems {
     param(
         [string]$CopyToLocation,
         [Array]$ItemsToCopyLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
@@ -1,4 +1,4 @@
-Function Copy-FullLogFullPathRecurse {
+﻿Function Copy-FullLogFullPathRecurse {
     param(
         [Parameter(Mandatory = $true)][string]$LogPath,
         [Parameter(Mandatory = $true)][string]$CopyToThisLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogmanData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogmanData.ps1
@@ -1,4 +1,4 @@
-Function Copy-LogmanData {
+﻿Function Copy-LogmanData {
     param(
         [Parameter(Mandatory = $true)]$ObjLogman
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
@@ -1,4 +1,4 @@
-Function Copy-LogsBasedOnTime {
+﻿Function Copy-LogsBasedOnTime {
     param(
         [Parameter(Mandatory = $false)][string]$LogPath,
         [Parameter(Mandatory = $true)][string]$CopyToThisLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Invoke-CatchBlockActions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Invoke-CatchBlockActions.ps1
@@ -1,4 +1,4 @@
-Function Invoke-CatchBlockActions {
+﻿Function Invoke-CatchBlockActions {
     Write-ScriptDebug -WriteString ("Error Exception: $($Error[0].Exception)")
     Write-ScriptDebug -WriteString ("Error Stack: $($Error[0].ScriptStackTrace)")
     [array]$Script:ErrorsHandled += $Error[0]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataInfoToFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataInfoToFile.ps1
@@ -1,4 +1,4 @@
-Function Save-DataInfoToFile {
+﻿Function Save-DataInfoToFile {
     param(
         [Parameter(Mandatory = $false)][object]$DataIn,
         [Parameter(Mandatory = $true)][string]$SaveToLocation,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
@@ -1,4 +1,4 @@
-#Save out the failover cluster information for the local node, besides the event logs.
+﻿#Save out the failover cluster information for the local node, besides the event logs.
 Function Save-FailoverClusterInformation {
     Write-ScriptDebug("Function Enter: Save-FailoverClusterInformation")
     $copyTo = "$Script:RootCopyToDirectory\Cluster_Information"

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExmonData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExmonData.ps1
@@ -1,3 +1,3 @@
-Function Save-LogmanExmonData {
+﻿Function Save-LogmanExmonData {
     Get-LogmanData -LogmanName $PassedInfo.ExmonLogmanName -ServerName $env:COMPUTERNAME
 }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExperfwizData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExperfwizData.ps1
@@ -1,4 +1,4 @@
-Function  Save-LogmanExperfwizData {
+﻿Function  Save-LogmanExperfwizData {
 
     $PassedInfo.ExperfwizLogmanName |
         ForEach-Object {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
@@ -1,4 +1,4 @@
-Function Save-ServerInfoData {
+﻿Function Save-ServerInfoData {
     Write-ScriptDebug("Function Enter: Save-ServerInfoData")
     $copyTo = $Script:RootCopyToDirectory + "\General_Server_Info"
     New-Folder -NewFolder $copyTo -IncludeDisplayCreate $true

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-WindowsEventLogs.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-WindowsEventLogs.ps1
@@ -1,4 +1,4 @@
-Function Save-WindowsEventLogs {
+﻿Function Save-WindowsEventLogs {
 
     Write-ScriptDebug("Function Enter: Save-WindowsEventLogs")
     $baseSaveLocation = $Script:RootCopyToDirectory + "\Windows_Event_Logs"

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-DebugLog.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-DebugLog.ps1
@@ -1,4 +1,4 @@
-#Calls the $Script:Logger object to write the data to file only.
+﻿#Calls the $Script:Logger object to write the data to file only.
 Function Write-DebugLog($message) {
     if ($null -ne $message -and
         ![string]::IsNullOrEmpty($message) -and

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-ScriptDebug.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-ScriptDebug.ps1
@@ -1,4 +1,4 @@
-Function Write-ScriptDebug {
+﻿Function Write-ScriptDebug {
     param(
         [Parameter(Mandatory = $true)]$WriteString
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-ScriptHost.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-ScriptHost.ps1
@@ -1,4 +1,4 @@
-Function Write-ScriptHost {
+﻿Function Write-ScriptHost {
     param(
         [Parameter(Mandatory = $true)][string]$WriteString,
         [Parameter(Mandatory = $false)][bool]$ShowServer = $true,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -1,4 +1,4 @@
-Function Invoke-RemoteMain {
+﻿Function Invoke-RemoteMain {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Required to be used in the current format')]
     [CmdletBinding()]
     param()

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-ZipFolder.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-ZipFolder.ps1
@@ -1,4 +1,4 @@
-Function Invoke-ZipFolder {
+﻿Function Invoke-ZipFolder {
     param(
         [string]$Folder,
         [bool]$ZipItAll,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanData.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanData {
+﻿Function Get-LogmanData {
     param(
         [Parameter(Mandatory = $true)][string]$LogmanName,
         [Parameter(Mandatory = $true)][string]$ServerName

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanExt.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanExt.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanExt {
+﻿Function Get-LogmanExt {
     param(
         [Parameter(Mandatory = $true)]$RawLogmanData
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanObject.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanObject.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanObject {
+﻿Function Get-LogmanObject {
     param(
         [Parameter(Mandatory = $true)][string]$LogmanName,
         [Parameter(Mandatory = $true)][string]$ServerName

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanRootPath.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanRootPath.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanRootPath {
+﻿Function Get-LogmanRootPath {
     param(
         [Parameter(Mandatory = $true)]$RawLogmanData
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanStartDate.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanStartDate.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanStartDate {
+﻿Function Get-LogmanStartDate {
     param(
         [Parameter(Mandatory = $true)]$RawLogmanData
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanStatus.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Get-LogmanStatus.ps1
@@ -1,4 +1,4 @@
-Function Get-LogmanStatus {
+﻿Function Get-LogmanStatus {
     param(
         [Parameter(Mandatory = $true)]$RawLogmanData
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Start-Logman.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Start-Logman.ps1
@@ -1,4 +1,4 @@
-Function Start-Logman {
+﻿Function Start-Logman {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I like Start Logman')]
     param(
         [Parameter(Mandatory = $true)][string]$LogmanName,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Stop-Logman.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Logman/Stop-Logman.ps1
@@ -1,4 +1,4 @@
-Function Stop-Logman {
+﻿Function Stop-Logman {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I like Stop Logman')]
     param(
         [Parameter(Mandatory = $true)][string]$LogmanName,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
@@ -1,4 +1,4 @@
-Function Test-CommandExists {
+﻿Function Test-CommandExists {
     param(
         [string]$command
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
@@ -1,4 +1,4 @@
-Function Test-FreeSpace {
+﻿Function Test-FreeSpace {
     param(
         [Parameter(Mandatory = $false)][array]$FilePaths
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Compress-Folder.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Compress-Folder.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Compress-Folder/Compress-Folder.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Compress-Folder/Compress-Folder.ps1
 #v21.01.22.2234
 Function Compress-Folder {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because it returns different types that needs to be addressed')]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ClusterNodeFileVersions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ClusterNodeFileVersions.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ClusterNodeFileVersions/Get-ClusterNodeFileVersions.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ClusterNodeFileVersions/Get-ClusterNodeFileVersions.ps1
 #v21.01.22.2212
 Function Get-ClusterNodeFileVersions {
     [CmdletBinding()]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ExchangeInstallDirectory.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ExchangeInstallDirectory.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Get-ExchangeInstallDirectory/Get-ExchangeInstallDirectory.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Get-ExchangeInstallDirectory/Get-ExchangeInstallDirectory.ps1
 #v21.01.22.2234
 Function Get-ExchangeInstallDirectory {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Different types returned')]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-FreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Get-FreeSpace.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-FreeSpace/Get-FreeSpace.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-FreeSpace/Get-FreeSpace.ps1
 #v21.01.22.2234
 Function Get-FreeSpace {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Different types returned')]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/New-Folder.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/New-Folder.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/New-Folder/New-Folder.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/New-Folder/New-Folder.ps1
 #v21.01.22.2234
 Function New-Folder {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I prefer New here')]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Save-DataToFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Save-DataToFile.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Save-DataToFile/Save-DataToFile.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Save-DataToFile/Save-DataToFile.ps1
 #v21.01.22.2234
 Function Save-DataToFile {
     [CmdletBinding()]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-InvokeCommandReturnHostWriter.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-InvokeCommandReturnHostWriter.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-InvokeCommandReturnHostWriter.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-InvokeCommandReturnHostWriter.ps1
 #v21.01.22.2212
 Function Write-InvokeCommandReturnHostWriter {
     param(

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-InvokeCommandReturnVerboseWriter.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-InvokeCommandReturnVerboseWriter.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-InvokeCommandReturnVerboseWriter.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-InvokeCommandReturnVerboseWriter.ps1
 #v21.01.22.2212
 Function Write-InvokeCommandReturnVerboseWriter {
     param(

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-ScriptMethodHostWriter.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/extern/Write-ScriptMethodHostWriter.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
 #v21.01.22.2212
 Function Write-ScriptMethodHostWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]

--- a/Diagnostics/ExchangeLogCollector/Write/Get-WritersToAddToScriptBlock.ps1
+++ b/Diagnostics/ExchangeLogCollector/Write/Get-WritersToAddToScriptBlock.ps1
@@ -1,4 +1,4 @@
-Function Get-WritersToAddToScriptBlock {
+﻿Function Get-WritersToAddToScriptBlock {
 
     $writersString = "Function Write-InvokeCommandReturnHostWriter { " + (${Function:Write-InvokeCommandReturnHostWriter}).ToString() + " } `n`n Function Write-InvokeCommandReturnVerboseWriter { " + (${Function:Write-InvokeCommandReturnVerboseWriter}).ToString() + " } `n`n#"
     return $writersString

--- a/Diagnostics/ExchangeLogCollector/Write/Write-DataOnlyOnceOnMasterServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/Write/Write-DataOnlyOnceOnMasterServer.ps1
@@ -1,4 +1,4 @@
-Function Write-DataOnlyOnceOnMasterServer {
+﻿Function Write-DataOnlyOnceOnMasterServer {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseUsingScopeModifierInNewRunspaces', '', Justification = 'Can not use using for an env variable')]
     param()
     Write-ScriptDebug("Enter Function: Write-DataOnlyOnceOnMasterServer")

--- a/Diagnostics/ExchangeLogCollector/Write/Write-LargeDataObjectsOnMachine.ps1
+++ b/Diagnostics/ExchangeLogCollector/Write/Write-LargeDataObjectsOnMachine.ps1
@@ -1,4 +1,4 @@
-#This function job is to write out the Data that is too large to pass into the main script block
+﻿#This function job is to write out the Data that is too large to pass into the main script block
 #This is for mostly Exchange Related objects.
 #To handle this, we export the data locally and copy the data over the correct server.
 Function Write-LargeDataObjectsOnMachine {

--- a/Diagnostics/ExchangeLogCollector/extern/Enter-YesNoLoopAction.ps1
+++ b/Diagnostics/ExchangeLogCollector/extern/Enter-YesNoLoopAction.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Enter-YesNoLoopAction/Enter-YesNoLoopAction.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Enter-YesNoLoopAction/Enter-YesNoLoopAction.ps1
 #v21.01.22.2234
 Function Enter-YesNoLoopAction {
     [CmdletBinding()]

--- a/Diagnostics/ExchangeLogCollector/extern/Import-ScriptConfigFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/extern/Import-ScriptConfigFile.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Import-ScriptConfigFile/Import-ScriptConfigFile.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Import-ScriptConfigFile/Import-ScriptConfigFile.ps1
 #v21.02.07.1240
 Function Import-ScriptConfigFile {
     [CmdletBinding()]

--- a/Diagnostics/ExchangeLogCollector/extern/Start-JobManager.ps1
+++ b/Diagnostics/ExchangeLogCollector/extern/Start-JobManager.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Start-JobManager/Start-JobManager.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Start-JobManager/Start-JobManager.ps1
 #v21.01.22.2234
 Function Start-JobManager {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I prefer Start here')]

--- a/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
@@ -1,4 +1,4 @@
-Function Add-AnalyzedResultInformation {
+﻿Function Add-AnalyzedResultInformation {
     param(
         [object]$Details,
         [string]$Name,

--- a/Diagnostics/HealthChecker/Analyzer/Get-DisplayResultsGroupingKey.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-DisplayResultsGroupingKey.ps1
@@ -1,4 +1,4 @@
-Function Get-DisplayResultsGroupingKey {
+﻿Function Get-DisplayResultsGroupingKey {
     param(
         [string]$Name,
         [bool]$DisplayGroupName = $true,

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -1,4 +1,4 @@
-Function Invoke-AnalyzerEngine {
+﻿Function Invoke-AnalyzerEngine {
     param(
         [HealthChecker.HealthCheckerExchangeServer]$HealthServerObject
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
@@ -1,4 +1,4 @@
-Function Get-ExSetupDetails {
+﻿Function Get-ExSetupDetails {
 
     Write-VerboseOutput("Calling: Get-ExSetupDetails")
     $exSetupDetails = [string]::Empty

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAppPoolsInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAppPoolsInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeAppPoolsInformation {
+﻿Function Get-ExchangeAppPoolsInformation {
 
     Write-VerboseOutput("Calling: Get-ExchangeAppPoolsInformation")
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeApplicationConfigurationFileValidation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeApplicationConfigurationFileValidation.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeApplicationConfigurationFileValidation {
+﻿Function Get-ExchangeApplicationConfigurationFileValidation {
     param(
         [string[]]$ConfigFileLocation
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeInformation {
+﻿Function Get-ExchangeInformation {
     param(
         [HealthChecker.OSServerVersion]$OSMajorVersion
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeServerCertificates {
+﻿Function Get-ExchangeServerCertificates {
 
     Write-VerboseOutput("Calling: Get-ExchangeServerCertificates")
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceSate.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceSate.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeServerMaintenanceState {
+﻿Function Get-ExchangeServerMaintenanceState {
     param(
         [Parameter(Mandatory = $false)][array]$ComponentsToSkip
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
@@ -1,4 +1,4 @@
-Function Get-ExchangeUpdates {
+﻿Function Get-ExchangeUpdates {
     param(
         [Parameter(Mandatory = $true)][HealthChecker.ExchangeMajorVersion]$ExchangeMajorVersion
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-HealthCheckerExchangeServer.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-HealthCheckerExchangeServer.ps1
@@ -1,4 +1,4 @@
-Function Get-HealthCheckerExchangeServer {
+﻿Function Get-HealthCheckerExchangeServer {
 
     Write-VerboseOutput("Calling: Get-HealthCheckerExchangeServer")
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-CredentialGuardEnabled.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-CredentialGuardEnabled.ps1
@@ -1,4 +1,4 @@
-Function Get-CredentialGuardEnabled {
+﻿Function Get-CredentialGuardEnabled {
 
     Write-VerboseOutput("Calling: Get-CredentialGuardEnabled")
     $registryValue = Invoke-RegistryGetValue -MachineName $Script:Server -SubKey "SYSTEM\CurrentControlSet\Control\LSA" -GetValue "LsaCfgFlags" -CatchActionFunction ${Function:Invoke-CatchActions}

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HardwareInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-HardwareInformation {
+﻿Function Get-HardwareInformation {
 
     Write-VerboseOutput("Calling: Get-HardwareInformation")
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HttpProxySetting.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HttpProxySetting.ps1
@@ -1,4 +1,4 @@
-Function Get-HttpProxySetting {
+﻿Function Get-HttpProxySetting {
 
     $httpProxy32 = [String]::Empty
     $httpProxy64 = [String]::Empty

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-LmCompatibilityLevelInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-LmCompatibilityLevelInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-LmCompatibilityLevelInformation {
+﻿Function Get-LmCompatibilityLevelInformation {
 
     Write-VerboseOutput("Calling: Get-LmCompatibilityLevelInformation")
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-OperatingSystemInformation {
+﻿Function Get-OperatingSystemInformation {
 
     Write-VerboseOutput("Calling: Get-OperatingSystemInformation")
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PageFileInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PageFileInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-PageFileInformation {
+﻿Function Get-PageFileInformation {
 
     Write-VerboseOutput("Calling: Get-PageFileInformation")
     [HealthChecker.PageFileInformation]$page_obj = New-Object HealthChecker.PageFileInformation

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerRole.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerRole.ps1
@@ -1,4 +1,4 @@
-Function Get-ServerRole {
+﻿Function Get-ServerRole {
     param(
         [Parameter(Mandatory = $true)][object]$ExchangeServerObj
     )

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-AllNicInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-AllNicInformation.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
 #v21.03.08.0445
 Function Get-AllNicInformation {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Just creating internal objects')]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-AllTlsSettingsFromRegistry.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-AllTlsSettingsFromRegistry.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
 #v21.03.02.0919
 Function Get-AllTlsSettingsFromRegistry {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Just creating internal objects')]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-DotNetDllFileVersions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-DotNetDllFileVersions.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-DotNetDllFileVersions/Get-DotNetDllFileVersions.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-DotNetDllFileVersions/Get-DotNetDllFileVersions.ps1
 #v21.01.22.2234
 Function Get-DotNetDllFileVersions {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-ExchangeBuildVersionInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-ExchangeBuildVersionInformation.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Get-ExchangeBuildVersionInformation/Get-ExchangeBuildVersionInformation.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Get-ExchangeBuildVersionInformation/Get-ExchangeBuildVersionInformation.ps1
 #v21.03.11.0754
 Function Get-ExchangeBuildVersionInformation {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-ProcessorInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-ProcessorInformation.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ProcessorInformation/Get-ProcessorInformation.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ProcessorInformation/Get-ProcessorInformation.ps1
 #v21.01.22.2234
 Function Get-ProcessorInformation {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerOperatingSystemVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerOperatingSystemVersion.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerOperatingSystemVersion/Get-ServerOperatingSystemVersion.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerOperatingSystemVersion/Get-ServerOperatingSystemVersion.ps1
 #v21.01.22.2234
 Function Get-ServerOperatingSystemVersion {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Need it for old legacy servers')]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerRebootPending.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerRebootPending.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerRebootPending/Get-ServerRebootPending.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerRebootPending/Get-ServerRebootPending.ps1
 #v21.01.22.2234
 Function Get-ServerRebootPending {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerType.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-ServerType.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerType/Get-ServerType.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerType/Get-ServerType.ps1
 #v21.01.22.2234
 Function Get-ServerType {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-Smb1ServerSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-Smb1ServerSettings.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-Smb1ServerSettings/Get-Smb1ServerSettings.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-Smb1ServerSettings/Get-Smb1ServerSettings.ps1
 #v21.01.22.2234
 Function Get-Smb1ServerSettings {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-TimeZoneInformationRegistrySettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-TimeZoneInformationRegistrySettings.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-TimeZoneInformationRegistrySettings/Get-TimeZoneInformationRegistrySettings.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-TimeZoneInformationRegistrySettings/Get-TimeZoneInformationRegistrySettings.ps1
 #v21.01.22.2234
 Function Get-TimeZoneInformationRegistrySettings {
     [CmdletBinding()]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Get-WmiObjectHandler.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Get-WmiObjectHandler.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Get-WmiObjectHandler/Get-WmiObjectHandler.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Get-WmiObjectHandler/Get-WmiObjectHandler.ps1
 #v21.01.22.2234
 Function Get-WmiObjectHandler {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'This is what this function is for')]

--- a/Diagnostics/HealthChecker/DataCollection/extern/Invoke-RegistryGetValue.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/extern/Invoke-RegistryGetValue.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Invoke-RegistryGetValue/Invoke-RegistryGetValue.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Invoke-RegistryGetValue/Invoke-RegistryGetValue.ps1
 #v21.01.22.2234
 Function Invoke-RegistryGetValue {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Multiple output types occur')]

--- a/Diagnostics/HealthChecker/Features/Get-CasLoadBalancingReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-CasLoadBalancingReport.ps1
@@ -1,4 +1,4 @@
-Function Get-CASLoadBalancingReport {
+﻿Function Get-CASLoadBalancingReport {
 
     Write-VerboseOutput("Calling: Get-CASLoadBalancingReport")
     #Connection and requests per server and client type values

--- a/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
@@ -1,4 +1,4 @@
-Function Get-ComputerCoresObject {
+﻿Function Get-ComputerCoresObject {
     param(
         [Parameter(Mandatory = $true)][string]$Machine_Name
     )

--- a/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
@@ -1,4 +1,4 @@
-Function Get-HtmlServerReport {
+﻿Function Get-HtmlServerReport {
     param(
         [Parameter(Mandatory = $true)][array]$AnalyzedHtmlServerValues
     )

--- a/Diagnostics/HealthChecker/Features/Get-MailboxDatabaseAndMailboxStatistics.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-MailboxDatabaseAndMailboxStatistics.ps1
@@ -1,4 +1,4 @@
-Function Get-MailboxDatabaseAndMailboxStatistics {
+﻿Function Get-MailboxDatabaseAndMailboxStatistics {
 
     Write-VerboseOutput("Calling: Get-MailboxDatabaseAndMailboxStatistics")
     $AllDBs = Get-MailboxDatabaseCopyStatus -server $Script:Server -ErrorAction SilentlyContinue

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .NOTES
 	Name: HealthChecker.ps1
 	Requires: Exchange Management Shell and administrator rights on the target Exchange

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -1,4 +1,4 @@
-try {
+﻿try {
     #Enums and custom data types
     Add-Type -TypeDefinition @"
     using System;

--- a/Diagnostics/HealthChecker/Helpers/Get-CounterSamples.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-CounterSamples.ps1
@@ -1,4 +1,4 @@
-Function Get-CounterSamples {
+﻿Function Get-CounterSamples {
     param(
         [Parameter(Mandatory = $true)][array]$MachineNames,
         [Parameter(Mandatory = $true)][array]$Counters

--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -1,4 +1,4 @@
-Function Get-ErrorsThatOccurred {
+﻿Function Get-ErrorsThatOccurred {
 
     if ($Error.Count -gt 0) {
         Write-Grey(" "); Write-Grey(" ")

--- a/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
@@ -1,4 +1,4 @@
-Function Get-HealthCheckFilesItemsFromLocation {
+﻿Function Get-HealthCheckFilesItemsFromLocation {
     $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthCheck-*-*.xml" }
 
     if ($null -eq $items) {

--- a/Diagnostics/HealthChecker/Helpers/Get-OnlyRecentUniqueServersXmls.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-OnlyRecentUniqueServersXmls.ps1
@@ -1,4 +1,4 @@
-Function Get-OnlyRecentUniqueServersXMLs {
+﻿Function Get-OnlyRecentUniqueServersXMLs {
     param(
         [Parameter(Mandatory = $true)][array]$FileItems
     )

--- a/Diagnostics/HealthChecker/Helpers/Import-MyData.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Import-MyData.ps1
@@ -1,4 +1,4 @@
-Function Import-MyData {
+﻿Function Import-MyData {
     param(
         [Parameter(Mandatory = $true)][array]$FilePaths
     )

--- a/Diagnostics/HealthChecker/Helpers/Invoke-CatchActions.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-CatchActions.ps1
@@ -1,4 +1,4 @@
-Function Invoke-CatchActions {
+﻿Function Invoke-CatchActions {
     param(
         [object]$CopyThisError = $Error[0]
     )

--- a/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
@@ -1,4 +1,4 @@
-Function Invoke-ScriptLogFileLocation {
+﻿Function Invoke-ScriptLogFileLocation {
     param(
         [Parameter(Mandatory = $true)][string]$FileName,
         [Parameter(Mandatory = $false)][bool]$IncludeServerName = $false

--- a/Diagnostics/HealthChecker/Helpers/Test-RequiresServerFqdn.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Test-RequiresServerFqdn.ps1
@@ -1,4 +1,4 @@
-Function Test-RequiresServerFqdn {
+﻿Function Test-RequiresServerFqdn {
 
     Write-VerboseOutput("Calling: Test-RequiresServerFqdn")
     $tempServerName = ($Script:Server).Split(".")

--- a/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
@@ -1,4 +1,4 @@
-
+﻿
 function Write-Red($message) {
     Write-DebugLog $message
     Write-Host $message -ForegroundColor Red

--- a/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
@@ -1,4 +1,4 @@
-Function Write-ResultsToScreen {
+﻿Function Write-ResultsToScreen {
     param(
         [Hashtable]$ResultsToWrite
     )

--- a/Diagnostics/HealthChecker/Writers/Write-Verbose.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-Verbose.ps1
@@ -1,4 +1,4 @@
-Function Write-Verbose {
+﻿Function Write-Verbose {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose from Shared functions')]
     [CmdletBinding()]
     param(

--- a/Diagnostics/HealthChecker/extern/Write-ScriptMethodHostWriters.ps1
+++ b/Diagnostics/HealthChecker/extern/Write-ScriptMethodHostWriters.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
 #v21.01.22.2212
 Function Write-ScriptMethodHostWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]

--- a/Performance/ExPerfAnalyzer.ps1
+++ b/Performance/ExPerfAnalyzer.ps1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Vars are in use')]
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Vars are in use')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameters are in use')]
 [CmdletBinding()]
 Param(

--- a/PublicFolders/src/SourceSideValidations/Get-BadPermission.ps1
+++ b/PublicFolders/src/SourceSideValidations/Get-BadPermission.ps1
@@ -1,4 +1,4 @@
-function Get-BadPermission {
+﻿function Get-BadPermission {
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PublicFolders/src/SourceSideValidations/Get-BadPermissionJob.ps1
+++ b/PublicFolders/src/SourceSideValidations/Get-BadPermissionJob.ps1
@@ -1,4 +1,4 @@
-function Get-BadPermissionJob {
+﻿function Get-BadPermissionJob {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Incorrect rule result')]
     param (

--- a/PublicFolders/src/SourceSideValidations/Get-FolderData.ps1
+++ b/PublicFolders/src/SourceSideValidations/Get-FolderData.ps1
@@ -1,4 +1,4 @@
-function Get-FolderData {
+﻿function Get-FolderData {
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PublicFolders/src/SourceSideValidations/JobQueue.ps1
+++ b/PublicFolders/src/SourceSideValidations/JobQueue.ps1
@@ -1,4 +1,4 @@
-$jobsQueued = New-Object 'System.Collections.Generic.Queue[object]'
+﻿$jobsQueued = New-Object 'System.Collections.Generic.Queue[object]'
 
 function Add-JobQueueJob {
     [CmdletBinding()]

--- a/PublicFolders/src/SourceSideValidations/Remove-InvalidPermission.ps1
+++ b/PublicFolders/src/SourceSideValidations/Remove-InvalidPermission.ps1
@@ -1,4 +1,4 @@
-function Remove-InvalidPermission {
+﻿function Remove-InvalidPermission {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter()]

--- a/PublicFolders/src/ValidateMailEnabledPublicFolders.ps1
+++ b/PublicFolders/src/ValidateMailEnabledPublicFolders.ps1
@@ -1,4 +1,4 @@
-# ValidateMailEnabledPublicFolders.ps1
+﻿# ValidateMailEnabledPublicFolders.ps1
 #
 # Note: If running on Exchange 2010, the ExFolders tool must be in the V14\bin folder
 # in order to run one of the checks. ExFolders can be downloaded here:

--- a/Search/Troubleshoot-ModernSearch/Get-BasicMailboxQueryContext.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-BasicMailboxQueryContext.ps1
@@ -1,4 +1,4 @@
-Function Get-BasicMailboxQueryContext {
+﻿Function Get-BasicMailboxQueryContext {
     [CmdletBinding()]
     param(
         [object]$StoreQueryHandler

--- a/Search/Troubleshoot-ModernSearch/Get-BigFunnelPropertyNameMapping.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-BigFunnelPropertyNameMapping.ps1
@@ -1,4 +1,4 @@
-Function Get-BigFunnelPropertyNameMapping {
+﻿Function Get-BigFunnelPropertyNameMapping {
     [CmdletBinding()]
     param(
         [object]$StoreQueryHandler,

--- a/Search/Troubleshoot-ModernSearch/Get-FolderInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-FolderInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-FolderInformation {
+﻿Function Get-FolderInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/Get-IndexStateOfMessage.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-IndexStateOfMessage.ps1
@@ -1,4 +1,4 @@
-Function Get-IndexStateOfMessage {
+﻿Function Get-IndexStateOfMessage {
     [CmdletBinding()]
     [OutputType([System.String])]
     param(

--- a/Search/Troubleshoot-ModernSearch/Get-MailboxIndexMessageStatistics.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-MailboxIndexMessageStatistics.ps1
@@ -1,4 +1,4 @@
-Function Get-MailboxIndexMessageStatistics {
+﻿Function Get-MailboxIndexMessageStatistics {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/Get-MailboxInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-MailboxInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-MailboxInformation {
+﻿Function Get-MailboxInformation {
     [CmdletBinding()]
     param(
         [string]

--- a/Search/Troubleshoot-ModernSearch/Get-MessageIndexState.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-MessageIndexState.ps1
@@ -1,4 +1,4 @@
-Function Get-MessageIndexState {
+﻿Function Get-MessageIndexState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/Get-QueryItemResult.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-QueryItemResult.ps1
@@ -1,4 +1,4 @@
-Function Get-QueryItemResult {
+﻿Function Get-QueryItemResult {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/Get-StoreQueryHandler.ps1
+++ b/Search/Troubleshoot-ModernSearch/Get-StoreQueryHandler.ps1
@@ -1,4 +1,4 @@
-Function Get-StoreQueryHandler {
+﻿Function Get-StoreQueryHandler {
     [CmdletBinding()]
     param(
         [object]$MailboxInformation,

--- a/Search/Troubleshoot-ModernSearch/Troubleshoot-ModernSearch.ps1
+++ b/Search/Troubleshoot-ModernSearch/Troubleshoot-ModernSearch.ps1
@@ -1,4 +1,4 @@
-#Exchange On Prem Script to help assist with determining why search might not be working on an Exchange 2019+ Server
+﻿#Exchange On Prem Script to help assist with determining why search might not be working on an Exchange 2019+ Server
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameter is used')]
 [CmdletBinding()]
 param(

--- a/Search/Troubleshoot-ModernSearch/Write-MailboxIndexMessageStatistics.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write-MailboxIndexMessageStatistics.ps1
@@ -1,4 +1,4 @@
-Function Write-MailboxIndexMessageStatistics {
+﻿Function Write-MailboxIndexMessageStatistics {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     .SYNOPSIS
         This script contains mitigations to help address the following vulnerabilities.
             CVE-2021-26855

--- a/Setup/.NotPublished/BreakupSetupLog.NotPublished.ps1
+++ b/Setup/.NotPublished/BreakupSetupLog.NotPublished.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [System.IO.FileInfo]$SetupLog
 )

--- a/Setup/.NotPublished/CopyMsiOnly.NotPublished.ps1
+++ b/Setup/.NotPublished/CopyMsiOnly.NotPublished.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [string]$CuRoot,
     [string]$CopyToRoot

--- a/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
+++ b/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
@@ -1,4 +1,4 @@
-#This script is to take the last part of the setup log and take out all the content that we need to run Pester Testing
+﻿#This script is to take the last part of the setup log and take out all the content that we need to run Pester Testing
 #It will then change typical values that we see/need to lab values so it can be in the project.
 #Error Context might not be scrubbed properly
 [CmdletBinding()]

--- a/Setup/CopyMissingDlls/CopyMissingDlls.ps1
+++ b/Setup/CopyMissingDlls/CopyMissingDlls.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(SupportsShouldProcess = $True)]
+﻿[CmdletBinding(SupportsShouldProcess = $True)]
 param(
     [Parameter(Mandatory = $true, ParameterSetName = "CopyMissingDllsFromIso")]
     [ValidateNotNullOrEmpty()]

--- a/Setup/CopyMissingDlls/DllMappings/DllMaper.NotPublished.ps1
+++ b/Setup/CopyMissingDlls/DllMappings/DllMaper.NotPublished.ps1
@@ -1,4 +1,4 @@
-#This is mostly code that was slapped together to get the job done.
+﻿#This is mostly code that was slapped together to get the job done.
 [CmdletBinding()]
 param(
     [string]$ExInstall = "C:\Program Files\Microsoft\Exchange Server\V15",

--- a/Setup/FixInstallerCache/FixInstallerCache.ps1
+++ b/Setup/FixInstallerCache/FixInstallerCache.ps1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameters are being used')]
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameters are being used')]
 [CmdletBinding(DefaultParameterSetName = "CopyFromCu")]
 param(
     [Parameter(Mandatory = $true, ParameterSetName = "CopyFromCu")]

--- a/Setup/SetupAssist/Checks/Confirm-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/Confirm-VirtualDirectoryConfiguration.ps1
@@ -1,4 +1,4 @@
-function Confirm-VirtualDirectoryConfiguration {
+﻿function Confirm-VirtualDirectoryConfiguration {
     [CmdletBinding()]
     param ()
 

--- a/Setup/SetupAssist/Checks/Test-CriticalService.ps1
+++ b/Setup/SetupAssist/Checks/Test-CriticalService.ps1
@@ -1,4 +1,4 @@
-Function Test-CriticalService {
+﻿Function Test-CriticalService {
     $critical = @(
         "MpsSvc",
         "FMS",

--- a/Setup/SetupAssist/Checks/Test-ExchangeAdLevel.ps1
+++ b/Setup/SetupAssist/Checks/Test-ExchangeAdLevel.ps1
@@ -1,4 +1,4 @@
-Function Write-PrepareADInfo {
+﻿Function Write-PrepareADInfo {
     param(
         [bool]$SchemaUpdateRequired
     )

--- a/Setup/SetupAssist/Checks/Test-MissingDirectory.ps1
+++ b/Setup/SetupAssist/Checks/Test-MissingDirectory.ps1
@@ -1,4 +1,4 @@
-Function Test-MissingDirectory {
+﻿Function Test-MissingDirectory {
     $installPath = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction SilentlyContinue).MsiInstallPath
     $owaVersion = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction SilentlyContinue).OwaVersion
 

--- a/Setup/SetupAssist/Checks/Test-MissingMsiFiles.ps1
+++ b/Setup/SetupAssist/Checks/Test-MissingMsiFiles.ps1
@@ -1,4 +1,4 @@
-Function Test-MissingMsiFiles {
+﻿Function Test-MissingMsiFiles {
 
     $packageFiles = Get-InstallerPackages -FilterDisplayName @("Microsoft Lync Server", "Exchange", "Microsoft Server Speech", "Microsoft Unified Communications")
     $packagesMissing = @($packageFiles | Where-Object { $_.ValidMsi -eq $false })

--- a/Setup/SetupAssist/Checks/Test-OtherWellKnownObjects.ps1
+++ b/Setup/SetupAssist/Checks/Test-OtherWellKnownObjects.ps1
@@ -1,4 +1,4 @@
-Function Test-OtherWellKnownObjects {
+﻿Function Test-OtherWellKnownObjects {
     [CmdletBinding()]
     param ()
 

--- a/Setup/SetupAssist/Checks/Test-PendingReboot.ps1
+++ b/Setup/SetupAssist/Checks/Test-PendingReboot.ps1
@@ -1,4 +1,4 @@
-# From https://stackoverflow.com/questions/47867949/how-can-i-check-for-a-pending-reboot
+﻿# From https://stackoverflow.com/questions/47867949/how-can-i-check-for-a-pending-reboot
 function Test-PendingReboot {
     if (Get-Item "HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" -EA Ignore) {
         "Key set in: HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending. Remove it if reboot doesn't work" | Receive-Output -Diagnostic

--- a/Setup/SetupAssist/Checks/Test-PrerequisiteInstalled.ps1
+++ b/Setup/SetupAssist/Checks/Test-PrerequisiteInstalled.ps1
@@ -1,4 +1,4 @@
-Function Test-PrerequisiteInstalled {
+﻿Function Test-PrerequisiteInstalled {
     [CmdletBinding()]
     param()
     begin {

--- a/Setup/SetupAssist/Checks/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/Test-UserGroupMemberOf.ps1
@@ -1,4 +1,4 @@
-Function Test-UserGroupMemberOf {
+﻿Function Test-UserGroupMemberOf {
 
     $whoamiOutput = whoami /all
 

--- a/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
+++ b/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
@@ -1,4 +1,4 @@
-Function Test-ValidHomeMDB {
+﻿Function Test-ValidHomeMDB {
     $filePath = "$PSScriptRoot\validHomeMdb.txt"
     ldifde -t 3268 -r "(&(objectClass=user)(mailnickname=*)(!(msExchRemoteRecipientType=*))(!(targetAddress=*))(msExchHideFromAddressLists=TRUE)(!(cn=HealthMailbox*)))" -l "distinguishedName,homeMDB" -f $filePath | Out-Null
     $ldifeObject = @(Get-Content $filePath | ConvertFrom-Ldif)

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -1,4 +1,4 @@
-# SetupAssist.ps1 is used for running on the Exchange Server that we are wanting to install or upgrade.
+﻿# SetupAssist.ps1 is used for running on the Exchange Server that we are wanting to install or upgrade.
 # We validate common prerequisites that or overlooked and look at AD to make sure it is able to upgrade
 #
 # TODO: Add AD Object Permissions check

--- a/Setup/SetupAssist/Utils/ConvertFrom-Ldif.ps1
+++ b/Setup/SetupAssist/Utils/ConvertFrom-Ldif.ps1
@@ -1,4 +1,4 @@
-function ConvertFrom-Ldif {
+﻿function ConvertFrom-Ldif {
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/Test-KnownIssuesByErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-KnownIssuesByErrors.ps1
@@ -1,4 +1,4 @@
-Function Test-KnownIssuesByErrors {
+﻿Function Test-KnownIssuesByErrors {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/Setup/SetupLogReviewer/Checks/Test-KnownLdifErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-KnownLdifErrors.ps1
@@ -1,4 +1,4 @@
-Function Test-KnownLdifErrors {
+﻿Function Test-KnownLdifErrors {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/Setup/SetupLogReviewer/Checks/Test-KnownMsiIssuesCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-KnownMsiIssuesCheck.ps1
@@ -1,4 +1,4 @@
-Function Test-KnownMsiIssuesCheck {
+﻿Function Test-KnownMsiIssuesCheck {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/Setup/SetupLogReviewer/Checks/Test-KnownOrganizationPreparationErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-KnownOrganizationPreparationErrors.ps1
@@ -1,4 +1,4 @@
-Function Test-KnownOrganizationPreparationErrors {
+﻿Function Test-KnownOrganizationPreparationErrors {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/Setup/SetupLogReviewer/Checks/Test-PrerequisiteCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-PrerequisiteCheck.ps1
@@ -1,4 +1,4 @@
-Function Test-PrerequisiteCheck {
+﻿Function Test-PrerequisiteCheck {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param(

--- a/Setup/SetupLogReviewer/Delegated/Get-DelegatedInstallerHasProperRights.ps1
+++ b/Setup/SetupLogReviewer/Delegated/Get-DelegatedInstallerHasProperRights.ps1
@@ -1,4 +1,4 @@
-# Get-DelegatedInstallerHasProperRights
+﻿# Get-DelegatedInstallerHasProperRights
 #
 # Identifies the issue described in https://support.microsoft.com/en-us/help/2961741
 # by reading the setup log to see if this is why we failed.

--- a/Setup/SetupLogReviewer/SetupLogReviewer.ps1
+++ b/Setup/SetupLogReviewer/SetupLogReviewer.ps1
@@ -1,4 +1,4 @@
-# This script reviews the ExchangeSetup.log and determines if it is a known issue and reports an
+﻿# This script reviews the ExchangeSetup.log and determines if it is a known issue and reports an
 # action to take to resolve the issue.
 #
 # Use the DelegateSetup switch if the log is from a Delegated Setup and you are running into a Prerequisite Check issue

--- a/Setup/Shared/Get-FileInformation.ps1
+++ b/Setup/Shared/Get-FileInformation.ps1
@@ -1,4 +1,4 @@
-Function Get-FileInformation {
+﻿Function Get-FileInformation {
     [CmdletBinding()]
     param(
         [IO.FileInfo]$File,

--- a/Setup/Shared/Get-InstallerPackages.ps1
+++ b/Setup/Shared/Get-InstallerPackages.ps1
@@ -1,4 +1,4 @@
-#By doing it this way and looking at the registry, we get msp files as well. (Security Updates)
+﻿#By doing it this way and looking at the registry, we get msp files as well. (Security Updates)
 #Vs doing Get-CimInstance -ClassName Win32_Product
 Function Get-InstallerPackages {
     [CmdletBinding()]

--- a/Setup/Shared/New-SetupLogReviewer.ps1
+++ b/Setup/Shared/New-SetupLogReviewer.ps1
@@ -1,4 +1,4 @@
-
+﻿
 Function New-SetupLogReviewer {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'New is the best option')]
     [CmdletBinding()]

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+﻿BeforeAll {
     $parent = Split-Path -Parent $PSScriptRoot
     $parent = [IO.Path]::Combine($parent, "SetupLogReviewer")
     $sut = "SetupLogReviewer.ps1"

--- a/Shared/Confirm-Administrator.ps1
+++ b/Shared/Confirm-Administrator.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Confirm-Administrator/Confirm-Administrator.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Confirm-Administrator/Confirm-Administrator.ps1
 #v21.01.22.2212
 Function Confirm-Administrator {
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal( [Security.Principal.WindowsIdentity]::GetCurrent() )

--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -1,4 +1,4 @@
-Function Confirm-ExchangeShell {
+﻿Function Confirm-ExchangeShell {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)][bool]$LoadExchangeShell = $true,

--- a/Shared/Get-NETFrameworkVersion.ps1
+++ b/Shared/Get-NETFrameworkVersion.ps1
@@ -1,4 +1,4 @@
-Function Get-NETFrameworkVersion {
+﻿Function Get-NETFrameworkVersion {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,

--- a/Shared/Get-RemoteRegistrySubKey.ps1
+++ b/Shared/Get-RemoteRegistrySubKey.ps1
@@ -1,4 +1,4 @@
-Function Get-RemoteRegistrySubKey {
+﻿Function Get-RemoteRegistrySubKey {
     [CmdletBinding()]
     param(
         [string]$RegistryHive = "LocalMachine",

--- a/Shared/Get-RemoteRegistryValue.ps1
+++ b/Shared/Get-RemoteRegistryValue.ps1
@@ -1,4 +1,4 @@
-Function Get-RemoteRegistryValue {
+﻿Function Get-RemoteRegistryValue {
     [CmdletBinding()]
     param(
         [string]$RegistryHive = "LocalMachine",

--- a/Shared/Get-VisualCRedistributableVersion.ps1
+++ b/Shared/Get-VisualCRedistributableVersion.ps1
@@ -1,4 +1,4 @@
-Function Get-VisualCRedistributableVersion {
+﻿Function Get-VisualCRedistributableVersion {
     [CmdletBinding()]
     param(
         [string]$ComputerName = $env:COMPUTERNAME,

--- a/Shared/Invoke-ScriptBlockHandler.ps1
+++ b/Shared/Invoke-ScriptBlockHandler.ps1
@@ -1,4 +1,4 @@
-Function Invoke-ScriptBlockHandler {
+﻿Function Invoke-ScriptBlockHandler {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Shared/New-LoggerObject.ps1
+++ b/Shared/New-LoggerObject.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/New-LoggerObject/New-LoggerObject.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/New-LoggerObject/New-LoggerObject.ps1
 #v21.01.22.2234
 Function New-LoggerObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I prefer New here')]

--- a/Shared/Test-ScriptVersion.ps1
+++ b/Shared/Test-ScriptVersion.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
     Determines if the script has an update available. Use the optional
     -AutoUpdate switch to make it update itself. Returns $true if an
     update was downloaded, $false otherwise. The result will always

--- a/Shared/Write-HostWriter.ps1
+++ b/Shared/Write-HostWriter.ps1
@@ -1,4 +1,4 @@
-Function Write-HostWriter {
+﻿Function Write-HostWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]
     param(
         [Parameter(Mandatory = $true)][string]$WriteString

--- a/Shared/Write-ScriptMethodVerboseWriter.ps1
+++ b/Shared/Write-ScriptMethodVerboseWriter.ps1
@@ -1,4 +1,4 @@
-#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-ScriptMethodVerboseWriter.ps1
+﻿#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-ScriptMethodVerboseWriter.ps1
 #v21.01.22.2212
 Function Write-ScriptMethodVerboseWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]

--- a/Shared/Write-VerboseWriter.ps1
+++ b/Shared/Write-VerboseWriter.ps1
@@ -1,4 +1,4 @@
-Function Write-VerboseWriter {
+﻿Function Write-VerboseWriter {
     param(
         [Parameter(Mandatory = $true)][string]$WriteString
     )


### PR DESCRIPTION
Issue:

We do not use a consistent encoding across the repo. Some scripts have BOMs and some don't. When we release, we currently release scripts with no BOMs.

See [https://docs.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/understanding-file-encoding](https://docs.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/understanding-file-encoding).

Per that article, in Windows PowerShell, which is where our released scripts will usually be executed, the default encoding is Windows-1252. This means that a file with no BOM, like we currently release, is _not_ assumed to be UTF8. This will be problematic if we need to release scripts that include Unicode characters.

In PowerShell 6+, the default encoding is UTF8, so a BOM is not needed. VSCode will create files with UTF8 no BOM by default.

Proposal:

This PR changes our build process to always produce released scripts as UTF8 _with_ a BOM. This ensures that Windows PowerShell does not assume they are Windows-1252.

This PR also changes our code formatter script to enforce UTF8 _with_ a BOM at dev time. This ensures that our scripts behave the same at dev time as they do at release.

Additional Notes:

This change is agnostic to other files in the repo, such as text files.

We're taking a dependency on the EncodingAnalyzer module from PSGallery to check for a BOM.

Fixes #528 where Windows PowerShell can't figure out what to do with a curly quote because it thinks it's Windows 1252. Though we should probably change those to non-curly quotes anyway.