### PR TITLE
Ensure dot sourced script paths use correct case

### DIFF
--- a/.build/BuildFunctions/Get-FileMostRecentCommit.ps1
+++ b/.build/BuildFunctions/Get-FileMostRecentCommit.ps1
@@ -1,0 +1,29 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Test-PathCaseSensitive.ps1
+
+function Get-FileMostRecentCommit {
+    [CmdletBinding()]
+    [OutputType([DateTime])]
+    param (
+        [Parameter()]
+        [string]
+        $File
+    )
+
+    Write-Verbose "Get-FileMostRecentCommit called for file $File"
+
+    if (-not (Test-PathCaseSensitive $File)) {
+        Write-Error "Path case is not correct: $File"
+    }
+
+    try {
+        $commitTime = [DateTime]::Parse((git log -n 1 --format="%ad" --date=rfc $File))
+        Write-Verbose "Commit time $commitTime for file $File"
+        return $commitTime
+    } catch {
+        Write-Error "Failed to get commit time for file $File"
+        throw
+    }
+}

--- a/.build/BuildFunctions/Get-ScriptProjectMostRecentCommit.ps1
+++ b/.build/BuildFunctions/Get-ScriptProjectMostRecentCommit.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-EmbeddedFileList.ps1
+. $PSScriptRoot\Get-FileMostRecentCommit.ps1
 
 <#
 .SYNOPSIS
@@ -19,15 +20,13 @@ function Get-ScriptProjectMostRecentCommit {
 
     process {
         Write-Verbose "Get-ScriptProjectMostRecentCommit called for file $File"
-        $mostRecentCommit = [DateTime]::MinValue
-        if ([DateTime]::TryParse((git log -n 1 --format="%ad" --date=rfc $File), [ref] $mostRecentCommit)) {
-            Get-EmbeddedFileList $File | ForEach-Object {
-                Write-Verbose "Getting commit time for $_"
-                $commitTime = [DateTime]::Parse((git log -n 1 --format="%ad" --date=rfc $_))
-                if ($commitTime -gt $mostRecentCommit) {
-                    $mostRecentCommit = $commitTime
-                    Write-Host ("Changing commit time to: $($commitTime.ToString("yy.MM.dd.HHmm"))")
-                }
+        $mostRecentCommit = Get-FileMostRecentCommit $File
+        foreach ($embeddedFile in (Get-EmbeddedFileList $File)) {
+            Write-Verbose "Getting commit time for $embeddedFile"
+            $commitTime = Get-FileMostRecentCommit $embeddedFile
+            if ($commitTime -gt $mostRecentCommit) {
+                $mostRecentCommit = $commitTime
+                Write-Host ("Changing commit time to: $($commitTime.ToString("yy.MM.dd.HHmm"))")
             }
         }
 

--- a/.build/BuildFunctions/Test-PathCaseSensitive.ps1
+++ b/.build/BuildFunctions/Test-PathCaseSensitive.ps1
@@ -1,0 +1,29 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Test-PathCaseSensitive {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        Write-Warning "Path does not exist: $Path"
+        return $false
+    }
+
+    $directoryName = [IO.Path]::GetDirectoryName($Path)
+    $fileName = [IO.Path]::GetFileName($Path)
+    $childItem = Get-ChildItem $directoryName -Filter $fileName
+    $actualPath = $childItem.FullName
+    if ($actualPath -ceq $Path) {
+        return $true
+    }
+
+    Write-Warning "Provided path: $Path"
+    Write-Warning "Actual path: $actualPath"
+    Write-Warning "Path case is not correct."
+    return $false
+}


### PR DESCRIPTION
**Issue:**
If a dot loaded script path has incorrect casing, we can't find the commit time of the file at build time. This causes build to fail with a somewhat vague error, which doesn't even tell you which embedded file failed, or why:

![image](https://user-images.githubusercontent.com/4518572/124028875-1d151f00-d9ba-11eb-9c43-563650da7a6e.png)

**Reason:**
Makes it hard to troubleshoot this build issue.

**Fix:**
Explicitly check the path case and throw a descriptive error. If the git log command fails for some other reason, still throw an error that at least calls out the file that failed. Output for the path case issue now looks like this:

![image](https://user-images.githubusercontent.com/4518572/124029590-ec81b500-d9ba-11eb-8ee9-3a6df928374a.png)
