### PR TITLE
Write down error when incorrect cores values are present

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -78,7 +78,9 @@ Function Invoke-AnalyzerHardwareInformation {
         $logicalValue -gt 48) {
         $displayWriteTypeLogic = "Red"
 
-        if ($logicalValue -ge $physicalValue) {
+        if (($physicalValue -gt 24 -and
+                $exchangeInformation.BuildInformation.MajorVersion -lt [HealthChecker.ExchangeMajorVersion]::Exchange2019) -or
+            $physicalValue -gt 48) {
             $physicalValueDisplay = "$physicalValue - Error"
             $displayWriteTypePhysical = "Red"
         }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -78,7 +78,7 @@ Function Invoke-AnalyzerHardwareInformation {
         $logicalValue -gt 48) {
         $displayWriteTypeLogic = "Red"
 
-        if ($logicalValue -gt $physicalValue) {
+        if ($logicalValue -ge $physicalValue) {
             $physicalValueDisplay = "$physicalValue - Error"
             $displayWriteTypePhysical = "Red"
         }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -69,21 +69,30 @@ Function Invoke-AnalyzerHardwareInformation {
 
     $physicalValue = $hardwareInformation.Processor.NumberOfPhysicalCores
     $logicalValue = $hardwareInformation.Processor.NumberOfLogicalCores
-    $displayWriteType = "Green"
+    $physicalValueDisplay = $physicalValue
+    $logicalValueDisplay = $logicalValue
+    $displayWriteTypeLogic = $displayWriteTypePhysical = "Green"
 
     if (($logicalValue -gt 24 -and
             $exchangeInformation.BuildInformation.MajorVersion -lt [HealthChecker.ExchangeMajorVersion]::Exchange2019) -or
         $logicalValue -gt 48) {
-        $displayWriteType = "Yellow"
+        $displayWriteTypeLogic = "Red"
+
+        if ($logicalValue -gt $physicalValue) {
+            $physicalValueDisplay = "$physicalValue - Error"
+            $displayWriteTypePhysical = "Red"
+        }
+
+        $logicalValueDisplay = "$logicalValue - Error"
     }
 
-    $AnalyzeResults | Add-AnalyzedResultInformation -Name "Number of Physical Cores" -Details $physicalValue `
+    $AnalyzeResults | Add-AnalyzedResultInformation -Name "Number of Physical Cores" -Details $physicalValueDisplay `
         -DisplayGroupingKey $keyHardwareInformation `
-        -DisplayWriteType $displayWriteType
+        -DisplayWriteType $displayWriteTypePhysical
 
-    $AnalyzeResults | Add-AnalyzedResultInformation -Name "Number of Logical Cores" -Details $logicalValue `
+    $AnalyzeResults | Add-AnalyzedResultInformation -Name "Number of Logical Cores" -Details $logicalValueDisplay `
         -DisplayGroupingKey $keyHardwareInformation `
-        -DisplayWriteType $displayWriteType `
+        -DisplayWriteType $displayWriteTypeLogic `
         -AddHtmlOverviewValues $true
 
     $displayValue = "Disabled"

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Hardware/HyperV_Win32_Processor1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Hardware/HyperV_Win32_Processor1.xml
@@ -1,0 +1,106 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.ManagementObject#root\cimv2\Win32_Processor</T>
+      <T>System.Management.ManagementObject#root\cimv2\CIM_Processor</T>
+      <T>System.Management.ManagementObject#root\cimv2\CIM_LogicalDevice</T>
+      <T>System.Management.ManagementObject#root\cimv2\CIM_LogicalElement</T>
+      <T>System.Management.ManagementObject#root\cimv2\CIM_ManagedSystemElement</T>
+      <T>System.Management.ManagementObject#Win32_Processor</T>
+      <T>System.Management.ManagementObject#CIM_Processor</T>
+      <T>System.Management.ManagementObject#CIM_LogicalDevice</T>
+      <T>System.Management.ManagementObject#CIM_LogicalElement</T>
+      <T>System.Management.ManagementObject#CIM_ManagedSystemElement</T>
+      <T>System.Management.ManagementObject</T>
+      <T>System.Management.ManagementBaseObject</T>
+      <T>System.ComponentModel.Component</T>
+      <T>System.MarshalByRefObject</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>\\SOLO-E16A\root\cimv2:Win32_Processor.DeviceID="CPU0"</ToString>
+    <Props>
+      <I32 N="__GENUS">2</I32>
+      <S N="__CLASS">Win32_Processor</S>
+      <S N="__SUPERCLASS">CIM_Processor</S>
+      <S N="__DYNASTY">CIM_ManagedSystemElement</S>
+      <S N="__RELPATH">Win32_Processor.DeviceID="CPU0"</S>
+      <I32 N="__PROPERTY_COUNT">57</I32>
+      <Obj N="__DERIVATION" RefId="1">
+        <TN RefId="1">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>CIM_Processor</S>
+          <S>CIM_LogicalDevice</S>
+          <S>CIM_LogicalElement</S>
+          <S>CIM_ManagedSystemElement</S>
+        </LST>
+      </Obj>
+      <S N="__SERVER">SOLO-E16A</S>
+      <S N="__NAMESPACE">root\cimv2</S>
+      <S N="__PATH">\\SOLO-E16A\root\cimv2:Win32_Processor.DeviceID="CPU0"</S>
+      <U16 N="AddressWidth">64</U16>
+      <U16 N="Architecture">9</U16>
+      <S N="AssetTag">None</S>
+      <U16 N="Availability">3</U16>
+      <S N="Caption">Intel64 Family 6 Model 45 Stepping 7</S>
+      <U32 N="Characteristics">4</U32>
+      <Nil N="ConfigManagerErrorCode" />
+      <Nil N="ConfigManagerUserConfig" />
+      <U16 N="CpuStatus">1</U16>
+      <S N="CreationClassName">Win32_Processor</S>
+      <U32 N="CurrentClockSpeed">2200</U32>
+      <U16 N="CurrentVoltage">10</U16>
+      <U16 N="DataWidth">64</U16>
+      <S N="Description">Intel64 Family 6 Model 45 Stepping 7</S>
+      <S N="DeviceID">CPU0</S>
+      <Nil N="ErrorCleared" />
+      <Nil N="ErrorDescription" />
+      <U32 N="ExtClock">100</U32>
+      <U16 N="Family">179</U16>
+      <Nil N="InstallDate" />
+      <Nil N="L2CacheSize" />
+      <Nil N="L2CacheSpeed" />
+      <U32 N="L3CacheSize">0</U32>
+      <U32 N="L3CacheSpeed">0</U32>
+      <Nil N="LastErrorCode" />
+      <U16 N="Level">6</U16>
+      <U16 N="LoadPercentage">1</U16>
+      <S N="Manufacturer">GenuineIntel</S>
+      <U32 N="MaxClockSpeed">2200</U32>
+      <S N="Name">Intel(R) Xeon(R) CPU E5-2430 0 @ 2.20GHz</S>
+      <U32 N="NumberOfCores">48</U32>
+      <U32 N="NumberOfEnabledCore">48</U32>
+      <U32 N="NumberOfLogicalProcessors">48</U32>
+      <Nil N="OtherFamilyDescription" />
+      <S N="PartNumber">None</S>
+      <Nil N="PNPDeviceID" />
+      <Nil N="PowerManagementCapabilities" />
+      <B N="PowerManagementSupported">false</B>
+      <S N="ProcessorId">0000000000000000</S>
+      <U16 N="ProcessorType">3</U16>
+      <U16 N="Revision">11527</U16>
+      <S N="Role">CPU</S>
+      <B N="SecondLevelAddressTranslationExtensions">false</B>
+      <S N="SerialNumber">None</S>
+      <S N="SocketDesignation">None</S>
+      <S N="Status">OK</S>
+      <U16 N="StatusInfo">3</U16>
+      <Nil N="Stepping" />
+      <S N="SystemCreationClassName">Win32_ComputerSystem</S>
+      <S N="SystemName">SOLO-E16A</S>
+      <U32 N="ThreadCount">1</U32>
+      <Nil N="UniqueId" />
+      <U16 N="UpgradeMethod">6</U16>
+      <S N="Version"></S>
+      <B N="VirtualizationFirmwareEnabled">false</B>
+      <B N="VMMonitorModeExtensions">false</B>
+      <Nil N="VoltageCaps" />
+    </Props>
+    <MS>
+      <S N="PSComputerName">SOLO-E16A</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -131,4 +131,21 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             $Script:ActiveGrouping.Count | Should -Be 11
         }
     }
+
+    Context "Testing Scenario 1 - Exchange 2016" {
+        BeforeAll {
+            Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Test EEMS pattern service connectivity" } -MockWith { return $null }
+            Mock Get-WmiObjectHandler -ParameterFilter { $Class -eq "Win32_Processor" } `
+                -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Hardware\HyperV_Win32_Processor1.xml" }
+            $hc = Get-HealthCheckerExchangeServer
+            $hc | Export-Clixml $PSScriptRoot\Debug_E16_Results.xml -Depth 6 -Encoding utf8
+            $Script:results = Invoke-AnalyzerEngine $hc
+        }
+
+        It "Display Results - Process/Hardware Information" {
+            SetActiveDisplayGrouping "Processor/Hardware Information"
+            TestObjectMatch "Number of Physical Cores" "48 - Error" -WriteType "Red"
+            TestObjectMatch "Number of Logical Cores" "48 - Error" -WriteType "Red"
+        }
+    }
 }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
@@ -386,11 +386,11 @@ Describe "Testing Health Checker by Mock Data Imports" {
         }
 
         It "Number of Physical Cores" {
-            TestObjectMatch "Number of Physical Cores" 48 -WriteType "Yellow"
+            TestObjectMatch "Number of Physical Cores" 48 -WriteType "Green"
         }
 
         It "Number of Logical Cores" {
-            TestObjectMatch "Number of Logical Cores" 96 -WriteType "Yellow"
+            TestObjectMatch "Number of Logical Cores" "96 - Error" -WriteType "Red"
         }
 
         It "Hyper-Threading" {


### PR DESCRIPTION
**Issue:**
In the text file, we didn't state if something was wrong on Exchange 2016 when on 48 cores. Looking over the code, we just color code it as `Yellow` and don't draw any attention to it. 

**Reason:**
On Exchange 2013 and 2016, if you have over 24 cores that is a problem. On Exchange 2019, if you have over 48 cores, that is also a problem that needs to be called out more clearly in the text files. 

**Fix:**
Appended ` - Error` when we are over the value per Exchange Server version and changed the display color to be `Red` instead as it is an error. 


Resolved #848 