### PR TITLE
Setup Assist and Log Reviewer Updates

### DIFF
--- a/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
@@ -1,0 +1,27 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\New-TestResult.ps1
+Function Test-DomainMultiActiveSyncVirtualDirectories {
+    $params = @{
+        TestName = "Multiple Active Sync Vdirs Detected"
+    }
+    $rootDSE = [ADSI]("LDAP://RootDSE")
+    $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
+    $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
+    $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=msExchOrganizationContainer)", @("distinguishedName"))
+    $result = $searcher.FindOne()
+    $orgDN = $result.Properties["distinguishedName"]
+    $containerPath = [ADSI]("LDAP://CN=$env:ComputerName,CN=Servers,CN=Exchange administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,$orgDN")
+    $searcher = New-Object System.DirectoryServices.DirectorySearcher($containerPath, "(objectClass=msExchMobileVirtualDirectory)", @("distinguishedName"))
+    $result = $searcher.FindAll()
+    $fe = $result | Where-Object { $_.Properties["distinguishedName"] -notlike "*(Exchange Back End)*" }
+
+    if ($fe.Count -gt 1) {
+        $fe | ForEach-Object {
+            New-TestResult @params -Result "Failed" -Details $_.Properties["distinguishedName"] -ReferenceInfo ("Remove the secondary virtual directory that is custom on the server")
+        }
+    } else {
+        New-TestResult @params -Result "Passed"
+    }
+}

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -13,6 +13,7 @@ param(
 
 . $PSScriptRoot\Checks\Domain\Test-ComputersContainerExists.ps1
 . $PSScriptRoot\Checks\Domain\Test-DomainControllerDnsHostName.ps1
+. $PSScriptRoot\Checks\Domain\Test-DomainMultiActiveSyncVirtualDirectories.ps1
 . $PSScriptRoot\Checks\Domain\Test-ExchangeADSetupLevel.ps1
 . $PSScriptRoot\Checks\Domain\Test-OtherWellKnownObjects.ps1
 . $PSScriptRoot\Checks\Domain\Test-ReadOnlyDomainControllerLocation.ps1
@@ -40,6 +41,7 @@ Function RunAllTests {
         "Test-ExchangeServices",
         "Test-ComputersContainerExists",
         "Test-DomainControllerDnsHostName",
+        "Test-DomainMultiActiveSyncVirtualDirectories",
         "Test-MissingDirectory",
         "Test-MsiCacheFiles",
         "Test-PrerequisiteInstalled",

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-InstallFromBin.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-InstallFromBin.ps1
@@ -1,0 +1,30 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\New-ActionPlan.ps1
+. $PSScriptRoot\..\New-ErrorContext.ps1
+Function Test-InstallFromBin {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [object]
+        $ErrorContext
+    )
+    process {
+        $errorContext = $ErrorContext.ErrorContext
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+        $installFromBin = $errorContext | Select-String -Pattern "The term '.+\\V15\\Bin\\ManageScheduledTask.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again"
+
+        if ($null -ne $installFromBin) {
+            Write-Verbose "Found issue for install from bin by ManageScheduledTask"
+
+            $errorContext |
+                New-ErrorContext
+
+            New-ActionPlan @(
+                "- Run Setup again, but when using powershell.exe you MUST USE '.\' prior to setup.exe."
+            )
+        }
+    }
+}

--- a/Setup/SetupLogReviewer/Checks/ErrorReference/Test-MultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorReference/Test-MultiActiveSyncVirtualDirectories.ps1
@@ -1,0 +1,38 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\New-ActionPlan.ps1
+. $PSScriptRoot\..\New-ErrorContext.ps1
+Function Test-MultiActiveSyncVirtualDirectories {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [object]
+        $ErrorRefAndSetupLog
+    )
+    process {
+        $errorReference = $ErrorRefAndSetupLog.ErrorReference
+        $setupLogReviewer = $ErrorRefAndSetupLog.SetupLogReviewer
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+        if ($errorReference.Matches.Groups[1].Value -eq "CafeComponent___e1130a139a734d90b6c5eec88868fbe9") {
+            Write-Verbose "Known issue with Multiple Active Sync Virtual Directories"
+            $errorContext = $setupLogReviewer | GetFirstErrorWithContextToLine $errorReference.LineNumber 1
+            $multiVDirs = $errorContext | Select-String -Pattern "Cannot convert 'System.Object\[\]' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter'"
+
+            if ($null -ne $multiVDirs) {
+                Write-Verbose "Found Multiple Virtual Directories"
+                $errorContext |
+                    New-ErrorContext
+
+                New-ActionPlan @(
+                    "- Remove the secondary virtual directory that is custom on the server."
+                    "- NOTE: You should only return one value when running the following cmdlet on the server:"
+                    "        Get-ActiveSyncVirtualDirectory -Server `$env:ComputerName"
+                )
+            } else {
+                Write-Verbose "Failed to find typical presentation of the issue"
+            }
+        }
+    }
+}

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
@@ -4,6 +4,7 @@
 . $PSScriptRoot\..\ErrorContext\Test-DisabledService.ps1
 . $PSScriptRoot\..\ErrorContext\Test-EndpointMapper.ps1
 . $PSScriptRoot\..\ErrorContext\Test-FailedSearchFoundation.ps1
