### PR TITLE
Addressed Build script to avoid excluding references of possible dot loading within itself

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -52,10 +52,12 @@ $scriptFiles = Get-ChildItem -Path $repoRoot -Directory |
 #>
 
 $scriptFiles = $scriptFiles | Where-Object {
+    $fullName = $_
     $scriptName = [IO.Path]::GetFileName($_)
     $pattern = "\. .*\\$scriptName"
     $m = $scriptFiles | Get-Item | Select-String -Pattern $pattern
-    $m.Count -lt 1
+    $r = $m | Where-Object { $_.Path -ne $fullName }
+    $r.Count -lt 1
 }
 
 $nonUnique = @($scriptFiles | ForEach-Object { [IO.Path]::GetFileName($_) } | Group-Object | Where-Object { $_.Count -gt 1 })


### PR DESCRIPTION
It is possible to have comment and or warnings where we have two periods in the same line and it looks like we are dot loading the file. When we just have a comment or a warning providing what to do within the same file, don't exclude it from the list that we want to publish.

![image](https://user-images.githubusercontent.com/22776718/126660632-2fb4d94a-2890-4630-9d4b-96a72938eb18.png)

