### PR TITLE
Check for Exchange Organization Hybrid Configuration

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -11,6 +11,7 @@
     $order = 0
     $keyBeginningInfo = Get-DisplayResultsGroupingKey -Name "BeginningInfo" -DisplayGroupName $false -DisplayOrder ($order++) -DefaultTabNumber 0
     $keyExchangeInformation = Get-DisplayResultsGroupingKey -Name "Exchange Information"  -DisplayOrder ($order++)
+    $keyHybridInformation = Get-DisplayResultsGroupingKey -Name "Hybrid Information" -DisplayOrder ($order++)
     $keyOSInformation = Get-DisplayResultsGroupingKey -Name "Operating System Information" -DisplayOrder ($order++)
     $keyHardwareInformation = Get-DisplayResultsGroupingKey -Name "Processor/Hardware Information" -DisplayOrder ($order++)
     $keyNICSettings = Get-DisplayResultsGroupingKey -Name "NIC Settings Per Active Adapter" -DisplayOrder ($order++) -DefaultTabNumber 2
@@ -164,6 +165,164 @@
                 -DisplayCustomTabNumber 2 `
                 -DisplayWriteType "Yellow" `
                 -AddHtmlDetailRow $false `
+                -AnalyzedInformation $analyzedResults
+        }
+    }
+
+    #########################
+    # Hybrid Information
+    #########################
+    Write-VerboseOutput("Working on Hybrid Configuration Information")
+    if ($exchangeInformation.BuildInformation.MajorVersion -ge [HealthChecker.ExchangeMajorVersion]::Exchange2013 -and
+        $null -ne $exchangeInformation.GetHybridConfiguration) {
+
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Organization Hybrid enabled" -Details "True" `
+            -DisplayGroupingKey $keyHybridInformation `
+            -AnalyzedInformation $analyzedResults
+
+        if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.OnPremisesSmartHost))) {
+            $onPremSmartHostDomain = ($exchangeInformation.GetHybridConfiguration.OnPremisesSmartHost).ToString()
+            $onPremSmartHostWriteType = "Grey"
+        } else {
+            $onPremSmartHostDomain = "No on-premises smart host domain configured for hybrid use"
+            $onPremSmartHostWriteType = "Yellow"
+        }
+
+        $analyzedResults = Add-AnalyzedResultInformation -Name "On-Premises Smart Host Domain" -Details $onPremSmartHostDomain `
+            -DisplayGroupingKey $keyHybridInformation `
+            -DisplayWriteType $onPremSmartHostWriteType `
+            -AnalyzedInformation $analyzedResults
+
+        if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.Domains))) {
+            $domainsConfiguredForHybrid = $exchangeInformation.GetHybridConfiguration.Domains
+            $domainsConfiguredForHybridWriteType = "Grey"
+        } else {
+            $domainsConfiguredForHybridWriteType = "Yellow"
+        }
+
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Domain(s) configured for Hybrid use" `
+            -DisplayGroupingKey $keyHybridInformation `
+            -DisplayWriteType $domainsConfiguredForHybridWriteType `
+            -AnalyzedInformation $analyzedResults
+
+        if ($domainsConfiguredForHybrid.Count -ge 1) {
+            foreach ($domain in $domainsConfiguredForHybrid) {
+                $analyzedResults = Add-AnalyzedResultInformation -Details $domain `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayWriteType $domainsConfiguredForHybridWriteType `
+                    -DisplayCustomTabNumber 2 `
+                    -AnalyzedInformation $analyzedResults
+            }
+        } else {
+            $analyzedResults = Add-AnalyzedResultInformation -Details "No domain configured for Hybrid use" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -DisplayWriteType $domainsConfiguredForHybridWriteType `
+                -DisplayCustomTabNumber 2 `
+                -AnalyzedInformation $analyzedResults
+        }
+
+        if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.EdgeTransportServers))) {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Edge Transport Server(s)" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -AnalyzedInformation $analyzedResults
+
+            foreach ($edgeServer in $exchangeInformation.GetHybridConfiguration.EdgeTransportServers) {
+                $analyzedResults = Add-AnalyzedResultInformation -Details $edgeServer `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayCustomTabNumber 2  `
+                    -AnalyzedInformation $analyzedResults
+            }
+
+            if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.ReceivingTransportServers)) -or
+                (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.SendingTransportServers)))) {
+                $analyzedResults = Add-AnalyzedResultInformation -Details "When configuring the EdgeTransportServers parameter, you must configure the ReceivingTransportServers and SendingTransportServers parameter values to null" `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayWriteType "Yellow" `
+                    -DisplayCustomTabNumber 2 `
+                    -AnalyzedInformation $analyzedResults
+            }
+        } else {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Receiving Transport Server(s)" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -AnalyzedInformation $analyzedResults
+
+            if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.ReceivingTransportServers))) {
+                foreach ($receivingTransportSrv in $exchangeInformation.GetHybridConfiguration.ReceivingTransportServers) {
+                    $analyzedResults = Add-AnalyzedResultInformation -Details $receivingTransportSrv `
+                        -DisplayGroupingKey $keyHybridInformation `
+                        -DisplayCustomTabNumber 2 `
+                        -AnalyzedInformation $analyzedResults
+                }
+            } else {
+                $analyzedResults = Add-AnalyzedResultInformation -Details "No Receiving Transport Server configured for Hybrid use" `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayCustomTabNumber 2 `
+                    -DisplayWriteType "Yellow" `
+                    -AnalyzedInformation $analyzedResults
+            }
+
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Sending Transport Server(s)" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -AnalyzedInformation $analyzedResults
+
+            if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.SendingTransportServers))) {
+                foreach ($sendingTransportSrv in $exchangeInformation.GetHybridConfiguration.SendingTransportServers) {
+                    $analyzedResults = Add-AnalyzedResultInformation -Details $sendingTransportSrv `
+                        -DisplayGroupingKey $keyHybridInformation `
+                        -DisplayCustomTabNumber 2 `
+                        -AnalyzedInformation $analyzedResults
+                }
+            } else {
+                $analyzedResults = Add-AnalyzedResultInformation -Details "No Sending Transport Server configured for Hybrid use" `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayCustomTabNumber 2 `
+                    -DisplayWriteType "Yellow" `
+                    -AnalyzedInformation $analyzedResults
+            }
+        }
+
+        if ($exchangeInformation.GetHybridConfiguration.ServiceInstance -eq 1) {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Service Instance" -Details "Office 365 operated by 21Vianet" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -AnalyzedInformation $analyzedResults
+        } elseif ($exchangeInformation.GetHybridConfiguration.ServiceInstance -ne 0) {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Service Instance" -Details ($exchangeInformation.GetHybridConfiguration.ServiceInstance) `
+                -DisplayGroupingKey $keyHybridInformation `
+                -DisplayWriteType "Red" `
+                -AnalyzedInformation $analyzedResults
+
+            $analyzedResults = Add-AnalyzedResultInformation -Details "You are using an invalid value. Please set this value to 0 (null) or re-run HCW" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -DisplayWriteType "Red" `
+                -AnalyzedInformation $analyzedResults
+        }
+
+        if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.TlsCertificateName))) {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "TLS Certificate Name" -Details ($exchangeInformation.GetHybridConfiguration.TlsCertificateName).ToString() `
+                -DisplayGroupingKey $keyHybridInformation `
+                -AnalyzedInformation $analyzedResults
+        } else {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "TLS Certificate Name" -Details "No valid certificate found" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -DisplayWriteType "Red" `
+                -AnalyzedInformation $analyzedResults
+        }
+
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Feature(s) enabled for Hybrid use" `
+            -DisplayGroupingKey $keyHybridInformation `
+            -AnalyzedInformation $analyzedResults
+
+        if (-not([System.String]::IsNullOrEmpty($exchangeInformation.GetHybridConfiguration.Features))) {
+            foreach ($feature in $exchangeInformation.GetHybridConfiguration.Features) {
+                $analyzedResults = Add-AnalyzedResultInformation -Details $feature `
+                    -DisplayGroupingKey $keyHybridInformation `
+                    -DisplayCustomTabNumber 2  `
+                    -AnalyzedInformation $analyzedResults
+            }
+        } else {
+            $analyzedResults = Add-AnalyzedResultInformation -Details "No feature(s) enabled for Hybrid use" `
+                -DisplayGroupingKey $keyHybridInformation `
+                -DisplayCustomTabNumber 2  `
                 -AnalyzedInformation $analyzedResults
         }
     }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -372,6 +372,12 @@
 
         if ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) {
             $exchangeInformation.ApplicationPools = Get-ExchangeAppPoolsInformation
+            try {
+                $exchangeInformation.GetHybridConfiguration = Get-HybridConfiguration -ErrorAction Stop
+            } catch {
+                Write-Yellow "Failed to run Get-HybridConfiguration"
+                Invoke-CatchActions
+            }
         }
 
         $serverExchangeBinDirectory = Invoke-ScriptBlockHandler -ComputerName $Script:Server `

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -22,6 +22,7 @@
                 public object GetMailboxServer;       //Stores the Get-MailboxServer Object
                 public object GetOwaVirtualDirectory; //Stores the Get-OwaVirtualDirectory Object
                 public object GetOrganizationConfig; //Stores the result from Get-OrganizationConfig
+                public object GetHybridConfiguration; //Stores the Get-HybridConfiguration Object
                 public bool EnableDownloadDomains = new bool(); //True if Download Domains are enabled on org level
                 public ExchangeNetFrameworkInformation NETFramework = new ExchangeNetFrameworkInformation();
                 public bool MapiHttpEnabled; //Stored from organization config


### PR DESCRIPTION
**Description:**
This is the first draft of the Exchange Organization Hybrid Configuration implementation. We query the information via `Get-HybridConfiguration` and store the results in `public class ExchangeInformation` as `public object GetHybridConfiguration;`.
We only run the validation of these values when the server is no Edge Transport server and Exchange version is greater or equal Exchange2013. We simply skip the checks when no Hybrid Configuration is available. 

![image](https://user-images.githubusercontent.com/40993616/120316572-dca08380-c2dd-11eb-895a-32745dbd6f7f.png)

Work item #539

**Validation:**
Validated in Exchange 2016 Hybrid lab with Edge Transport server in place; possible Pester unit test case