+. $PSScriptRoot\..\ErrorContext\Test-InstallFromBin.ps1
 . $PSScriptRoot\..\ErrorContext\Test-ExceptionADOperationFailedAlreadyExist.ps1
 . $PSScriptRoot\..\ErrorContext\Test-MissingDirectory.ps1
 . $PSScriptRoot\..\ErrorContext\Test-MissingHomeMdb.ps1
@@ -63,7 +64,8 @@ Function Test-KnownIssuesByErrors {
             "Test-MissingHomeMdb",
             "Test-MountDatabaseFailure",
             "Test-MSExchangeSecurityGroupsContainerDeleted",
-            "Test-VirtualDirectoryFailure"
+            "Test-VirtualDirectoryFailure",
+            "Test-InstallFromBin"
         )
 
         if ($Script:ReturnNow) {

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
@@ -13,6 +13,7 @@
 . $PSScriptRoot\..\ErrorContext\Test-VirtualDirectoryFailure.ps1
 . $PSScriptRoot\..\ErrorReference\Test-FipsUpgradeConfiguration.ps1
 . $PSScriptRoot\..\ErrorReference\Test-InitializePermissionsOfDomain.ps1
+. $PSScriptRoot\..\ErrorReference\Test-MultiActiveSyncVirtualDirectories.ps1
 Function Test-KnownIssuesByErrors {
     [CmdletBinding()]
     param(
@@ -77,7 +78,8 @@ Function Test-KnownIssuesByErrors {
                 SetupLogReviewer = $SetupLogReviewer
             }) -Tests @(
             "Test-InitializePermissionsOfDomain",
-            "Test-FipsUpgradeConfiguration"
+            "Test-FipsUpgradeConfiguration",
+            "Test-MultiActiveSyncVirtualDirectories"
         )
     }
 }

