### PR TITLE
Out-Columns multiline support

### DIFF
--- a/Shared/Out-Columns.ps1
+++ b/Shared/Out-Columns.ps1
@@ -39,6 +39,60 @@ function Out-Columns {
     )
 
     begin {
+        function GetLineObjects {
+            param($obj, $props)
+            $linesNeededForThisObject = 1
+            $multiLineProps = @{}
+            foreach ($p in $props) {
+                $val = $obj."$p"
+                if ($val -is [array]) {
+                    $multiLineProps[$p] = $val
+                    if ($val.Length -gt $linesNeededForThisObject) {
+                        $linesNeededForThisObject = $val.Length
+                    }
+                }
+            }
+
+            if ($linesNeededForThisObject -eq 1) {
+                $obj
+            } else {
+                for ($i = 0; $i -lt $linesNeededForThisObject; $i++) {
+                    $lineProps = @{}
+                    foreach ($p in $props) {
+                        if ($null -ne $multiLineProps[$p] -and $multiLineProps[$p].Length -gt $i) {
+                            $lineProps[$p] = $multiLineProps[$p][$i]
+                        } elseif ($i -eq 0) {
+                            $lineProps[$p] = $o."$p"
+                        } else {
+                            $lineProps[$p] = $null
+                        }
+                    }
+
+                    [PSCustomObject]$lineProps
+                }
+            }
+        }
+
+        function GetColumnColors {
+            param($obj, $props, $funcs)
+
+            $colColors = New-Object string[] $props.Count
+            for ($i = 0; $i -lt $props.Count; $i++) {
+                $fgColor = (Get-Host).ui.rawui.ForegroundColor
+                foreach ($func in $funcs) {
+                    $result = $func.Invoke($o, $props[$i])
+                    if (-not [string]::IsNullOrEmpty($result)) {
+                        $fgColor = $result
+                        break # The first colorizer that takes action wins
+                    }
+                }
+
+                $colColors[$i] = $fgColor
+            }
+
+            $colColors
+        }
+
         $objects = New-Object System.Collections.ArrayList
         $padding = 2
         $stb = New-Object System.Text.StringBuilder
@@ -70,7 +124,12 @@ function Out-Columns {
                 for ($i = 0; $i -lt $props.Count; $i++) {
                     $val = $thing."$($props[$i])"
                     if ($null -ne $val) {
-                        $width = $thing."$($props[$i])".ToString().Length
+                        $width = 0
+                        if ($val -is [array]) {
+                            $width = ($val | ForEach-Object { $_.ToString() } | Sort-Object Length -Descending | Select-Object -First 1).Length
+                        } else {
+                            $width = $thing."$($props[$i])".ToString().Length
+                        }
                         if ($width -gt $colWidths[$i]) {
                             $colWidths[$i] = $width
                         }
@@ -103,28 +162,21 @@ function Out-Columns {
             Write-Host
             [void]$stb.Append([System.Environment]::NewLine)
 
-            $defaultFgColor = (Get-Host).ui.rawui.ForegroundColor
-
             foreach ($o in $objects) {
-                Write-Host (" " * $IndentSpaces) -NoNewline
-                [void]$stb.Append(" " * $IndentSpaces)
-                for ($i = 0; $i -lt $props.Count; $i++) {
-                    $val = $o."$($props[$i])"
-                    $fgColor = $defaultFgColor
-                    foreach ($func in $ColorizerFunctions) {
-                        $result = $func.Invoke($o, $props[$i])
-                        if (-not [string]::IsNullOrEmpty($result)) {
-                            $fgColor = $result
-                            break # The first colorizer that takes action wins
-                        }
+                $colColors = GetColumnColors -obj $o -props $props -funcs $ColorizerFunctions
+                $lineObjects = @(GetLineObjects -obj $o -props $props)
+                foreach ($lineObj in $lineObjects) {
+                    Write-Host (" " * $IndentSpaces) -NoNewline
+                    [void]$stb.Append(" " * $IndentSpaces)
+                    for ($i = 0; $i -lt $props.Count; $i++) {
+                        $val = $o."$($props[$i])"
+                        Write-Host ("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $lineObj."$($props[$i])") -NoNewline -ForegroundColor $colColors[$i]
+                        [void]$stb.Append("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $lineObj."$($props[$i])")
                     }
 
-                    Write-Host ("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $o."$($props[$i])") -NoNewline -ForegroundColor $fgColor
-                    [void]$stb.Append("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $o."$($props[$i])")
+                    Write-Host
+                    [void]$stb.Append([System.Environment]::NewLine)
                 }
-
-                Write-Host
-                [void]$stb.Append([System.Environment]::NewLine)
             }
 
             Write-Host


### PR DESCRIPTION
Any array property now produces multiline output. This is mostly intended for large amounts of text, but may be useful in other scenarios as well. Example:

```
$tailSpinToys = [PSCustomObject]@{ Company = "TailSpinToys"; Description = "Short description"; Ids = 12432, 8223 }
$longText = @(
  "Lorem ipsum dolor sit amet,",
  "consectetur adipiscing elit. Ut sodales",
  "ligula dui, dictum pharetra mauris hendrerit",
  "vel. Vivamus odio velit, tempus eget",
  "sit amet, fermentum laoreet.")
$contoso = [PSCustomObject]@{ Company = "Contoso"; Description = $longText; Ids = 3458 }
$aDatum = [PSCustomObject]@{ Company = "A. Datum Corp"; Description = "Another short description"; Ids = 1923823 }
$companies = $tailSpinToys, $contoso, $aDatum
$companies | Out-Columns -ColorizerFunctions @({ param($o, $p) if ($o."$p" -like "*ipsum*") { "Red" } })
```

Result:

![image](https://user-images.githubusercontent.com/4518572/130453519-d9521fdd-f828-4dc6-8e1b-c858c81cbb74.png)
