### PR TITLE
Display build status of release instead of main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exchange Server Support Scripts
 
-[![Build Status](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_apis/build/status/microsoft.CSS-Exchange?branchName=main)](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_build/latest?definitionId=7&branchName=main)
+[![Build Status](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_apis/build/status/microsoft.CSS-Exchange?branchName=release)](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_build/latest?definitionId=7&branchName=release)
 
 ## The Repository
 


### PR DESCRIPTION
**Issue:**
Badge in README doesn't show a build status.

**Reason:**
We don't build main anymore.

**Fix:**
Point the badge to release branch.
