### PR TITLE
Convert certificate status to string to fix AnalyzeDataOnly display issue

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -64,7 +64,7 @@
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "Services" -Value $cert.Services
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "IsCurrentAuthConfigCertificate" -Value $isAuthConfigInfo
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "LifetimeInDays" -Value $certificateLifetime
-                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Status" -Value $cert.Status
+                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Status" -Value ($cert.Status).ToString()
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "CertificateObject" -Value $cert
 
                     $certObject += $certInformationObj


### PR DESCRIPTION
**Issue:**
`AnalyzeDataOnly` does not properly detect certificate status in switch statement and so it shows a yellow output:
![image](https://user-images.githubusercontent.com/40993616/116693244-e58bf580-a9bd-11eb-8299-5d393bf70a49.png)


**Reason:**
We receive the status with base type `System.Enum`. In `AnalyzeDataOnly` mode, we must check the switch statement against `$certificate.Status.value` instead of `$certificate.Status`

**Fix:**
We convert the status in the `Get-ExchangeServerCertificate` function to a `string`. This should fix the issue for all cases (normal script run and `AnalyzeDataOnly` run).

**Validation:**
Validated in E2019 lab.