### PR TITLE
Include installed hotfixes in HTML report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -68,7 +68,7 @@ Function Invoke-AnalyzerExchangeInformation {
     }
 
     if ($null -ne $exchangeInformation.BuildInformation.KBsInstalled) {
-        $AnalyzeResults | Add-AnalyzedResultInformation -Name ("Exchange IU or Security Hotfix Detected.") `
+        $AnalyzeResults | Add-AnalyzedResultInformation -Name ("Exchange IU or Security Hotfix Detected") `
             -DisplayGroupingKey $keyExchangeInformation `
             -AddHtmlDetailRow $true
 

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -73,10 +73,11 @@ Function Invoke-AnalyzerExchangeInformation {
             -AddHtmlDetailRow $false
 
         foreach ($kb in $exchangeInformation.BuildInformation.KBsInstalled) {
-            $AnalyzeResults | Add-AnalyzedResultInformation -Details $kb `
+            $AnalyzeResults | Add-AnalyzedResultInformation -Name "Installed Hotfix" `
+                -Details $kb `
                 -DisplayGroupingKey $keyExchangeInformation `
                 -DisplayCustomTabNumber 2 `
-                -AddHtmlDetailRow $false
+                -AddHtmlDetailRow $true
         }
     }
 

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -68,13 +68,12 @@ Function Invoke-AnalyzerExchangeInformation {
     }
 
     if ($null -ne $exchangeInformation.BuildInformation.KBsInstalled) {
-        $AnalyzeResults | Add-AnalyzedResultInformation -Details ("Exchange IU or Security Hotfix Detected.") `
+        $AnalyzeResults | Add-AnalyzedResultInformation -Name ("Exchange IU or Security Hotfix Detected.") `
             -DisplayGroupingKey $keyExchangeInformation `
-            -AddHtmlDetailRow $false
+            -AddHtmlDetailRow $true
 
         foreach ($kb in $exchangeInformation.BuildInformation.KBsInstalled) {
-            $AnalyzeResults | Add-AnalyzedResultInformation -Name "Installed Hotfix" `
-                -Details $kb `
+            $AnalyzeResults | Add-AnalyzedResultInformation -Details $kb `
                 -DisplayGroupingKey $keyExchangeInformation `
                 -DisplayCustomTabNumber 2 `
                 -AddHtmlDetailRow $true


### PR DESCRIPTION
**Issue:**
Hotfix information is not included in HTML reports

**Reason:**
We use HTML reports to validate server health following updates, including hotfix information in the report makes it possible to validate that a hotfix has been successfully installed

**Fix:**
Include KBsInstalled in HTML Detail information, provide a name for the hotfix column
