### PR TITLE
Check for FullLanguage mode

### DIFF
--- a/Setup/SetupAssist/Checks/Test-FullLanguageMode.ps1
+++ b/Setup/SetupAssist/Checks/Test-FullLanguageMode.ps1
@@ -1,0 +1,11 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Test-FullLanguageMode {
+    if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
+        "PowerShell is not in FullLanguage mode. Exchange Setup requires FullLanguage mode. The SetupAssist script also requires it. Cannot continue." | Receive-Output -IsWarning
+        return $false
+    }
+
+    return $true
+}

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -24,6 +24,7 @@ param(
 . $PSScriptRoot\Checks\Test-PrerequisiteInstalled.ps1
 . .\Checks\Test-UserGroupMemberOf.ps1
 . .\Checks\Test-ValidHomeMdb.ps1
+. .\Checks\Test-FullLanguageMode.ps1
 . .\Utils\ConvertFrom-Ldif.ps1
 
 #Local Shared
@@ -185,6 +186,10 @@ Function Main {
 }
 
 try {
+    if (-not (Test-FullLanguageMode)) {
+        return
+    }
+
     Out-File -FilePath $Script:ScriptLogging -Force | Out-Null
     Receive-Output "Starting Script At: $([DateTime]::Now)" -Diagnostic
     Receive-Output "Test Latest Script Version" -Diagnostic


### PR DESCRIPTION
This test has to be the first thing we do. The version check can't even run if we're not in FullLanguage mode.

![image](https://user-images.githubusercontent.com/4518572/127897520-ee84ac5a-636c-4795-a724-b390cd25fb21.png)
