### PR TITLE
[New feature] Download Domains configuration check

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -1807,7 +1807,7 @@
                 -DisplayGroupingKey $keySecuritySettings `
                 -DisplayWriteType "Red" `
                 -DisplayCustomTabNumber 2 `
-                -AddHtmlDetailRow $false `
+                -AddHtmlDetailRow $true `
                 -AnalyzedInformation $analyzedResults
         } else {
 
@@ -1823,7 +1823,7 @@
                     -DisplayGroupingKey $keySecuritySettings `
                     -DisplayWriteType "Red" `
                     -DisplayCustomTabNumber 2 `
-                    -AddHtmlDetailRow $false `
+                    -AddHtmlDetailRow $true `
                     -AnalyzedInformation $analyzedResults
             }
 
@@ -1839,7 +1839,7 @@
                     -DisplayGroupingKey $keySecuritySettings `
                     -DisplayWriteType "Red" `
                     -DisplayCustomTabNumber 2 `
-                    -AddHtmlDetailRow $false `
+                    -AddHtmlDetailRow $true `
                     -AnalyzedInformation $analyzedResults
             }
         }
@@ -1852,7 +1852,7 @@
                 -DisplayGroupingKey $keySecuritySettings `
                 -DisplayWriteType "Red" `
                 -DisplayCustomTabNumber 2 `
-                -AddHtmlDetailRow $false `
+                -AddHtmlDetailRow $true `
                 -AnalyzedInformation $analyzedResults
 
             $Script:AllVulnerabilitiesPassed = $false

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -18,6 +18,14 @@
         $exchangeInformation.GetMailboxServer = (Get-MailboxServer -Identity $Script:Server)
     }
 
+    if (($buildInformation.MajorVersion -ge [HealthChecker.ExchangeMajorVersion]::Exchange2016 -and
+            $buildInformation.ServerRole -le [HealthChecker.ExchangeServerRole]::Mailbox) -or
+        ($buildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2013 -and
+            ($buildInformation.ServerRole -eq [HealthChecker.ExchangeServerRole]::ClientAccess -or
+                $buildInformation.ServerRole -eq [HealthChecker.ExchangeServerRole]::MultiRole))) {
+        $exchangeInformation.GetOwaVirtualDirectory = Get-OwaVirtualDirectory -Identity ("{0}\owa (Default Web Site)" -f $Script:Server) -ADPropertiesOnly
+    }
+
     if ($Script:ExchangeShellComputer.ToolsOnly) {
         $buildInformation.LocalBuildNumber = "{0}.{1}.{2}.{3}" -f $Script:ExchangeShellComputer.Major, $Script:ExchangeShellComputer.Minor, `
             $Script:ExchangeShellComputer.Build, `

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -354,10 +354,20 @@
         }
 
         try {
-            $exchangeInformation.MapiHttpEnabled = (Get-OrganizationConfig -ErrorAction Stop).MapiHttpEnabled
+            $organizationConfig = Get-OrganizationConfig -ErrorAction Stop
+            $exchangeInformation.GetOrganizationConfig = $organizationConfig
         } catch {
-            Write-Yellow "Failed to run Get-OrganizationConfig. Mapi HTTP Enabled results not accurate"
+            Write-Yellow "Failed to run Get-OrganizationConfig."
             Invoke-CatchActions
+        }
+
+        if ($null -ne $organizationConfig) {
+            $exchangeInformation.MapiHttpEnabled = $organizationConfig.MapiHttpEnabled
+            if ($null -ne $organizationConfig.EnableDownloadDomains) {
+                $exchangeInformation.EnableDownloadDomains = $organizationConfig.EnableDownloadDomains
+            }
+        } else {
+            Write-VerboseOutput("MAPI HTTP Enabled and Download Domains Enabled results not accurate")
         }
 
         if ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) {

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -20,6 +20,7 @@
                 public ExchangeBuildInformation BuildInformation = new ExchangeBuildInformation();   //Exchange build information
                 public object GetExchangeServer;      //Stores the Get-ExchangeServer Object
                 public object GetMailboxServer;       //Stores the Get-MailboxServer Object
+                public object GetOwaVirtualDirectory; //Stores the Get-OwaVirtualDirectory Object
                 public ExchangeNetFrameworkInformation NETFramework = new ExchangeNetFrameworkInformation();
                 public bool MapiHttpEnabled; //Stored from organization config
                 public System.Array ExchangeServicesNotRunning; //Contains the Exchange services not running by Test-ServiceHealth

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -21,6 +21,8 @@
                 public object GetExchangeServer;      //Stores the Get-ExchangeServer Object
                 public object GetMailboxServer;       //Stores the Get-MailboxServer Object
                 public object GetOwaVirtualDirectory; //Stores the Get-OwaVirtualDirectory Object
+                public object GetOrganizationConfig; //Stores the result from Get-OrganizationConfig
+                public bool EnableDownloadDomains = new bool(); //True if Download Domains are enabled on org level
                 public ExchangeNetFrameworkInformation NETFramework = new ExchangeNetFrameworkInformation();
                 public bool MapiHttpEnabled; //Stored from organization config
                 public System.Array ExchangeServicesNotRunning; //Contains the Exchange services not running by Test-ServiceHealth


### PR DESCRIPTION
**Feature description**
We introduced the `Download Domains` feature with Exchange 2016 CU18 and Exchange 2019 CU7. The feature was introduced to address `CVE-2021-1730 Spoofing Vulnerability` and should be configured.

For more information, see the FAQ section: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1730

**Fix:**
We check if the `Download Domains` feature is enabled or not. We show a red warning if it's available but not configured (disabled).
If the feature is enabled, then we check the configuration.
We compare the `ExternalDownloadHostName` and `InternalDownloadHostName` with the OWA `ExternalUrl` and `InternalUrl` and show a red warning if they are configured to use the same namespace (like owa.contoso.com).

**Validation:**
Validated in lab. Possible Pester test case.