### PR TITLE
Ensure that $installed is not null

### DIFF
--- a/Setup/SetupAssist/Checks/Test-PrerequisiteInstalled.ps1
+++ b/Setup/SetupAssist/Checks/Test-PrerequisiteInstalled.ps1
@@ -12,7 +12,7 @@ Function Test-PrerequisiteInstalled {
             "Download .NET 4.8 and install: https://dotnet.microsoft.com/download/dotnet-framework/net48" | Receive-Output
         }
 
-        $installed = Get-VisualCRedistributableInstalledVersion
+        $installed = @(Get-VisualCRedistributableInstalledVersion)
 
         if (-not (Test-VisualCRedistributableUpToDate -Year 2012 -Installed $installed)) {
             "Download Visual C++ 2012 Redistributable Package and install: $((Get-VisualCRedistributableInfo 2012).DownloadUrl)" | Receive-Output


### PR DESCRIPTION
When Get-VisualCRedistributableInstalledVersion finds nothing at all, it returns an empty list, which PowerShell unwinds into a null value. Passing $installed as null causes this error:

```
System.Management.Automation.ParameterBindingValidationException: Cannot bind argument to parameter 'Installed' because
it is null.
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProces
s)
   at System.Management.Automation.PSScriptCmdlet.DoProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
at Test-PrerequisiteInstalled<Process>, C:\Users\Administrator\Downloads\SetupAssist.ps1: line 669
at MainUse, C:\Users\Administrator\Downloads\SetupAssist.ps1: line 1865
at Main, C:\Users\Administrator\Downloads\SetupAssist.ps1: line 1940
at <ScriptBlock>, C:\Users\Administrator\Downloads\SetupAssist.ps1: line 1958
at <ScriptBlock>, <No file>: line 1
```

This change ensures we always get an array so we do not pass $installed as a null to the subsequent calls.