### PR TITLE
Add Verbose output to track down rule error

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -119,7 +119,7 @@ foreach ($file in $scriptFiles) {
         $filesFailed = $true
     }
 
-    $analyzerResults = Invoke-ScriptAnalyzer -Path $file -Settings $repoRoot\PSScriptAnalyzerSettings.psd1
+    $analyzerResults = Invoke-ScriptAnalyzer -Path $file -Settings $repoRoot\PSScriptAnalyzerSettings.psd1 -Verbose
     if ($null -ne $analyzerResults) {
         $filesFailed = $true
         $analyzerResults | Format-Table -AutoSize


### PR DESCRIPTION
We are getting intermittent build failures with a NullReferenceException from Invoke-ScriptAnalyzer. It's a different script file each time, but the exception is the same. It works if we rerun the pipeline.

```
========================== Starting Command Output ===========================
"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'D:\a\_temp\c740e368-6763-42fc-97cc-9b91696b7c82.ps1'"
Invoke-ScriptAnalyzer : Object reference not set to an instance of an object.
At D:\a\1\s\.build\CodeFormatter.ps1:122 char:24
+ … erResults = Invoke-ScriptAnalyzer -Path $file -Settings $repoRoot\PSS …
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidOperation: (D:\a\1\s\PublicFold…SideValidations.ps1:String) [Invoke-ScriptAnalyzer], NullReferenceException
+ FullyQualifiedErrorId : RULE_ERROR,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand
##[error]PowerShell exited with code '1'.
Finishing: Code Formatting Script
```

RULE_ERROR indicates the exception is being caught here: https://github.com/PowerShell/PSScriptAnalyzer/blob/d1942a14083dd191e5d409ea289ade1ed554deaf/Engine/ScriptAnalyzer.cs#L2147

This change adds the -Verbose switch so we can try to determine which rule is doing this.