### PR TITLE
SetupAssist to check for a newer version

### DIFF
--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -27,6 +27,7 @@ param(
 . $PSScriptRoot\Checks\LocalServer\Test-VirtualDirectoryConfiguration.ps1
 . $PSScriptRoot\..\Shared\SetupLogReviewerLogic.ps1
 . $PSScriptRoot\..\..\Shared\LoggerFunctions.ps1
+. $PSScriptRoot\..\..\Shared\Test-ScriptVersion.ps1
 . $PSScriptRoot\..\..\Shared\Write-Host.ps1
 . $PSScriptRoot\WriteFunctions.ps1
 
@@ -135,6 +136,11 @@ try {
         -AppendDateTimeToFileName $false `
         -ErrorAction SilentlyContinue
     SetWriteHostAction ${Function:Write-DebugLog}
+
+    if ((Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/SA-VersionsUrl")) {
+        Write-Host "Script was updated. Please rerun the script."
+        return
+    }
 
     Main
 } catch {

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -31,6 +31,8 @@ param(
 . $PSScriptRoot\..\..\Shared\Write-Host.ps1
 . $PSScriptRoot\WriteFunctions.ps1
 
+$BuildVersion = ""
+
 Function WriteCatchInfo {
     Write-Host "$($Error[0].Exception)"
     Write-Host "$($Error[0].ScriptStackTrace)"
@@ -141,6 +143,8 @@ try {
         Write-Host "Script was updated. Please rerun the script."
         return
     }
+
+    Write-Host "Setup Assist Version $BuildVersion"
 
     Main
 } catch {

--- a/Setup/SetupLogReviewer/SetupLogReviewer.ps1
+++ b/Setup/SetupLogReviewer/SetupLogReviewer.ps1
@@ -16,7 +16,10 @@ param(
 
 . $PSScriptRoot\..\Shared\SetupLogReviewerLogic.ps1
 
+$BuildVersion = ""
+
 try {
+    Write-Host "Setup Log Reviewer Version: $BuildVersion"
     Invoke-SetupLogReviewer -SetupLog $SetupLog -DelegatedSetup:$DelegatedSetup
 } catch {
     "$($Error[0].Exception)" | Write-Output


### PR DESCRIPTION
**Reason:**
Due to some changes that occur within SetupAssist and SetupLogReviewer logic best to have SetupAssist check for newer updates. 

**Fix:**
Added `Test-ScriptVersion` to SetupAssist before running. 

Added `$BuildVersion` to be displayed when running the script. 


Resolved #851 