### PR TITLE
New feature: ScriptUpdateOnly

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
@@ -16,7 +16,8 @@ Function Invoke-ScriptLogFileLocation {
     $Script:OutXmlFullPath = $Script:OutputFullPath.Replace(".txt", ".xml")
 
     if ($AnalyzeDataOnly -or
-        $BuildHtmlServersReport) {
+        $BuildHtmlServersReport -or
+        $ScriptUpdateOnly) {
         return
     }
 

--- a/docs/Diagnostics/HealthChecker.md
+++ b/docs/Diagnostics/HealthChecker.md
@@ -102,3 +102,4 @@ DCCoreRatio | Gathers the Exchange to DC/GC Core ratio and displays the results 
 AnalyzeDataOnly | Switch to analyze the existing HealthChecker XML files. The results are displayed on the screen and an HTML report is generated.
 SkipVersionCheck | No version check is performed when this switch is used.
 SaveDebugLog | The debug log is kept even if the script is executed successfully.
+ScriptUpdateOnly | Switch to check for the latest version of the script and perform an auto update if a newer version was found. Can be run on any machine with internet connectivity. No elevated permissions or EMS are required.


### PR DESCRIPTION
**Feature description:**
Many customers don't have an internet connectivity on their Exchange machines. These customers must manually download the latest version of the script from the internet by visiting `https://aka.ms/ExchangeHealthChecker`. 

The new feature `ScriptUpdateOnly` allows them to run the script without elevated permissions and without Exchange Management Tools installed on a machine with internet connectivity to perform an auto update only. Makes it easier for them to get the latest version of the script.