### PR TITLE
Parameters added to documentation

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -50,6 +50,12 @@
     Name of the HTML output file from the BuildHtmlServersReport. Default is ExchangeAllServersReport.html
 .PARAMETER DCCoreRatio
     Gathers the Exchange to DC/GC Core ratio and displays the results in the current site that the script is running in.
+.PARAMETER AnalyzeDataOnly
+    Switch to analyze the existing HealthChecker XML files. The results are displayed on the screen and an HTML report is generated.
+.PARAMETER SkipVersionCheck
+    No version check is performed when this switch is used.
+.PARAMETER SaveDebugLog
+    The debug log is kept even if the script is executed successfully.
 .PARAMETER Verbose
 	This optional parameter enables verbose logging.
 .EXAMPLE

--- a/docs/Diagnostics/HealthChecker.md
+++ b/docs/Diagnostics/HealthChecker.md
@@ -99,3 +99,6 @@ XMLDirectoryPath | Used in combination with BuildHtmlServersReport switch for th
 BuildHtmlServersReport | Switch to enable the script to build the HTML report for all the servers XML results in the XMLDirectoryPath location.
 HtmlReportFile | Name of the HTML output file from the BuildHtmlServersReport. Default is ExchangeAllServersReport.html
 DCCoreRatio | Gathers the Exchange to DC/GC Core ratio and displays the results in the current site that the script is running in.
+AnalyzeDataOnly | Switch to analyze the existing HealthChecker XML files. The results are displayed on the screen and an HTML report is generated.
+SkipVersionCheck | No version check is performed when this switch is used.
+SaveDebugLog | The debug log is kept even if the script is executed successfully.


### PR DESCRIPTION
Parameters `AnalyzeDataOnly`, `SkipVersionCheck`, `SaveDebugLog` were missing in the documentation.
