### PR TITLE
Aka.ms shortlink for Download Domains feature added

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -2169,7 +2169,7 @@ Function Invoke-AnalyzerEngine {
             $downloadDomainsExtWriteType -eq "Red" -or
             $downloadDomainsIntWriteType -eq "Red") {
 
-            $analyzedResults = Add-AnalyzedResultInformation -Details "Configuration instructions: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1730" `
+            $analyzedResults = Add-AnalyzedResultInformation -Details "Configuration instructions: https://aka.ms/HC-DownloadDomains" `
                 -DisplayGroupingKey $keySecuritySettings `
                 -DisplayWriteType "Red" `
                 -DisplayCustomTabNumber 2 `


### PR DESCRIPTION
**Issue:**
Replaced `https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1730` with `https://aka.ms/HC-DownloadDomains`