### PR TITLE
Added the Security Checks description to GitHub pages documentation

### DIFF
--- a/docs/Diagnostics/HealthChecker/CertificateCheck.md
+++ b/docs/Diagnostics/HealthChecker/CertificateCheck.md
@@ -1,0 +1,37 @@
+---
+title: Certificate Check
+parent: HealthChecker.ps1
+grand_parent: Diagnostics
+---
+
+This check retrieves all certificates from the Exchange server by using the `Get-ExchangeCertificate` cmdlet. We display the following information:
+- FriendlyName
+- Thumbprint
+- Lifetime in days
+- Key size
+- Signature algorithm
+- Signature hash algorithm
+- Bound to services
+- Current Auth Certificate
+- SAN Certificate
+- Namespaces
+
+We also perform the following checks:
+
+- Certificate lifetime check:
+    - We show a green output, if the certificate is valid for 60 or more days.
+    - We show a yellow warning, if the certificate lifetime is between 30 and 59 days.
+    - We show a red warning if the lifetime is < 30 days.
+
+- Weak key size check:
+    - We show a red warning, if the key size is lower than 2048 bit.
+
+- Weak hash algorithm check:
+    - We show a yellow warning if the hash algorithm used to sign a certificate is weak.
+
+- Valid Auth certificate check:
+    - We check if the certificate which is set as current Auth certificate is available on the server.
+
+**Included in HTML Report?**
+
+Yes

--- a/docs/Diagnostics/HealthChecker/LMCompatibilityLevelInformationCheck.md
+++ b/docs/Diagnostics/HealthChecker/LMCompatibilityLevelInformationCheck.md
@@ -1,0 +1,15 @@
+---
+title: LM Compatibility Level Information Check
+parent: HealthChecker.ps1
+grand_parent: Diagnostics
+---
+
+LAN Manager authentication level setting determines which challenge/response authentication protocol is used for network logons. This choice affects the authentication protocol level that clients use, the session security level that the computers negotiate, and the authentication level that servers accept.
+
+**Included in HTML Report?**
+
+Yes
+
+**Additional resources:**
+
+https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level

--- a/docs/Diagnostics/HealthChecker/SMBv1Check.md
+++ b/docs/Diagnostics/HealthChecker/SMBv1Check.md
@@ -1,0 +1,19 @@
+---
+title: SMBv1 Check
+parent: HealthChecker.ps1
+grand_parent: Diagnostics
+---
+
+To make sure that your Exchange organization is better protected against the latest threats (for example Emotet, TrickBot or WannaCry to name a few) we recommend disabling SMBv1 if it’s enabled on your Exchange (2013/2016/2019) server.
+
+There is no need to run the nearly 30-year-old SMBv1 protocol when Exchange 2013/2016/2019 is installed on your system. SMBv1 isn’t safe and you lose key protections offered by later SMB protocol versions.
+
+This check verifies that SMBv1 is not installed (if OS allows) and that its activation is blocked.
+
+**Included in HTML Report?**
+
+Yes
+
+**Additional resources:**
+
+https://techcommunity.microsoft.com/t5/exchange-team-blog/exchange-server-and-smbv1/ba-p/1165615

--- a/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
+++ b/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
@@ -1,0 +1,23 @@
+---
+title: TLS Configuration Check
+parent: HealthChecker.ps1
+grand_parent: Diagnostics
+---
+
+We check and validate Exchange servers TLS 1.0 - 1.2 configuration. We can detect mismatches in TLS versions for client and server. This is important because Exchange can be both a client and a server.
+
+We also check for the SystemDefaultTlsVersions registry value which controls if .NET Framework will inherit its defaults from the Windows Schannel DisabledByDefault registry values or not.
+
+An invalid TLS configuration can cause issues within Exchange for communication.
+
+**Included in HTML Report?**
+
+Yes
+
+**Additional resources:**
+
+https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-part-1-Getting-Ready-for-TLS-1-2/ba-p/607649
+
+https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-Part-2-Enabling-TLS-1-2-and/ba-p/607761
+
+https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-Part-3-Turning-Off-TLS-1-0-1-1/ba-p/607898

--- a/docs/Diagnostics/HealthChecker/VulnerabilityCheck.md
+++ b/docs/Diagnostics/HealthChecker/VulnerabilityCheck.md
@@ -1,0 +1,18 @@
+---
+title: Vulnerability Check
+parent: HealthChecker.ps1
+grand_parent: Diagnostics
+---
+
+The script performs different checks to detect vulnerabilities which may lead into a security issue for the Exchange server.
+
+**Vulnerability checks performed:**
+
+- Check the Exchange server build number against known vulnerabilities that exists within a specific build
+- Check for `CVE-2020-0796` SMBv3 vulnerability
+- Check for `CVE-2020-1147` .NET Core & .NET Framework vulnerability
+- Check for `CVE-2021-1730` Download Domains state
+
+**Included in HTML Report?**
+
+Yes


### PR DESCRIPTION
Started to port the documentation for the different Health Checker checks to the GitHub pages documentation.
This PR contains the documentation of the checks listed under the security section of the script. It looks like we're (unfortunately) limited to 3 layers within the navigation (see: https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/#children-with-children). 

Work item: #547 