### PR TITLE
Add new condition to DL2365Groupupgrade script

### DIFF
--- a/M365/README.md
+++ b/M365/README.md
@@ -1,8 +1,8 @@
 # [DLT365Groupsupgrade.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1)
 
-## Validating Distribution group eligibility for upgrade to O365 Group
+## Validating Distribution group eligibility for upgrade to Microsoft 365 Group
 
-This script allows you to check Distribution to O365 Group migration eligibility for a specific distribution group SMTP, for more information over the Distribution to O365 Group migration blockers please check: https://docs.microsoft.com/en-us/microsoft-365/admin/manage/upgrade-distribution-lists?view=o365-worldwide
+This script allows you to check Distribution to Microsoft 365 Group migration eligibility for a specific distribution group SMTP, for more information over the Distribution to Microsoft 365 Group migration blockers please check: https://docs.microsoft.com/en-us/microsoft-365/admin/manage/upgrade-distribution-lists?view=o365-worldwide
 
 Download the latest release here: [https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/DLT365Groupsupgrade.ps1)
 

--- a/M365/src/DLT365Groupsupgrade.ps1
+++ b/M365/src/DLT365Groupsupgrade.ps1
@@ -121,9 +121,9 @@ Function Debuggroupnesting {
     $ParentDGroups = @()
     try {
         $alldgs = Get-DistributionGroup -ResultSize unlimited -ErrorAction Stop
-        #$CurrentDescription = "Retrieving All DGs in the EXO directory"
-        #$CurrentStatus = "Success"
-        #log -Function "Retrieve All DGs" -CurrentDescription $CurrentDescription -CurrentStatus $CurrentStatus
+        $CurrentDescription = "Retrieving All DGs in the EXO directory"
+        $CurrentStatus = "Success"
+        log -Function "Retrieve All DGs" -CurrentDescription $CurrentDescription -CurrentStatus $CurrentStatus
     } catch {
         $CurrentDescription = "Retrieving All DGs in the EXO directory"
         $CurrentStatus = "Failure"
@@ -132,9 +132,6 @@ Function Debuggroupnesting {
     foreach ($parentdg in $alldgs) {
         try {
             $Pmembers = Get-DistributionGroupMember $($parentdg.Guid.ToString()) -ErrorAction Stop
-            #$CurrentDescription = "Retrieving: $parentdg members"
-            #$CurrentStatus = "Success"
-            #log -Function "Retrieve Distribution Group membership" -CurrentDescription $CurrentDescription -CurrentStatus $CurrentStatus
         } catch {
             $CurrentDescription = "Retrieving: $parentdg members"
             $CurrentStatus = "Failure"


### PR DESCRIPTION
**Issue:**
Describe what the issue is you are addressing

- I've added new condition to test DL owners with RecipientTypeDetails other than UserMailbox, MailUser
- I've modified the EAP condition to work case sensitively while comparing DL PrimarySmtpAddress& EnabledPrimarySMTPAddressTemplate
- Modified readme file by change title O365 to Microsoft 365

**Reason:**
Describe what the reason is for making the change

To address these new conditions I've mentioned earlier that might fail DL to M365 group upgrade

**Fix:**
Short description of the fix

- I've added new condition to test DL owners with RecipientTypeDetails other than UserMailbox, MailUser
- I've modified the EAP condition to work case sensitively while comparing DL PrimarySmtpAddress& EnabledPrimarySMTPAddressTemplate
- Modified readme file by change title O365 to Microsoft 365

**Validation:**
Provide if applicable
![image](https://user-images.githubusercontent.com/71065889/129482836-b7948800-c305-4671-8a24-099faf0a0a26.png)

