### PR TITLE
Make Get-ExchangeEmergencyMitigationServiceState proxy aware

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeEmergencyMitigationServiceState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeEmergencyMitigationServiceState.ps1
@@ -41,8 +41,15 @@ Function Get-ExchangeEmergencyMitigationServiceState {
                 -CatchActionFunction $CatchActionFunction `
                 -ScriptBlock {
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
+                    if ($null -ne $args[0]) {
+                    Write-Verbose "Proxy Server detected. Going to use: $($args[0])"
+                    [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy($args[0])
+                    [System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+                    [System.Net.WebRequest]::DefaultWebProxy.BypassProxyOnLocal = $true
+                }; `
                     Invoke-WebRequest -Method Get -Uri "https://officeclient.microsoft.com/getexchangemitigations" -UseBasicParsing
-            }
+            } `
+                -ArgumentList $exchangeServerConfiguration.InternetWebProxy
         }
     }
     end {


### PR DESCRIPTION
**Issue:**
`Get-ExchangeEmergencyMitigationServiceState` did not yet honor a proxy server which was set via `Set-ExchangeServer <Computername> -InternetWebProxy`.

**Reason:**
EEMS makes use of the proxy server (to download mitigations) if it was set. We should honor this setting as well within this check.

**Fix:**

- Check if `InternetWebProxy` is not null
- Use the proxy server (if set) to do the `Invoke-WebRequest` call

**Validation:**
By affected cx