### PR TITLE
Multiple fixes based on feedback

### DIFF
--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -17,7 +17,7 @@ begin {
         }
 
         function StopServicesAndProcesses {
-            Write-Host "$($env:COMPUTERNAME) Stopping services..."
+            Write-Host "$($env:COMPUTERNAME) Stopping MSExchangeTransport, FMS, and updateservice..."
             Stop-Service FMS -Force
             $updateservice = Get-Process updateservice -ErrorAction SilentlyContinue
             if ($null -ne $updateservice) {

--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -22,9 +22,15 @@ begin {
             $updateservice = Get-Process updateservice -ErrorAction SilentlyContinue
             if ($null -ne $updateservice) {
                 $updateservice | Stop-Process -Force
+                Start-Sleep -Seconds 2
+                $updateservice = Get-Process updateservice -ErrorAction SilentlyContinue
+                if ($null -ne $updateservice) {
+                    Write-Warning "$($env:COMPUTERNAME) Could not end process updateservice.exe. Please end this process and rerun the script."
+                    return $false
+                }
             }
 
-            Start-Sleep -Seconds 2
+            return $true
         }
 
         function RemoveMicrosoftFolder {
@@ -95,7 +101,11 @@ begin {
             return
         }
 
-        StopServicesAndProcesses
+        $succeeded = StopServicesAndProcesses
+        if (-not $succeeded) {
+            return
+        }
+
         RemoveMicrosoftFolder
         EmptyMetadataFolder
         StartServices

--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -23,6 +23,8 @@ begin {
             if ($null -ne $updateservice) {
                 $updateservice | Stop-Process -Force
             }
+
+            Start-Sleep -Seconds 2
         }
 
         function RemoveMicrosoftFolder {

--- a/Admin/Reset-ScanEngineVersion.ps1
+++ b/Admin/Reset-ScanEngineVersion.ps1
@@ -60,12 +60,14 @@ begin {
         }
 
         function WaitForDownload {
+            $percentComplete = 0
             do {
                 Start-Sleep -Seconds 1
                 $transfer = Get-BitsTransfer -AllUsers | Where-Object { $_.DisplayName -like "Forefront_FPS*" }
                 if ($null -ne $transfer) {
-                    $percentComplete = 0
-                    if ($transfer.BytesTotal.GetType() -eq [Int64] -and
+                    if ($null -ne $transfer.BytesTotal -and
+                        $null -ne $transfer.BytesTransferred -and
+                        $transfer.BytesTotal.GetType() -eq [Int64] -and
                         $transfer.BytesTransferred.GetType() -eq [Int64] -and
                         $transfer.BytesTotal -gt 0) {
                         $percentComplete = ($transfer.BytesTransferred * 100 / $transfer.BytesTotal)


### PR DESCRIPTION
This PR contains the following fixes:

* Check if server has an impacted version starting with 22 before running. Can override with -Force.
* Check if server has mailbox role, as it is not needed to run on Edge servers. Can override with -Force.
* Verify updateprocess.exe is actually killed before proceeding. If not, script asks user to kill process and rerun script.
* Say exactly what we're stopping instead of just "stopping services".
* Don't attempt to update progress if values are null.

Behavior with the new version (I faked the role issue as I don't have an Edge role):

![image](https://user-images.githubusercontent.com/4518572/147885975-1449b033-04ff-4aad-800c-88d359d792e7.png)

![image](https://user-images.githubusercontent.com/4518572/147886046-50a8c436-36a1-4987-b946-d119cfb486b3.png)
