### PR TITLE
Feedback text added to the script output

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -307,6 +307,10 @@ try {
     if ($Script:Logger.PreventLogCleanup) {
         Write-Host("Output Debug file written to {0}" -f $Script:Logger.FullPath)
     }
+    if (((Get-Date).DayOfYear % 2) -eq 1) {
+        Write-Host("Do you like the script? Visit https://aka.ms/HC-Feedback to rate it and to provide feedback.") -ForegroundColor Green
+        Write-Host
+    }
     RevertProperForegroundColor
 }
 

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -307,7 +307,7 @@ try {
     if ($Script:Logger.PreventLogCleanup) {
         Write-Host("Output Debug file written to {0}" -f $Script:Logger.FullPath)
     }
-    if (((Get-Date).DayOfYear % 2) -eq 1) {
+    if (((Get-Date).Ticks % 2) -eq 1) {
         Write-Host("Do you like the script? Visit https://aka.ms/HC-Feedback to rate it and to provide feedback.") -ForegroundColor Green
         Write-Host
     }


### PR DESCRIPTION
We display a feedback text on odd days of the year. We call the `Get-Date` cmdlet to query the `DayOfYear`. We then use the modulus (mod) to calculate the remainder of this division operation. 

Example:
```
DateTime    : Monday, November 8, 2021 10:47:20 AM
Date        : 11/8/2021 12:00:00 AM
Day         : 8
DayOfWeek   : Monday
DayOfYear   : 312
```

312 mod 2 = 0 --> We don't show the feedback text
313 (tomorrow) mod 2 = 1 --> We show the feedback text

Edit: We now use `Ticks` instead of `DayOfYear` to add a little more randomness