### PR TITLE
Don't use switches internally

### DIFF
--- a/Performance/SimplePerf.ps1
+++ b/Performance/SimplePerf.ps1
@@ -89,11 +89,11 @@ begin {
             $OutputFolder,
 
             [Parameter(Mandatory = $true, Position = 4)]
-            [switch]
+            [bool]
             $IncludeThread,
 
             [Parameter(Mandatory = $true, Position = 5)]
-            [switch]
+            [bool]
             $Circular
         )
 


### PR DESCRIPTION
Passing a switch as a boolean results in wonky behavior. Should be using booleans internally. The script syntax itself can still use switches.