### PR TITLE
Prevent null-value exception in NIC WMI fallback scenario

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
@@ -234,8 +234,17 @@ Function Get-AllNicInformation {
 
                         $ipv6Enabled = ($adapterConfiguration.IPAddress | Where-Object { $_.Contains(":") }).Count -ge 1
 
-                        $ipv4Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(".") }
-                        $ipv6Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(":") }
+                        if ($null -ne $adapterConfiguration.DefaultIPGateway) {
+                            $ipv4Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(".") }
+                        } else {
+                            $ipv4Gateway = "No default IPv4 gateway set"
+                        }
+
+                        if ($null -ne $adapterConfiguration.DefaultIPGateway) {
+                            $ipv6Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(":") }
+                        } else {
+                            $ipv6Gateway = "No default IPv6 gateway set"
+                        }
 
                         for ($i = 0; $i -lt $adapterConfiguration.IPAddress.Count; $i++) {
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
@@ -236,13 +236,9 @@ Function Get-AllNicInformation {
 
                         if ($null -ne $adapterConfiguration.DefaultIPGateway) {
                             $ipv4Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(".") }
-                        } else {
-                            $ipv4Gateway = "No default IPv4 gateway set"
-                        }
-
-                        if ($null -ne $adapterConfiguration.DefaultIPGateway) {
                             $ipv6Gateway = $adapterConfiguration.DefaultIPGateway | Where-Object { $_.Contains(":") }
                         } else {
+                            $ipv4Gateway = "No default IPv4 gateway set"
                             $ipv6Gateway = "No default IPv6 gateway set"
                         }
 


### PR DESCRIPTION
**Issue:**
We end up in an exception: `"You cannot call a method on a null-valued expression."` if a fallback to WMI was performed and `$adapterConfiguration.DefaultIPGateway` is `$null` in `Get-NicInformation`. 

**Fix:**
Check if `$adapterConfiguration.DefaultIPGateway` is not `$null` before calling the `Where-Object` method.

**Validation:**
Lab/Customer