### PR TITLE
Another adjustment to return certificate status correctly in PSSession scenarios

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -55,6 +55,12 @@
                         $certFriendlyName = $cert.FriendlyName
                     }
 
+                    if ([String]::IsNullOrEmpty($cert.Status)) {
+                        $certStatus = "Unknown"
+                    } else {
+                        $certStatus = ($cert.Status).ToString()
+                    }
+
                     $certInformationObj = New-Object PSCustomObject
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "FriendlyName" -Value $certFriendlyName
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "Thumbprint" -Value $cert.Thumbprint
@@ -64,7 +70,7 @@
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "Services" -Value $cert.Services
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "IsCurrentAuthConfigCertificate" -Value $isAuthConfigInfo
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "LifetimeInDays" -Value $certificateLifetime
-                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Status" -Value ($cert.Status).ToString()
+                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Status" -Value $certStatus
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "CertificateObject" -Value $cert
 
                     $certObject += $certInformationObj


### PR DESCRIPTION
**Issue:**
We can't query the certificate status on tools machines where no EMS is installed and just a PSSession is used to connect to an Exchange server (like: `New-PSSession -ConfigurationName microsoft.exchange -URI http://exlab-ex1901.exchangelabs.dom/powershell -AllowRedirection`). 

**Reason:**
The fix made in PR #571 breaks the `Get-ExchangeServerCertificates` function in the scenario described under 'issue'.

**Fix:**
We check if `cert.status` is not `nullorempty`. If it is, we set the `Unknown` value.

**Validation:**
Validated in lab.