### PR TITLE
Fix null-valued expression on nodeToRemove

### DIFF
--- a/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
@@ -130,7 +130,13 @@ function Test-VirtualDirectoryConfiguration {
 
                 $expectedIISObjectsPresent | ForEach-Object {
                     $nodeToRemove = $appHostConfig.SelectSingleNode("/configuration/system.applicationHost/sites/site[@name = '$siteName']/application[@path = '$_']")
-                    $nodeToRemove.ParentNode.RemoveChild($nodeToRemove) | Out-Null
+
+                    if ($null -ne $nodeToRemove -and
+                        $null -ne $nodeToRemove.ParentNode ) {
+                        $nodeToRemove.ParentNode.RemoveChild($nodeToRemove) | Out-Null
+                    } else {
+                        Write-Verbose "Failed to find the node to remove in the appHostConfig for site '$siteName' and path '$_'"
+                    }
 
                     if ($null -ne $adObject) {
                         New-TestResult @resultParams -Result "Warning" -Details "Only AD object is present for $($expectedVdir.DirectoryName)"

--- a/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
@@ -107,7 +107,7 @@ function Test-VirtualDirectoryConfiguration {
             foreach ($expectedPath in $expectedVdir.Paths) {
                 $iisObject = $iisSite.application | Where-Object { $_.Path -eq $expectedPath }
                 if ($null -ne $iisObject) {
-                    $expectedIISObjectsPresent += $expectedPath
+                    $expectedIISObjectsPresent += $iisObject.Path
                 } else {
                     $expectedIISObjectsMissing += $expectedPath
                 }

--- a/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
@@ -130,13 +130,7 @@ function Test-VirtualDirectoryConfiguration {
 
                 $expectedIISObjectsPresent | ForEach-Object {
                     $nodeToRemove = $appHostConfig.SelectSingleNode("/configuration/system.applicationHost/sites/site[@name = '$siteName']/application[@path = '$_']")
-
-                    if ($null -ne $nodeToRemove -and
-                        $null -ne $nodeToRemove.ParentNode ) {
-                        $nodeToRemove.ParentNode.RemoveChild($nodeToRemove) | Out-Null
-                    } else {
-                        Write-Verbose "Failed to find the node to remove in the appHostConfig for site '$siteName' and path '$_'"
-                    }
+                    $nodeToRemove.ParentNode.RemoveChild($nodeToRemove) | Out-Null
 
                     if ($null -ne $adObject) {
                         New-TestResult @resultParams -Result "Warning" -Details "Only AD object is present for $($expectedVdir.DirectoryName)"


### PR DESCRIPTION
**Issue:**
Failing in `Test-VirtualDirectoryConfiguration` with `System.Management.Automation.RuntimeException: You cannot call a method on a null-valued expression.`

Resolved #881 

**Fix:**
Do a null check on the `$nodeToRemove` prior to calling method `RemoveChild()`

**Validation:**
Customer verified that this worked