### PR TITLE
SetupAssist - Fixed issue when running from Child Domain for Test-ValidHomeMdb

### DIFF
--- a/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
+++ b/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
@@ -46,6 +46,6 @@ Function Test-ValidHomeMDB {
             "All Critical Mailboxes have valid HomeMDB values" | Receive-Output
         }
     } else {
-        throw "Unexpected LDIF data."
+        Write-Error "Unexpected LDIF data in Test-ValidHomeMdb."
     }
 }

--- a/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
+++ b/Setup/SetupAssist/Checks/Test-ValidHomeMdb.ps1
@@ -3,7 +3,10 @@
 
 Function Test-ValidHomeMDB {
     $filePath = "$PSScriptRoot\validHomeMdb.txt"
-    ldifde -t 3268 -r "(&(objectClass=user)(mailnickname=*)(!(msExchRemoteRecipientType=*))(!(targetAddress=*))(msExchHideFromAddressLists=TRUE)(!(cn=HealthMailbox*)))" -l "distinguishedName,homeMDB" -f $filePath | Out-Null
+    $rootDSE = [ADSI]("LDAP://RootDSE")
+    ldifde -t 3268 -r "(&(objectClass=user)(mailnickname=*)(!(msExchRemoteRecipientType=*))(!(targetAddress=*))(msExchHideFromAddressLists=TRUE)(!(cn=HealthMailbox*)))" `
+        -l "distinguishedName,homeMDB" -f $filePath -d $rootDSE.rootDomainNamingContext | Out-Null
+
     $ldifeObject = @(Get-Content $filePath | ConvertFrom-Ldif)
 
     if ($ldifeObject.Count -gt 0) {


### PR DESCRIPTION
Script was stopping with an error and wouldn't complete if ran from Child or Tree Domain. Addressed the base of the query within the LDIFDE command and softly handled any failures to read the data to allow the script to continue. 

Resolved #632 