--- a/Setup/Shared/SetupLogReviewerLogic.ps1
+++ b/Setup/Shared/SetupLogReviewerLogic.ps1
@@ -54,8 +54,17 @@ Function Invoke-SetupLogReviewer {
     if (-not ([string]::IsNullOrEmpty($setupLogReviewer.LocalBuildNumber))) {
         Write-Host "Current Exchange Build: $($setupLogReviewer.LocalBuildNumber)"
 
-        if ($setupLogReviewer.LocalBuildNumber -eq $setupLogReviewer.SetupBuildNumber) {
-            Write-Host "Same build number detected..... if using powershell.exe to start setup. Make sure you do '.\setup.exe'" -ForegroundColor "Red"
+        try {
+            $localBuild = New-Object System.Version $setupLogReviewer.LocalBuildNumber -ErrorAction Stop
+            $setupBuild = New-Object System.Version $setupLogReviewer.SetupBuildNumber -ErrorAction Stop
+
+            if ($localBuild -eq $setupBuild -or
+                ($localBuild.Minor -eq $setupBuild.Minor -and
+                $localBuild.Build -eq $setupBuild.Build)) {
+                Write-Host "Same build number detected..... if using powershell.exe to start setup. Make sure you do '.\setup.exe'" -ForegroundColor "Red"
+            }
+        } catch {
+            Write-Verbose "Failed to convert to System.Version"
         }
     }
 

--- a/Setup/Tests/KnownIssues/ExchangeSetup_InstallFromBin.log
+++ b/Setup/Tests/KnownIssues/ExchangeSetup_InstallFromBin.log
@@ -1,0 +1,105 @@
+[12/17/2021 16:47:41.0778] [0] **********************************************
+[12/17/2021 16:47:41.0783] [0] Starting Microsoft Exchange Server 2016 Setup
+[12/17/2021 16:47:41.0783] [0] **********************************************
+[12/17/2021 16:47:41.0790] [0] Local time zone: (UTC-06:00) Central Time (US & Canada).
+[12/17/2021 16:47:41.0790] [0] Operating system version: Microsoft Windows NT 6.2.9200.0.
+[12/17/2021 16:47:41.0792] [0] Setup version: 15.1.2176.9.
+[12/17/2021 16:47:41.0793] [0] Logged on user: SOLO\Han.
+[12/17/2021 16:47:41.0826] [0] Command Line Parameter Name='mode', Value='Upgrade'.
+[12/17/2021 16:47:41.0826] [0] Command Line Parameter Name='iacceptexchangeserverlicenseterms', Value=''.
+[12/17/2021 16:47:41.0826] [0] Command Line Parameter Name='sourcedir', Value='D:\Program Files\Microsoft\Exchange Server\V15\bin'.
+[12/17/2021 16:47:42.0207] [0] RuntimeAssembly was started with the following command: '/mode:upgrade /IacceptExchangeServerLicenseTerms /sourcedir:D:\Program Files\Microsoft\Exchange Server\V15\bin'.
+[12/17/2021 16:47:42.0212] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Exchange\v8.0, wasn't found.
+[12/17/2021 16:47:42.0213] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v14, wasn't found.
+[12/17/2021 16:47:42.0224] [0] Assembly dll file location is D:\Program Files\Microsoft\Exchange Server\V15\bin\Microsoft.Exchange.Setup.Console.dll
+[12/17/2021 16:47:43.0882] [0] Setup is choosing the domain controller to use
+[12/17/2021 16:47:44.0085] [0] The MSExchangeADTopology has a persisted domain controller: DC1.Child.Solo.local
+[12/17/2021 16:47:45.0790] [0] PrepareAD has been run, and has replicated to this domain controller; so setup will use DC1.Child.Solo.local
+[12/17/2021 16:47:45.0790] [0] Setup is choosing a global catalog...
+[12/17/2021 16:47:45.0807] [0] Setup has chosen the global catalog server DC1.Child.Solo.local.
+[12/17/2021 16:47:45.0836] [0] Setup will use the domain controller 'DC1.Child.Solo.local'.
+[12/17/2021 16:47:45.0836] [0] Setup will use the global catalog 'DC1.Child.Solo.local'.
+[12/17/2021 16:47:45.0840] [0] Exchange configuration container for the organization is 'CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Child,DC=Solo,DC=local'.
+[12/17/2021 16:47:45.0846] [0] Exchange organization container for the organization is 'CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Child,DC=Solo,DC=local'.
+[12/17/2021 16:47:45.0873] [0] Setup will search for an Exchange Server object for the local machine with name 'ExSvr1'.
+[12/17/2021 16:47:46.0198] [0] Exchange Server object found : 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Child,DC=Solo,DC=local'.
+[12/17/2021 16:47:46.0309] [0] The following roles have been unpacked: BridgeheadRole ClientAccessRole MailboxRole UnifiedMessagingRole FrontendTransportRole AdminToolsRole CafeRole
+[12/17/2021 16:47:46.0310] [0] The following datacenter roles are unpacked:
+[12/17/2021 16:47:46.0311] [0] The following roles are installed: BridgeheadRole ClientAccessRole MailboxRole UnifiedMessagingRole FrontendTransportRole AdminToolsRole CafeRole
+[12/17/2021 16:47:46.0316] [0] The local server has some Exchange files installed.
+[12/17/2021 16:47:46.0334] [0] Server Name=ExSvr1
+[12/17/2021 16:47:46.0351] [0] Setup will use the path 'D:\Program Files\Microsoft\Exchange Server\V15\bin' for installing Exchange.
+[12/17/2021 16:47:46.0353] [0] Setup will discover the installed roles from server object 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Child,DC=Solo,DC=local'.
+[12/17/2021 16:47:46.0353] [0] 'BridgeheadRole' is installed on the server object.
+[12/17/2021 16:47:46.0354] [0] 'ClientAccessRole' is installed on the server object.
+[12/17/2021 16:47:46.0354] [0] 'MailboxRole' is installed on the server object.
+[12/17/2021 16:47:46.0354] [0] 'UnifiedMessagingRole' is installed on the server object.
+[12/17/2021 16:47:46.0354] [0] 'CafeRole' is installed on the server object.
+[12/17/2021 16:47:46.0354] [0] 'FrontendTransportRole' is installed on the server object.
+[12/17/2021 16:47:46.0359] [0] The installation mode is set to: 'BuildToBuildUpgrade'.
+[12/17/2021 16:47:46.0770] [0] An Exchange organization with name 'SoloORG' was found in this forest.
+[12/17/2021 16:47:46.0771] [0] Active Directory Initialization status : 'True'.
+[12/17/2021 16:47:46.0771] [0] Schema Update Required Status : 'False'.
+[12/17/2021 16:47:46.0772] [0] Organization Configuration Update Required Status : 'False'.
+[12/17/2021 16:47:46.0772] [0] Domain Configuration Update Required Status : 'False'.
+[12/17/2021 16:47:46.0773] [0] The locally installed version is 15.1.2176.2.
+[12/17/2021 16:47:46.0774] [0] Exchange Installation Directory : 'D:\Program Files\Microsoft\Exchange Server\V15'.
+[12/17/2021 16:47:46.0872] [0] Setup is determining what organization-level operations to perform.
+[12/17/2021 16:47:46.0873] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[12/17/2021 16:47:46.0899] [0] RootDataHandler has 1 DataHandlers
+[12/17/2021 16:47:46.0900] [0]      Languages
+[12/17/2021 16:47:46.0904] [0]      Management tools
+[12/17/2021 16:47:46.0907] [0]      Mailbox role: Transport service
+[12/17/2021 16:47:46.0909] [0]      Mailbox role: Client Access service
+[12/17/2021 16:47:46.0910] [0]      Mailbox role: Unified Messaging service
+[12/17/2021 16:47:46.0912] [0]      Mailbox role: Mailbox service
+[12/17/2021 16:47:46.0914] [0]      Mailbox role: Front End Transport service
+[12/17/2021 16:47:46.0917] [0]      Mailbox role: Client Access Front End service
+[12/17/2021 16:47:46.0932] [0] Validating options for the 7 requested roles
+[12/17/2021 16:47:46.0933] [0] UpgradeModeDataHandler has 17 handlers and 17 work units
+[12/17/2021 16:47:47.0044] [0] Performing Microsoft Exchange Server Prerequisite Check
+[12/17/2021 16:47:47.0844] [0] **************
+[12/17/2021 16:47:55.0464] [1] Evaluated [Setting:ComputerNameDnsFullyQualified] [HasException:False] [Value:"ExSvr1.Child.Solo.local"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0010002]
+[12/17/2021 16:48:24.0814] [2] Beginning processing Write-ExchangeSetupLog
+[12/17/2021 16:48:24.0817] [2] [ServiceControl.ps1] Disabling service 'MSExchangeEdgeSync'.
+[12/17/2021 16:51:06.0743] [2] Beginning processing Write-ExchangeSetupLog
+[12/17/2021 16:51:06.0744] [2] [ServiceControl.ps1] Killing instead of Stopping 'FMS'.
+[12/17/2021 16:51:06.0744] [2] Ending processing Write-ExchangeSetupLog
+[12/17/2021 16:51:06.0779] [2] Beginning processing Write-ExchangeSetupLog
+[12/17/2021 16:51:06.0780] [2] [ServiceControl.ps1] Script completed succesfully.
+[12/17/2021 16:51:06.0780] [2] Ending processing Write-ExchangeSetupLog
+[12/17/2021 16:51:06.0783] [1] The following 1 error(s) occurred during task execution:
+[12/17/2021 16:51:06.0784] [1] 0.  ErrorRecord: The term 'D:\Program Files\Microsoft\Exchange Server\V15\Bin\ManageScheduledTask.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+[12/17/2021 16:51:06.0784] [1] 0.  ErrorRecord: System.Management.Automation.CommandNotFoundException: The term 'D:\Program Files\Microsoft\Exchange Server\V15\Bin\ManageScheduledTask.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+   at System.Management.Automation.CommandDiscovery.LookupCommandInfo(String commandName, CommandTypes commandTypes, SearchResolutionOptions searchResolutionOptions, CommandOrigin commandOrigin, ExecutionContext context)
+   at System.Management.Automation.CommandDiscovery.LookupCommandProcessor(String commandName, CommandOrigin commandOrigin, Nullable`1 useLocalScope)
+   at System.Management.Automation.ExecutionContext.CreateCommand(String command, Boolean dotSource)
+   at System.Management.Automation.PipelineOps.AddCommand(PipelineProcessor pipe, CommandParameterInternal[] commandElements, CommandBaseAst commandBaseAst, CommandRedirection[] redirections, ExecutionContext context)
+   at System.Management.Automation.PipelineOps.InvokePipeline(Object input, Boolean ignoreInput, CommandParameterInternal[][] pipeElements, CommandBaseAst[] pipeElementAsts, CommandRedirection[][] commandRedirections, FunctionContext funcContext)
+   at System.Management.Automation.Interpreter.ActionCallInstruction`6.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
+[12/17/2021 16:51:06.0806] [1] [ERROR] The following error was generated when "$error.Clear();
+          & $RoleBinPath\ServiceControl.ps1 -Operation:DisableServices -Roles:($RoleRoles.Replace('Role','').Split(',')) -SetupScriptsDirectory:$RoleBinPath;
+          & $RoleBinPath\ServiceControl.ps1 -Operation:Stop -Roles:($RoleRoles.Replace('Role','').Split(',')) -IsDatacenter:([bool]$RoleIsDatacenter)
+        " was run: "System.Management.Automation.CommandNotFoundException: The term 'D:\Program Files\Microsoft\Exchange Server\V15\Bin\ManageScheduledTask.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+   at System.Management.Automation.CommandDiscovery.LookupCommandInfo(String commandName, CommandTypes commandTypes, SearchResolutionOptions searchResolutionOptions, CommandOrigin commandOrigin, ExecutionContext context)
+   at System.Management.Automation.CommandDiscovery.LookupCommandProcessor(String commandName, CommandOrigin commandOrigin, Nullable`1 useLocalScope)
+   at System.Management.Automation.ExecutionContext.CreateCommand(String command, Boolean dotSource)
+   at System.Management.Automation.PipelineOps.AddCommand(PipelineProcessor pipe, CommandParameterInternal[] commandElements, CommandBaseAst commandBaseAst, CommandRedirection[] redirections, ExecutionContext context)
+   at System.Management.Automation.PipelineOps.InvokePipeline(Object input, Boolean ignoreInput, CommandParameterInternal[][] pipeElements, CommandBaseAst[] pipeElementAsts, CommandRedirection[][] commandRedirections, FunctionContext funcContext)
+   at System.Management.Automation.Interpreter.ActionCallInstruction`6.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)".
+[12/17/2021 16:51:06.0806] [1] [ERROR] The term 'D:\Program Files\Microsoft\Exchange Server\V15\Bin\ManageScheduledTask.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+[12/17/2021 16:51:06.0807] [1] [ERROR-REFERENCE] Id=AllRolesPreFileCopyComponent___2f7e3804a2b340c69e930798211fb8fd Component=EXCHANGE14:\Current\Release\Shared\Datacenter\Setup
+[12/17/2021 16:51:06.0821] [1] Setup is stopping now because of one or more critical errors.
+[12/17/2021 16:51:06.0821] [1] Finished executing component tasks.
+[12/17/2021 16:51:06.0850] [1] Ending processing Start-PreFileCopy
+[12/17/2021 16:51:06.0853] [0] CurrentResult console.ProcessRunInternal:198: 1
+[12/17/2021 16:51:06.0861] [0] CurrentResult launcherbase.maincore:90: 1
+[12/17/2021 16:51:06.0867] [0] CurrentResult console.startmain:52: 1
+[12/17/2021 16:51:06.0867] [0] CurrentResult SetupLauncherHelper.loadassembly:452: 1
+[12/17/2021 16:51:06.0868] [0] The Exchange Server setup operation didn't complete.  More details can be found in ExchangeSetup.log located in the <SystemDrive>:\ExchangeSetupLogs folder.
+[12/17/2021 16:51:06.0870] [0] CurrentResult main.run:235: 1
+[12/17/2021 16:51:06.0870] [0] CurrentResult setupbase.maincore:396: 1
+[12/17/2021 16:51:06.0871] [0] End of Setup
+[12/17/2021 16:51:06.0871] [0] **********************************************

--- a/Setup/Tests/KnownIssues/ExchangeSetup_Multi_EAS_Vdirs.log
+++ b/Setup/Tests/KnownIssues/ExchangeSetup_Multi_EAS_Vdirs.log
@@ -1,0 +1,142 @@
+[12/09/2021 18:43:47.0953] [0] **********************************************
+[12/09/2021 18:43:47.0965] [0] Starting Microsoft Exchange Server 2019 Setup
+[12/09/2021 18:43:47.0965] [0] **********************************************
+[12/09/2021 18:43:47.0969] [0] Local time zone: (UTC-05:00) Eastern Time (US & Canada).
+[12/09/2021 18:43:47.0970] [0] Operating system version: Microsoft Windows NT 6.2.9200.0.
+[12/09/2021 18:43:47.0974] [0] Setup version: 15.2.986.5.
+[12/09/2021 18:43:47.0976] [0] Logged on user: SOLO\Han.
+[12/09/2021 18:43:48.0015] [0] Command Line Parameter Name='mode', Value='Upgrade'.
+[12/09/2021 18:43:48.0015] [0] Command Line Parameter Name='iacceptexchangeserverlicenseterms_diagnosticdataon', Value=''.
+[12/09/2021 18:43:48.0015] [0] Command Line Parameter Name='sourcedir', Value='D:\'.
+[12/09/2021 18:43:48.0230] [0] RuntimeAssembly was started with the following command: '/mode:upgrade /IAcceptExchangeServerLicenseTerms_DiagnosticDataON /sourcedir:D:"'.
+[12/09/2021 18:43:48.0238] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Exchange\v8.0, wasn't found.
+[12/09/2021 18:43:48.0238] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v14, wasn't found.
+[12/09/2021 18:43:48.0247] [0] Copying Files...
+[12/09/2021 18:43:48.0254] [0] Starting copy from D:\Setup\ServerRoles\Common to C:\Windows\Temp\ExchangeSetup.
+[12/09/2021 18:43:54.0187] [0] Finished copy from D:\Setup\ServerRoles\Common to C:\Windows\Temp\ExchangeSetup.
+[12/09/2021 18:43:54.0189] [0] File copy complete.  Setup will now collect additional information needed for installation.
+
+[12/09/2021 18:43:54.0197] [0] Assembly dll file location is C:\Windows\Temp\ExchangeSetup\Microsoft.Exchange.Setup.Console.dll
+[12/09/2021 18:43:58.0557] [0] Setup is choosing the domain controller to use
+[12/09/2021 18:43:58.0907] [0] The MSExchangeADTopology has a persisted domain controller: DC2.Solo.local
+[12/09/2021 18:44:03.0198] [0] PrepareAD has either not been run or has not replicated to the domain controller used by Setup. Setup will attempt to use the Schema Master domain controller DC2.Solo.local
+[12/09/2021 18:44:03.0202] [0] The schema master domain controller is available
+[12/09/2021 18:44:03.0203] [0] The schema master domain controller is in the local domain; setup will use DC2.Solo.local
+[12/09/2021 18:44:03.0214] [0] Setup is choosing a global catalog...
+[12/09/2021 18:44:03.0281] [0] Setup has chosen the global catalog server DC2.Solo.local.
+[12/09/2021 18:44:03.0293] [0] Setup will use the domain controller 'DC2.Solo.local'.
+[12/09/2021 18:44:03.0294] [0] Setup will use the global catalog 'DC2.Solo.local'.
+[12/09/2021 18:44:03.0298] [0] Exchange configuration container for the organization is 'CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/09/2021 18:44:03.0311] [0] Exchange organization container for the organization is 'CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/09/2021 18:44:03.0346] [0] Setup will search for an Exchange Server object for the local machine with name 'ExSvr1'.
+[12/09/2021 18:44:03.0684] [0] Exchange Server object found : 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/09/2021 18:44:03.0820] [0] The following roles have been unpacked: BridgeheadRole ClientAccessRole MailboxRole FrontendTransportRole AdminToolsRole CafeRole
+[12/09/2021 18:44:03.0824] [0] The following datacenter roles are unpacked:
+[12/09/2021 18:44:03.0831] [0] The following roles are installed: BridgeheadRole ClientAccessRole MailboxRole FrontendTransportRole AdminToolsRole CafeRole
+[12/09/2021 18:44:03.0837] [0] The local server has some Exchange files installed.
+[12/09/2021 18:44:03.0859] [0] Server Name=ExSvr1
+[12/09/2021 18:44:03.0859] [0] Setup will use the path 'D:\' for installing Exchange.
+[12/09/2021 18:44:03.0862] [0] Setup will discover the installed roles from server object 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/09/2021 18:44:03.0862] [0] 'BridgeheadRole' is installed on the server object.
+[12/09/2021 18:44:03.0862] [0] 'ClientAccessRole' is installed on the server object.
+[12/09/2021 18:44:03.0863] [0] 'MailboxRole' is installed on the server object.
+[12/09/2021 18:44:03.0863] [0] 'CafeRole' is installed on the server object.
+[12/09/2021 18:44:03.0863] [0] 'FrontendTransportRole' is installed on the server object.
+[12/09/2021 18:44:03.0872] [0] The installation mode is set to: 'BuildToBuildUpgrade'.
+[12/09/2021 18:44:10.0421] [0] An Exchange organization with name 'SoloORG' was found in this forest.
+[12/09/2021 18:44:10.0422] [0] Active Directory Initialization status : 'True'.
+[12/09/2021 18:44:10.0423] [0] Schema Update Required Status : 'False'.
+[12/09/2021 18:44:10.0423] [0] Organization Configuration Update Required Status : 'True'.
+[12/09/2021 18:44:10.0424] [0] Domain Configuration Update Required Status : 'True'.
+[12/09/2021 18:44:10.0427] [0] The locally installed version is 15.2.922.7.
+[12/09/2021 18:44:10.0428] [0] Exchange Installation Directory : 'C:\Program Files\Microsoft\Exchange Server\V15'.
+[12/09/2021 18:44:10.0507] [0] Setup is determining what organization-level operations to perform.
+[12/09/2021 18:44:10.0508] [0] Setup has detected a missing value. Setup is adding the value PrepareOrganization.
+[12/09/2021 18:44:10.0508] [0] Setup has detected a missing value. Setup is adding the value PrepareDomain.
+[12/09/2021 18:44:10.0509] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[12/09/2021 18:44:10.0567] [0] RootDataHandler has 1 DataHandlers
+[12/09/2021 18:44:10.0567] [0]      Languages
+[12/09/2021 18:44:10.0569] [0]      Management tools
+[12/09/2021 18:44:10.0570] [0]      Mailbox role: Transport service
+[12/09/2021 18:44:10.0571] [0]      Mailbox role: Client Access service
+[12/09/2021 18:44:10.0571] [0]      Mailbox role: Mailbox service
+[12/09/2021 18:44:10.0571] [0]      Mailbox role: Front End Transport service
+[12/09/2021 18:44:10.0572] [0]      Mailbox role: Client Access Front End service
+[12/09/2021 18:44:10.0590] [0] Validating options for the 6 requested roles
+[12/09/2021 18:44:10.0591] [0] UpgradeModeDataHandler has 17 handlers and 17 work units
+[12/09/2021 18:44:10.0656] [0] Performing Microsoft Exchange Server Prerequisite Check
+[12/09/2021 18:44:10.0702] [0] Setup is determining what organization-level operations to perform.
+[12/09/2021 18:44:10.0702] [0] Setup has detected a missing value. Setup is adding the value PrepareOrganization.
+[12/09/2021 18:44:10.0702] [0] Setup has detected a missing value. Setup is adding the value PrepareDomain.
+[12/09/2021 18:44:10.0702] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[12/09/2021 18:44:21.0227] [0] **************
+[12/09/2021 18:44:33.0888] [1] Evaluated [Setting:ComputerNameDnsFullyQualified] [HasException:False] [Value:"ExSvr1.Solo.local"] [ParentValue:"<NULL>"] [Thread:21] [Duration:00:00:00.0030010]
+          {
+              $a = &"$windir\system32\inetsrv\appcmd.exe" "set" "config" "/section:system.webServer/modules" "/.[name=`'$moduleName`'].lockItem:false"
+              Write-ExchangeSetupLog -Info ($a)
+          }
+[12/09/2021 19:22:58.0244] [2] Searching objects "ExSvr1" of type "Server" under the root "$null".
+[12/09/2021 19:22:58.0299] [2] Previous operation run on domain controller 'DC2.Solo.local'.
+[12/09/2021 19:22:59.0979] [2] Ending processing get-ActiveSyncVirtualDirectory
+[12/09/2021 19:22:59.0990] [1] The following 1 error(s) occurred during task execution:
+[12/09/2021 19:22:59.0990] [1] 0.  ErrorRecord: Cannot convert 'System.Object[]' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter' required by parameter 'Identity'. Specified method is not supported.
+[12/09/2021 19:22:59.0991] [1] 0.  ErrorRecord: System.Management.Automation.ParameterBindingException: Cannot convert 'System.Object[]' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter' required by parameter 'Identity'. Specified method is not supported. ---> System.NotSupportedException: Specified method is not supported.
+   at System.Management.Automation.ParameterBinderBase.CoerceTypeAsNeeded(CommandParameterInternal argument, String parameterName, Type toType, ParameterCollectionTypeInformation collectionTypeInfo, Object currentValue)
+   --- End of inner exception stack trace ---
+   at System.Management.Automation.CmdletParameterBinderController.VerifyArgumentsProcessed(ParameterBindingException originalBindingException)
+   at System.Management.Automation.CmdletParameterBinderController.BindCommandLineParametersNoValidation(Collection`1 arguments)
+   at System.Management.Automation.CmdletParameterBinderController.BindCommandLineParameters(Collection`1 arguments)
+   at System.Management.Automation.CommandProcessor.BindCommandLineParameters()
+   at System.Management.Automation.CommandProcessor.Prepare(IDictionary psDefaultParameterValues)
+   at System.Management.Automation.CommandProcessorBase.DoPrepare(IDictionary psDefaultParameterValues)
+   at System.Management.Automation.Internal.PipelineProcessor.Start(Boolean incomingStream)
+   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
+--- End of stack trace from previous location where exception was thrown ---
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
+   at System.Management.Automation.PipelineOps.InvokePipeline(Object input, Boolean ignoreInput, CommandParameterInternal[][] pipeElements, CommandBaseAst[] pipeElementAsts, CommandRedirection[][] commandRedirections, FunctionContext funcContext)
+   at System.Management.Automation.Interpreter.ActionCallInstruction`6.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
+[12/09/2021 19:22:59.0994] [1] [ERROR] The following error was generated when "$error.Clear();
+          $fe = get-ActiveSyncVirtualDirectory -server $RoleFqdnOrName -DomainController $RoleDomainController -ErrorAction SilentlyContinue;
+
+          if ($fe -eq $null)
+          {
+            new-ActiveSyncVirtualDirectory -DomainController $RoleDomainController -Role ClientAccess;
+          }
+          else
+          {
+            update-ActiveSyncVirtualDirectory $fe -DomainController $RoleDomainController -InstallIsapiFilter $true
+          }
+        " was run: "System.Management.Automation.ParameterBindingException: Cannot convert 'System.Object[]' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter' required by parameter 'Identity'. Specified method is not supported. ---> System.NotSupportedException: Specified method is not supported.
+   at System.Management.Automation.ParameterBinderBase.CoerceTypeAsNeeded(CommandParameterInternal argument, String parameterName, Type toType, ParameterCollectionTypeInformation collectionTypeInfo, Object currentValue)
+   --- End of inner exception stack trace ---
+   at System.Management.Automation.CmdletParameterBinderController.VerifyArgumentsProcessed(ParameterBindingException originalBindingException)
+   at System.Management.Automation.CmdletParameterBinderController.BindCommandLineParametersNoValidation(Collection`1 arguments)
+   at System.Management.Automation.CmdletParameterBinderController.BindCommandLineParameters(Collection`1 arguments)
+   at System.Management.Automation.CommandProcessor.BindCommandLineParameters()
+   at System.Management.Automation.CommandProcessor.Prepare(IDictionary psDefaultParameterValues)
+   at System.Management.Automation.CommandProcessorBase.DoPrepare(IDictionary psDefaultParameterValues)
+   at System.Management.Automation.Internal.PipelineProcessor.Start(Boolean incomingStream)
+   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
+--- End of stack trace from previous location where exception was thrown ---
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
+   at System.Management.Automation.PipelineOps.InvokePipeline(Object input, Boolean ignoreInput, CommandParameterInternal[][] pipeElements, CommandBaseAst[] pipeElementAsts, CommandRedirection[][] commandRedirections, FunctionContext funcContext)
+   at System.Management.Automation.Interpreter.ActionCallInstruction`6.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)".
+[12/09/2021 19:22:59.0994] [1] [ERROR] Cannot convert 'System.Object[]' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter' required by parameter 'Identity'. Specified method is not supported.
+[12/09/2021 19:22:59.0995] [1] [ERROR] Specified method is not supported.
+[12/09/2021 19:22:59.0995] [1] [ERROR-REFERENCE] Id=CafeComponent___e1130a139a734d90b6c5eec88868fbe9 Component=EXCHANGE14:\Current\Release\Shared\Datacenter\Setup
+[12/09/2021 19:22:59.0996] [1] Setup is stopping now because of one or more critical errors.
+[12/09/2021 19:22:59.0996] [1] Finished executing component tasks.
+[12/09/2021 19:23:00.0056] [1] Ending processing Install-CafeRole
+[12/09/2021 19:23:00.0071] [0] CurrentResult console.ProcessRunInternal:198: 1
+[12/09/2021 19:23:00.0072] [0] CurrentResult launcherbase.maincore:90: 1
+[12/09/2021 19:23:00.0072] [0] CurrentResult console.startmain:52: 1
+[12/09/2021 19:23:00.0073] [0] CurrentResult SetupLauncherHelper.loadassembly:452: 1
+[12/09/2021 19:23:00.0087] [0] The Exchange Server setup operation didn't complete.  More details can be found in ExchangeSetup.log located in the <SystemDrive>:\ExchangeSetupLogs folder.
+[12/09/2021 19:23:00.0088] [0] CurrentResult main.run:235: 1
+[12/09/2021 19:23:00.0088] [0] CurrentResult setupbase.maincore:396: 1
+[12/09/2021 19:23:00.0095] [0] End of Setup
+[12/09/2021 19:23:00.0095] [0] **********************************************

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -445,5 +445,13 @@ Describe "Testing SetupLogReviewer" {
             Assert-MockCalled -Exactly 1 -CommandName Write-Host `
                 -ParameterFilter { $Object -like "*Missing homeMdb on critical mailbox. Run SetupAssist.ps1 to find all problem mailboxes that needs to be addressed." }
         }
+
+        It "Install from bin" {
+            & $sr -SetupLog "$PSScriptRoot\KnownIssues\ExchangeSetup_InstallFromBin.log"
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*was run: `"System.Management.Automation.CommandNotFoundException: The term 'D:\Program Files\Microsoft\Exchange Server\V15\Bin\ManageScheduledTask.ps1'*" -and $ForegroundColor -eq "Yellow" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*Run Setup again, but when using powershell.exe you MUST USE '.\' prior to setup.exe." }
+        }
     }
 }

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -380,6 +380,18 @@ Describe "Testing SetupLogReviewer" {
             Assert-MockCalled -Exactly 1 -CommandName Write-Host `
                 -ParameterFilter { $Object -like "*Check access rights to this location OR use PROCMON to determine why this is occurring." }
         }
+
+        It "Multiple Active Sync Virtual Directories" {
+            & $sr -SetupLog "$PSScriptRoot\KnownIssues\ExchangeSetup_Multi_EAS_Vdirs.log"
+            Assert-MockCalled -Exactly 2 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*Cannot convert 'System.Object*' to the type 'Microsoft.Exchange.Configuration.Tasks.VirtualDirectoryIdParameter' required by parameter 'Identity'*" -and $ForegroundColor -eq "Yellow" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*Remove the secondary virtual directory that is custom on the server." }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*NOTE: You should only return one value when running the following cmdlet on the server:" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*Get-ActiveSyncVirtualDirectory -Server `$env:ComputerName" }
+        }
     }
 
     Context "Error Context" {


### PR DESCRIPTION
**Reason:**
Improved Setup Log Reviewer logic and added some additional tests. 

- Improved logic for handling the last run of setup
- Tests for Multiple Active Sync virtual directories in Log Reviewer and Setup Assist 
- Log reviewer to determine an older or the same CU is being run improvement 
- Determine that we are running powershell.exe without `.\` in front of setup.exe when we can't find `ManageScheduledTask.ps1` in `\v15\bin`

Resolved #159 
Resolved #716 
