### PR TITLE
Improve Error Handling in SetupAssist

### DIFF
--- a/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
@@ -4,20 +4,27 @@
 . $PSScriptRoot\..\New-TestResult.ps1
 
 Function Test-ComputersContainerExists {
-    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
-    foreach ($domain in $forest.Domains) {
-        $domainDN = $domain.GetDirectoryEntry().distinguishedName
-        $computersPath = ("LDAP://CN=Computers," + $domainDN)
-        $params = @{
-            TestName = "Computers Container Exists"
-            Details  = $domainDN
-        }
+    try {
+        $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+        foreach ($domain in $forest.Domains) {
+            try {
+                $domainDN = $domain.GetDirectoryEntry().distinguishedName
+                $computersPath = ("LDAP://CN=Computers," + $domainDN)
+                $params = @{
+                    TestName = "Computers Container Exists"
+                    Details  = $domainDN
+                }
 
-        if (-not [System.DirectoryServices.DirectoryEntry]::Exists($computersPath)) {
-            New-TestResult @params -Result "Failed" -ReferenceInfo "https://aka.ms/SA-Computers"
-        } else {
-            New-TestResult @params -Result "Passed"
+                if (-not [System.DirectoryServices.DirectoryEntry]::Exists($computersPath)) {
+                    New-TestResult @params -Result "Failed" -ReferenceInfo "https://aka.ms/SA-Computers"
+                } else {
+                    New-TestResult @params -Result "Passed"
+                }
+            } catch {
+                Write-Warning "Failed to Test Computers Container Exists - DomainDN: $domainDN"
+            }
         }
+    } catch {
+        Write-Warning "Failed to run Test-ComputersContainerExists"
     }
 }
-

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -24,8 +24,9 @@ param(
 . $PSScriptRoot\Checks\LocalServer\Test-PendingReboot.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-PrerequisiteInstalled.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-VirtualDirectoryConfiguration.ps1
-. $PSScriptRoot\..\..\Shared\Out-Columns.ps1
-
+. $PSScriptRoot\..\..\Shared\LoggerFunctions.ps1
+. $PSScriptRoot\..\..\Shared\Write-Host.ps1
+. $PSScriptRoot\WriteFunctions.ps1
 
 Function WriteCatchInfo {
     Write-Host "$($Error[0].Exception)"
@@ -96,7 +97,7 @@ Function Main {
             }
             New-TestResult @params
         }
-    $quickResults | Out-Columns -Properties @("TestName", "Result", "Details") -ColorizerFunctions $sbResults
+    $quickResults | Write-OutColumns -Properties @("TestName", "Result", "Details") -ColorizerFunctions $sbResults
 
     Write-Host ""
     Write-Host "-----Results That Didn't Pass-----"
@@ -108,7 +109,7 @@ Function Main {
             Details       = $_.Group.Details
             ReferenceInfo = $_.Group.ReferenceInfo | Select-Object -Unique
         }
-    } | Out-Columns -IndentSpaces 5 -LinesBetweenObjects 2
+    } | Write-OutColumns -IndentSpaces 5 -LinesBetweenObjects 2
 }
 
 try {
@@ -117,12 +118,19 @@ try {
         return
     }
 
+    $Script:Logger = Get-NewLoggerInstance -LogName "SetupAssist-Debug" `
+        -AppendDateTimeToFileName $false `
+        -ErrorAction SilentlyContinue
+    SetWriteHostAction ${Function:Write-DebugLog}
+
     Main
 } catch {
     Write-Host "Failed in Main"
     WriteCatchInfo
 } finally {
     if ($Script:ErrorOccurred) {
-        Write-Warning ("Ran into an issue with the script. If possible please email 'ExToolsFeedback@microsoft.com' of the issue that you are facing")
+        Write-Warning ("Ran into an issue with the script. If possible please email 'ExToolsFeedback@microsoft.com' of the issue that you are facing including the SetupAssist-Debug.txt file.")
+    } elseif (-not ($PSBoundParameters["Verbose"])) {
+        $Script:Logger | Invoke-LoggerInstanceCleanup
     }
 }

--- a/Setup/SetupAssist/WriteFunctions.ps1
+++ b/Setup/SetupAssist/WriteFunctions.ps1
@@ -1,0 +1,79 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\..\Shared\Out-Columns.ps1
+Function Write-Verbose {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 1, ValueFromPipeline)]
+        [string]$Message
+    )
+
+    process {
+        Write-DebugLog $Message
+        Microsoft.PowerShell.Utility\Write-Verbose $Message
+    }
+}
+
+Function Write-Warning {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Waring')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 1, ValueFromPipeline)]
+        [string]$Message
+    )
+
+    process {
+        Write-DebugLog $Message
+        Microsoft.PowerShell.Utility\Write-Warning $Message
+    }
+}
+
+Function Write-DebugLog($Message) {
+    $Script:Logger = $Script:Logger | Write-LoggerInstance $Message
+}
+
+Function Write-OutColumns {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        [object[]]
+        $InputObject,
+
+        [Parameter(Mandatory = $false, Position = 0)]
+        [string[]]
+        $Properties,
+
+        [Parameter(Mandatory = $false, Position = 1)]
+        [scriptblock[]]
+        $ColorizerFunctions = @(),
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $IndentSpaces = 0,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $LinesBetweenObjects = 0
+    )
+    begin {
+        $objects = New-Object System.Collections.ArrayList
+    }
+    process {
+        foreach ($thing in $InputObject) {
+            [void]$objects.Add($thing)
+        }
+    }
+    end {
+        $stringOutput = [string]::Empty
+        SetWriteHostAction $null
+        $objects | Out-Columns -Properties $Properties `
+            -ColorizerFunctions $ColorizerFunctions `
+            -IndentSpaces $IndentSpaces `
+            -LinesBetweenObjects $LinesBetweenObjects `
+            -StringOutput ([ref]$stringOutput)
+        Write-DebugLog $stringOutput
+        SetWriteHostAction ${Function:Write-DebugLog}
+    }
+}

--- a/Shared/Write-Host.ps1
+++ b/Shared/Write-Host.ps1
@@ -37,6 +37,11 @@ Function Write-Host {
         }
 
         Microsoft.PowerShell.Utility\Write-Host @params
+
+        if ($null -ne $Script:WriteHostDebugAction -and
+            $null -ne $Object) {
+            &$Script:WriteHostDebugAction $Object
+        }
     }
 }
 
@@ -62,4 +67,8 @@ Function SetProperForegroundColor {
 
 Function RevertProperForegroundColor {
     $Host.UI.RawUI.ForegroundColor = $Script:OriginalConsoleForegroundColor
+}
+
+Function SetWriteHostAction ($DebugAction) {
+    $Script:WriteHostDebugAction = $DebugAction
 }


### PR DESCRIPTION
**Issue:**
If we have a single failure in a test that is caught by the `main` `try` `catch` block, it ends up stopping the script and failing to provide any results to the end user that could also assist with troubleshooting still.  


**Fix:**
Place each test within a `try` `catch` block loop that will allow the test to be handled and continue to the next test regardless if something made it to the pipeline. This allows the script to continue and display all the results as needed to the end user to still provide possible valuable information. 

Also included debug logging that writes everything to a log and it will be kept on the server if `-Verbose` is enabled or if we determine a `catch` has occurred that we need to handle and report. 
