### PR TITLE
Get-RemoteRegistryValue - ValueType check added

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -38,7 +38,7 @@
         }
     }
 
-    $osInformation.NetworkInformation.IPv6DisabledComponents = Invoke-RegistryGetValue -RegistryHive "LocalMachine" -MachineName $Script:Server -SubKey "SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" -GetValue "DisabledComponents" -CatchActionFunction ${Function:Invoke-CatchActions}
+    $osInformation.NetworkInformation.IPv6DisabledComponents = Get-RemoteRegistryValue -RegistryHive "LocalMachine" -MachineName $Script:Server -SubKey "SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" -GetValue "DisabledComponents" -ValueType "DWord" -CatchActionFunction ${Function:Invoke-CatchActions}
     $osInformation.NetworkInformation.TCPKeepAlive = Invoke-RegistryGetValue -RegistryHive "LocalMachine" -MachineName $Script:Server -SubKey "SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -GetValue "KeepAliveTime" -CatchActionFunction ${Function:Invoke-CatchActions}
     $osInformation.NetworkInformation.RpcMinConnectionTimeout = Invoke-RegistryGetValue -RegistryHive "LocalMachine" -MachineName $Script:Server -SubKey "Software\Policies\Microsoft\Windows NT\RPC\" -GetValue "MinimumConnectionTimeout" -CatchActionFunction ${Function:Invoke-CatchActions}
     $osInformation.NetworkInformation.HttpProxy = Get-HttpProxySetting

--- a/Shared/Get-RemoteRegistryValue.ps1
+++ b/Shared/Get-RemoteRegistryValue.ps1
@@ -6,8 +6,23 @@ Function Get-RemoteRegistryValue {
         [string]$MachineName,
         [string]$SubKey,
         [string]$GetValue,
+        [string]$ValueType,
         [scriptblock]$CatchActionFunction
     )
+
+    <#
+    Valid ValueType return values (case-sensitive)
+    (https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registryvaluekind?view=net-5.0)
+    Binary = REG_BINARY
+    DWord = REG_DWORD
+    ExpandString = REG_EXPAND_SZ
+    MultiString = REG_MULTI_SZ
+    None = No data type
+    QWord = REG_QWORD
+    String = REG_SZ
+    Unknown = An unsupported registry data type
+    #>
+
     begin {
         Write-Verbose "Calling: Get-RemoteRegistryValue"
         $registryGetValue = $null
@@ -20,10 +35,23 @@ Function Get-RemoteRegistryValue {
                 -MachineName $MachineName `
                 -SubKey $SubKey
 
-            if ($null -ne $regSubKey) {
+            if (-not ([System.String]::IsNullOrWhiteSpace($regSubKey))) {
                 Write-Verbose "Attempting to get the value $GetValue"
                 $registryGetValue = $regSubKey.GetValue($GetValue)
                 Write-Verbose "Finished running GetValue()"
+
+                if (-not ([System.String]::IsNullOrWhiteSpace($ValueType))) {
+                    Write-Verbose "Validating ValueType $ValueType"
+                    $registryValueType = $regSubKey.GetValueKind($GetValue)
+                    Write-Verbose "Finished running GetValueKind()"
+
+                    if ($ValueType -ne $registryValueType) {
+                        Write-Verbose "ValueType: $ValueType is different to the returned ValueType: $registryValueType"
+                        $registryGetValue = $null
+                    } else {
+                        Write-Verbose "ValueType matches: $ValueType"
+                    }
+                }
             }
         } catch {
             Write-Verbose "Failed to get the value on the registry"


### PR DESCRIPTION
**Description:**
`Get-RemoteRegistryValue` now supports an optional registry value type check. 

**Reason:**
We saw cases where customers used the wrong value type (for example issue #536). This feature can be used to only return a value when value + ValueType matches and so reduce false-positives (FP).

**Fix:**
We use the `RegistryKey.GetValueKind(String)` method to validate the ValueType if a value has been specified via `-ValueType ` parameter.

**Validation:**
Validated in E2016 lab. Possible Pester unit test.