### PR TITLE
Removed CVE-2021-42321 from E15

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -144,7 +144,7 @@ Function Invoke-AnalyzerSecurityCveCheck {
                 -CVENames "CVE-2021-26427"
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "1497.26" `
-                -CVENames "CVE-2021-42305", "CVE-2021-41349", "CVE-2021-42321"
+                -CVENames "CVE-2021-42305", "CVE-2021-41349"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {
 


### PR DESCRIPTION
Removed CVE-2021-42321 from E15 (E16/19 only)