### PR TITLE
SetupAssist check for Computers container

### DIFF
--- a/Setup/SetupAssist/Checks/Test-ComputersContainerExists.ps1
+++ b/Setup/SetupAssist/Checks/Test-ComputersContainerExists.ps1
@@ -1,0 +1,13 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Function Test-ComputersContainerExists {
+    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+    foreach ($domain in $forest.Domains) {
+        $domainDN = $domain.GetDirectoryEntry().distinguishedName
+        $computersPath = ("LDAP://CN=Computers," + $domainDN)
+        if (-not [System.DirectoryServices.DirectoryEntry]::Exists($computersPath)) {
+            "The Computers container in domain $domainDN has been renamed or deleted. This will cause /PrepareAd to fail in some scenarios." | Receive-Output -IsWarning
+        }
+    }
+}

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -15,6 +15,7 @@ param(
 . .\Checks\Confirm-VirtualDirectoryConfiguration.ps1
 . .\Checks\Test-CriticalService.ps1
 . .\Checks\Test-ExchangeAdLevel.ps1
+. .\Checks\Test-ComputersContainerExists.ps1
 . .\Checks\Test-MissingDirectory.ps1
 . .\Checks\Test-MissingMsiFiles.ps1
 . .\Checks\Test-OtherWellKnownObjects.ps1
@@ -124,6 +125,7 @@ Function MainUse {
     Test-ValidHomeMDB
     Test-MissingDirectory
     Test-ExchangeAdSetupObjects
+    Test-ComputersContainerExists
     Confirm-VirtualDirectoryConfiguration
 
     $exSetupLog = "$($env:HOMEDRIVE)\ExchangeSetupLogs\ExchangeSetup.log"


### PR DESCRIPTION
**Issue:**
Add a check for emerging issue where E16 CU21 cannot /PrepareAd because Computers container is renamed.
