### PR TITLE
Remove Schema Admin check

### DIFF
--- a/Security/src/Test-CVE-2021-34470.ps1
+++ b/Security/src/Test-CVE-2021-34470.ps1
@@ -65,20 +65,18 @@ if ($ApplyFix) {
         $storageGroupSchemaEntry.Properties["possSuperiors"] | Out-File $OutputFile -Append
     }
 
-    $isSchemaAdmin = $null -ne (whoami /groups | Select-String "\\Schema Admins\s+")
-    if (-not $isSchemaAdmin) {
-        Write-Warning "This user is not in Schema Admins. Cannot apply fix."
-        return
+    try {
+        Write-Host "Attempting to apply fix..."
+
+        $rootDSE = [ADSI]("LDAP://$($schemaMaster)/RootDSE")
+        [void]$rootDSE.Properties["schemaUpgradeInProgress"].Add(1)
+        $rootDSE.CommitChanges()
+
+        $storageGroupSchemaEntry.Properties["possSuperiors"].Clear()
+        $storageGroupSchemaEntry.CommitChanges()
+
+        Write-Host "Fix was applied successfully."
+    } catch {
+        Write-Warning "Failed to apply fix. Please ensure you have Schema Admin rights. Error was: `n$_"
     }
-
-    Write-Host "Attempting to apply fix..."
-
-    $rootDSE = [ADSI]("LDAP://$($schemaMaster)/RootDSE")
-    [void]$rootDSE.Properties["schemaUpgradeInProgress"].Add(1)
-    $rootDSE.CommitChanges()
-
-    $storageGroupSchemaEntry.Properties["possSuperiors"].Clear()
-    $storageGroupSchemaEntry.CommitChanges()
-
-    Write-Host "Fix was applied successfully."
 }


### PR DESCRIPTION
After discussing with dpaulson, we're taking out the Schema Admin check entirely. It's better to just try and let it fail, rather than doing a bad job of proactively checking rights.

New experience:

![image](https://user-images.githubusercontent.com/4518572/128532585-31b54d21-7691-47c9-845f-d7670e54290f.png)
