### PR TITLE
Change Out-Columns API

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -1633,11 +1633,11 @@ Function Invoke-AnalyzerEngine {
             )
         }
 
-        $sbStarted = { param($v) if ($v -eq "Started") { "Green" } else { "Red" } }
-        $sbRestart = { param($v) if ($v) { "Red" } else { "Green" } }
+        $sbStarted = { param($o, $p) if ($p -eq "State") { if ($o."$p" -eq "Started") { "Green" } else { "Red" } } }
+        $sbRestart = { param($o, $p) if ($p -eq "RestartConditionSet") { if ($o."$p") { "Red" } else { "Green" } } }
         $analyzedResults = Add-AnalyzedResultInformation -OutColumns ([PSCustomObject]@{
                 DisplayObject      = $outputObjectDisplayValue
-                ColorizerFunctions = @($null, $sbStarted, $null, $sbRestart)
+                ColorizerFunctions = @($sbStarted, $sbRestart)
                 IndentSpaces       = 8
             }) `
             -DisplayGroupingKey $keyWebApps `
@@ -1668,13 +1668,24 @@ Function Invoke-AnalyzerEngine {
                         }))
             }
 
-            $sbZero = { param($v) if ($v -eq "0") { "Green" } else { "Red" } }
-            $sbTime = { param($v) if ($v -eq "00:00:00") { "Green" } else { "Red" } }
-            $sbSchedule = { param($v) if ($v -eq "null") { "Green" } else { "Red" } }
+            $sbColorizer = {
+                param($o, $p)
+                switch ($p) {
+                    { $_ -in "PrivateMemory", "Memory", "Requests" } {
+                        if ($o."$p" -eq "0") { "Green" } else { "Red" }
+                    }
+                    "Time" {
+                        if ($o."$p" -eq "00:00:00") { "Green" } else { "Red" }
+                    }
+                    "Schedule" {
+                        if ($o."$p" -eq "null") { "Green" } else { "Red" }
+                    }
+                }
+            }
 
             $analyzedResults = Add-AnalyzedResultInformation -OutColumns ([PSCustomObject]@{
                     DisplayObject      = $outputObjectDisplayValue
-                    ColorizerFunctions = @($null, $sbZero, $sbZero, $sbZero, $sbSchedule, $sbTime)
+                    ColorizerFunctions = @($sbColorizer)
                     IndentSpaces       = 8
                 }) `
                 -DisplayGroupingKey $keyWebApps `

--- a/Shared/Out-Columns.ps1
+++ b/Shared/Out-Columns.ps1
@@ -3,7 +3,7 @@
 
 <#
 .SYNOPSIS
-    Outputs a table of objects with certain values colorized
+    Outputs a table of objects with certain values colorized.
 .EXAMPLE
     PS C:\> <example usage>
     Explanation of what the example does
@@ -111,12 +111,14 @@ function Out-Columns {
                 for ($i = 0; $i -lt $props.Count; $i++) {
                     $val = $o."$($props[$i])"
                     $fgColor = $defaultFgColor
-                    if ($i -lt $ColorizerFunctions.Length -and $null -ne $ColorizerFunctions[$i]) {
-                        $result = $ColorizerFunctions[$i].Invoke($val)
+                    foreach ($func in $ColorizerFunctions) {
+                        $result = $func.Invoke($o, $props[$i])
                         if (-not [string]::IsNullOrEmpty($result)) {
                             $fgColor = $result
+                            break # The first colorizer that takes action wins
                         }
                     }
+
                     Write-Host ("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $o."$($props[$i])") -NoNewline -ForegroundColor $fgColor
                     [void]$stb.Append("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $o."$($props[$i])")
                 }


### PR DESCRIPTION
This changes the Out-Columns API. The previous design has the following drawbacks:

* Colorizer functions must be passed in the same position as the property you're trying to affect. This is awkward for the caller. If you don't want to touch the first column, you have to pass $null in position 0 so you can pass a function in position 1.
* If you change the properties sent to output, or the order of the existing properties changes, the colorizer functions have to be rearranged.
* The colorizer function has no context beyond the value. This prevents us from, say, highlighting the name of a server when a configuration value on the server is bad. All we can do is highlight the bad value itself.

The approach in this PR changes it so the colorizer functions get passed the object and the property name we're about to display, instead of just the value. That is, a colorizer now looks like this:

```
{
  param($obj, $propName)
  # Do things and return a color
}
```

While this makes the colorizer functions a little more verbose, it also provides the ability to do things like the server name scenario above:

```
{
  param($obj, $propName)
  # Is the config value of interest bad?
  if ($obj.SomeProperty -eq "Bad") {
    # Are we about to display the bad value or the server name?
    if ($propName -eq "SomeProperty" -or $propName -eq "ServerName") {
      "Red"
    }
  }
}
```
![image](https://user-images.githubusercontent.com/4518572/130342823-b9ffc752-dc16-4f34-9163-d2b8f89ff0ec.png)

With this approach, both the value and the server name become Red, and all other properties are displayed in the normal color.

This also provides the ability to have a single colorizer function for multiple columns.

```
{
  param($obj, $propName)
  switch ($propName) {
    {$_ -in "FirstName", "LastName"} {
      "Blue"
    }
    "PhoneNumber" {
      "Green"
    }
  }
}
```

You can still pass an array of functions, but they need not be in any particular order. All colorizer functions are called for every value. As soon as one returns a color, we use that and move on to the next value.