### PR TITLE
Adding mkdocs.yml check to build pipeline

### DIFF
--- a/.build/Docs.ps1
+++ b/.build/Docs.ps1
@@ -1,0 +1,24 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$repoRoot = Get-Item "$PSScriptRoot\.."
+$docsDir = "$repoRoot\docs"
+$markDownFiles = Get-Content "$repoRoot\mkdocs.yml" |
+    Where-Object { $_ -like "*.md" } |
+    ForEach-Object {
+        if ($_.Contains(":")) {
+            $_.Split(":")[1].Trim()
+        } else {
+            $_.Replace("-", "").Trim()
+        }
+    }
+$allDocs = Get-ChildItem $docsDir -Recurse -File | Where-Object { $_.Extension -eq ".md" }
+Write-Host "Checking to make sure all the docs are in the mkdocs.yml file."
+
+foreach ($doc in $allDocs) {
+    if ($doc.FullName -ne "$docsDir\index.md" -and
+        -not($markDownFiles.Contains($doc.FullName.Split("\docs\")[1].Replace("\", "/")))) {
+        throw "Failed to have all docs in mkdocs.yml: $($doc.FullName)"
+    }
+}
+Write-Host "Success"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,11 @@ steps:
 
 - pwsh: |
     cd .\.build
+    .\docs.ps1
+  displayName: "Docs Check"
+
+- pwsh: |
+    cd .\.build
     .\CodeFormatter.ps1
   displayName: "Code Formatting Script"
 


### PR DESCRIPTION
**Issue:**
Forgetting to add a new doc to the `mkdocs.yml` file causes the new page to not show up. 

**Fix:**
Fail the build pipeline if file doesn't exist in the `mkdocs.yml` file 
