### PR TITLE
Make DisplayName check work in StrictMode

### DIFF
--- a/Shared/VisualCRedistributableVersionFunctions.ps1
+++ b/Shared/VisualCRedistributableVersionFunctions.ps1
@@ -21,7 +21,7 @@ Function Get-VisualCRedistributableInstalledVersion {
 
         foreach ($software in $installedSoftware) {
 
-            if ($software.DisplayName -like "Microsoft Visual C++ *") {
+            if ($software.PSObject.Properties.Name -contains "DisplayName" -and $software.DisplayName -like "Microsoft Visual C++ *") {
                 Write-Verbose "Microsoft Visual C++ Found: $($software.DisplayName)"
                 $softwareList.Add([PSCustomObject]@{
                         DisplayName       = $software.DisplayName


### PR DESCRIPTION
This fix allows SetupAssist to run when Set-StrictMode is not off.