### PR TITLE
Add -UseBasicParsing to remove IE dependency

### DIFF
--- a/Hybrid/Test-HMAEAS.ps1
+++ b/Hybrid/Test-HMAEAS.ps1
@@ -67,7 +67,7 @@ process {
                     'Accept'         = 'application/json'
                     'Content-Length' = '0'
                 }
-                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Method GET
+                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Method GET -UseBasicParsing
                 $jsonResponse = $webResponse.Content | ConvertFrom-Json
                 Write-Host
                 Write-Host "We sent an AutoDiscover Request to On-Premises for the Exchange ActiveSync Virtual Directory and below is the response" -ForegroundColor Green
@@ -151,7 +151,7 @@ process {
         process {
             try {
                 $RequestURI = "https://prod-autodetect.outlookmobile.com/detect?services=office365,outlook,google,icloud,yahoo&protocols=rest-cloud,rest-outlook,rest-office365,eas,imap,smtp"
-                $webResponse = Invoke-WebRequest -Uri $RequestURI -Headers @{'x-email' = $($SMTP) } -Method GET
+                $webResponse = Invoke-WebRequest -Uri $RequestURI -Headers @{'x-email' = $($SMTP) } -Method GET -UseBasicParsing
                 $jsonResponse = $webResponse.Content | ConvertFrom-Json
                 if (!$jsonResponse.services) {
                     Write-Host
@@ -201,7 +201,7 @@ process {
                     'Content-Length' = '0'
                 }
                 $requestURI = New-Object "System.Uri" -ArgumentList $easUrl
-                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Method OPTIONS
+                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Method OPTIONS -UseBasicParsing
                 $webResponse.RawContent
             } catch [System.Net.WebException] {
                 Write-Host
@@ -230,7 +230,7 @@ process {
                 #Actual payload: "<Settings xmlns=\"Settings:\">  <UserInformation>    <Get />  </UserInformation>   </Settings>"
                 #Converted to wbxml byte array
                 $bytes = [byte[]](0x03, 0x01, 0x6a, 0x00, 0x00, 0x12, 0x45, 0x5D, 0x07, 0x01, 0x01)
-                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Body $bytes -Method POST
+                $webResponse = Invoke-WebRequest -Uri $requestURI -Headers $headers -Body $bytes -Method POST -UseBasicParsing
                 $webResponse.RawContent
                 [System.Convert]::ToBase64String($webResponse.Content)
             } catch {

--- a/Shared/Test-ScriptVersion.ps1
+++ b/Shared/Test-ScriptVersion.ps1
@@ -26,7 +26,7 @@ function Test-ScriptVersion {
     try {
         $versionsUrl = "https://github.com/microsoft/CSS-Exchange/releases/latest/download/ScriptVersions.csv"
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        $versionData = [Text.Encoding]::UTF8.GetString((Invoke-WebRequest $versionsUrl).Content) | ConvertFrom-Csv
+        $versionData = [Text.Encoding]::UTF8.GetString((Invoke-WebRequest $versionsUrl -UseBasicParsing).Content) | ConvertFrom-Csv
         $latestVersion = ($versionData | Where-Object { $_.File -eq $scriptName }).Version
         if ($null -ne $latestVersion -and $latestVersion -ne $BuildVersion) {
             if ($AutoUpdate -and $BuildVersion -ne "") {
@@ -35,7 +35,7 @@ function Test-ScriptVersion {
                 }
                 Write-Host "AutoUpdate: Downloading update."
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                Invoke-WebRequest "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$scriptName" -OutFile $tempFullName
+                Invoke-WebRequest "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$scriptName" -OutFile $tempFullName -UseBasicParsing
                 $sig = Get-AuthenticodeSignature $tempFullName
                 if ($sig.Status -eq "Valid") {
                     Write-Host "AutoUpdate: File signed by" $sig.SignerCertificate.Subject


### PR DESCRIPTION
**Issue:**
Invoke-WebRequest uses IE to parse the web response by default. If IE is not available on newer versions of Windows Server, Invoke-WebRequest fails:

```
Exception: System.NotSupportedException: The response content cannot be parsed because the Internet Explorer engine is not
 available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.VerifyInternetExplorerAvailable(Boolean checkComObject)
   at Microsoft.PowerShell.Commands.InvokeWebRequestCommand.ProcessResponse(WebResponse response)
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.ProcessRecord()
```

**Fix:**
Add -UseBasicParsing to all Invoke-WebRequest calls. This removes the IE dependency.