### PR TITLE
Check for misconfigured DisabledComponents -1 value

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -946,10 +946,14 @@
         $displayValue = "True"
         $testingValue = $true
 
-        if ($osInformation.NetworkInformation.IPv6DisabledComponents -ne 255) {
+        if ($osInformation.NetworkInformation.IPv6DisabledComponents -eq -1) {
             $displayWriteType = "Red"
             $testingValue = $false
-            $displayValue = "False `r`n`t`tError: IPv6 is disabled on some NIC level settings but not fully disabled. DisabledComponents registry key currently set to '{0}'. For details please refer to the following articles: `r`n`t`thttps://blog.rmilne.ca/2014/10/29/disabling-ipv6-and-exchange-going-all-the-way `r`n`t`thttps://support.microsoft.com/en-us/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users" -f $osInformation.NetworkInformation.DisabledComponents
+            $displayValue = "False `r`n`t`tError: IPv6 is disabled on some NIC level settings but not correctly disabled via DisabledComponents registry value. It is currently set to '-1'. `r`n`t`tThis setting cause a system startup delay of 5 seconds. For details please refer to: `r`n`t`thttps://docs.microsoft.com/en-US/troubleshoot/windows-server/networking/configure-ipv6-in-windows#use-registry-key-to-configure-ipv6"
+        } elseif ($osInformation.NetworkInformation.IPv6DisabledComponents -ne 255) {
+            $displayWriteType = "Red"
+            $testingValue = $false
+            $displayValue = "False `r`n`t`tError: IPv6 is disabled on some NIC level settings but not fully disabled. DisabledComponents registry value currently set to '{0}'. For details please refer to the following articles: `r`n`t`thttps://blog.rmilne.ca/2014/10/29/disabling-ipv6-and-exchange-going-all-the-way `r`n`t`thttps://support.microsoft.com/en-us/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users" -f $osInformation.NetworkInformation.IPv6DisabledComponents
         }
 
         $analyzedResults = Add-AnalyzedResultInformation -Name "Disable IPv6 Correctly" -Details $displayValue `


### PR DESCRIPTION
**Issue:**
We now check if the `DisabledComponents` DWORD is set to `0xffffffff (-1)`. This setting causes a system startup delay of 5 seconds. For more information see issue #536 

**Fix:**
First we check for a value of `0xffffffff (-1)`, otherwise for not equal (ne) 255.

**Validation:**
Validated in lab