### PR TITLE
January 2022 Exchange security updates

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -145,6 +145,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "1497.26" `
                 -CVENames "CVE-2021-42305", "CVE-2021-41349"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "1497.28" `
+                -CVENames "CVE-2022-21845", "CVE-2022-21846"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {
 
@@ -272,6 +275,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "2308.20", "2375.17" `
                 -CVENames "CVE-2021-42305", "CVE-2021-41349", "CVE-2021-42321"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "2308.21", "2375.18" `
+                -CVENames "CVE-2022-21845", "CVE-2022-21846"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
 
@@ -372,6 +378,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "922.19", "986.14" `
                 -CVENames "CVE-2021-42305", "CVE-2021-41349", "CVE-2021-42321"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "922.20", "986.15" `
+                -CVENames "CVE-2022-21845", "CVE-2022-21846"
         }
     } else {
         Write-Verbose "Unknown Version of Exchange"

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -147,7 +147,7 @@ Function Invoke-AnalyzerSecurityCveCheck {
                 -CVENames "CVE-2021-42305", "CVE-2021-41349"
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "1497.28" `
-                -CVENames "CVE-2022-21845", "CVE-2022-21846"
+                -CVENames "CVE-2022-21845", "CVE-2022-21846", "CVE-2022-21969"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {
 
@@ -277,7 +277,7 @@ Function Invoke-AnalyzerSecurityCveCheck {
                 -CVENames "CVE-2021-42305", "CVE-2021-41349", "CVE-2021-42321"
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "2308.21", "2375.18" `
-                -CVENames "CVE-2022-21845", "CVE-2022-21846"
+                -CVENames "CVE-2022-21845", "CVE-2022-21846", "CVE-2022-21969"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
 
@@ -380,7 +380,7 @@ Function Invoke-AnalyzerSecurityCveCheck {
                 -CVENames "CVE-2021-42305", "CVE-2021-41349", "CVE-2021-42321"
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "922.20", "986.15" `
-                -CVENames "CVE-2022-21845", "CVE-2022-21846"
+                -CVENames "CVE-2022-21845", "CVE-2022-21846", "CVE-2022-21969"
         }
     } else {
         Write-Verbose "Unknown Version of Exchange"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             $downlaodDomains = GetObject "CVE-2021-1730"
             $downlaodDomains.DownloadDomainsEnabled | Should -Be "false"
 
-            $Script:ActiveGrouping.Count | Should -Be 8
+            $Script:ActiveGrouping.Count | Should -Be 10
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             $downlaodDomains = GetObject "CVE-2021-1730"
             $downlaodDomains.DownloadDomainsEnabled | Should -Be "false"
 
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
     }
 }


### PR DESCRIPTION
Security Updates added for:

- Exchange Server 2019 CU10 and CU11
- Exchange Server 2016 CU21 and CU22
- Exchange Server 2013 CU21