### PR TITLE
Optionally enable antimalware scanning when done

### DIFF
--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -3,8 +3,10 @@
 
 #Requires -Version 3
 
-[CmdletBinding()]
-param ()
+[CmdLetBinding()]
+param(
+    [switch]$DontEnableAntiMalwareScanning
+)
 
 begin {
     #region Remoting Scriptblock
@@ -71,6 +73,20 @@ begin {
                 }
             } while ($null -ne $transfer)
         }
+
+        function EnableAntiMalwareScanning {
+            $installPath = Get-ExchangeInstallPath
+            if (-not $DontEnableAntiMalwareScanning -and $null -ne $installPath) {
+                $response = Read-Host "Would you like to enable malware scanning now? (Y/n)"
+                if ($response -eq "" -or $response -eq "y") {
+                    Write-Host "$($env:COMPUTERNAME) Enabling Anti Malware Agent..."
+                    $enableScanningScriptPath = Join-Path $installPath "Scripts\Enable-AntiMalwareScanning.ps1"
+                    & $enableScanningScriptPath
+                    Write-Host "$($env:COMPUTERNAME) Starting MSExchangeTransport service..."
+                    Restart-Service MSExchangeTransport
+                }
+            }
+        }
         #endregion Functions
 
         StopServicesAndProcesses
@@ -79,6 +95,7 @@ begin {
         StartServices
         StartEngineUpdate
         WaitForDownload
+        EnableAntiMalwareScanning
     }
     #endregion Remoting Scriptblock
 }

--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -77,7 +77,7 @@ begin {
         function EnableAntiMalwareScanning {
             $installPath = Get-ExchangeInstallPath
             if (-not $DontEnableAntiMalwareScanning -and $null -ne $installPath) {
-                $response = Read-Host "Would you like to enable malware scanning now? (Y/n)"
+                $response = Read-Host "$($env:COMPUTERNAME) Would you like to enable malware scanning now? (Y/n)"
                 if ($response -eq "" -or $response -eq "y") {
                     Write-Host "$($env:COMPUTERNAME) Enabling Anti Malware Agent..."
                     $enableScanningScriptPath = Join-Path $installPath "Scripts\Enable-AntiMalwareScanning.ps1"

--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -77,7 +77,7 @@ begin {
         function EnableAntiMalwareScanning {
             $installPath = Get-ExchangeInstallPath
             if (-not $DontEnableAntiMalwareScanning -and $null -ne $installPath) {
-                $response = Read-Host "$($env:COMPUTERNAME) Would you like to enable malware scanning now? (Y/n)"
+                $response = Read-Host "$($env:COMPUTERNAME) Would you like to enable antimalware scanning now? (Y/n)"
                 if ($response -eq "" -or $response -eq "y") {
                     Write-Host "$($env:COMPUTERNAME) Enabling Anti Malware Agent..."
                     $enableScanningScriptPath = Join-Path $installPath "Scripts\Enable-AntiMalwareScanning.ps1"


### PR DESCRIPTION
With this change, the script offers to enable malware scanning when it is complete. Note that we always prompt before enabling. This is so the user can verify the script actually succeeded before enabling.

The prompt can be disabled by passing -DontEnableAntiMalwareScanning.