### PR TITLE
New Parameter of LogAge

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -53,7 +53,8 @@ Param (
     [switch]$WindowsSecurityLogs,
     [switch]$AcceptEULA,
     [switch]$AllPossibleLogs,
-    [bool]$CollectAllLogsBasedOnDaysWorth = $true,
+    [Alias("CollectAllLogsBasedOnDaysWorth")]
+    [bool]$CollectAllLogsBasedOnLogAge = $true,
     [switch]$ConnectivityLogs,
     [switch]$DatabaseFailoverIssue,
     [Parameter(ParameterSetName = "Worth")]

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Value is used')]
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName = "LogAge")]
 Param (
     [string]$FilePath = "C:\MS_Logs_Collection",
     [array]$Servers = @($env:COMPUTERNAME),
@@ -54,13 +54,17 @@ Param (
     [switch]$AcceptEULA,
     [switch]$AllPossibleLogs,
     [bool]$CollectAllLogsBasedOnDaysWorth = $true,
+    [switch]$ConnectivityLogs,
     [switch]$DatabaseFailoverIssue,
+    [Parameter(ParameterSetName = "Worth")]
     [int]$DaysWorth = 3,
+    [Parameter(ParameterSetName = "Worth")]
     [int]$HoursWorth = 0,
     [switch]$DisableConfigImport,
     [string]$ExmonLogmanName = "Exmon_Trace",
     [array]$ExperfwizLogmanName = @("Exchange_Perfwiz", "ExPerfwiz"),
-    [switch]$ConnectivityLogs,
+    [Parameter(ParameterSetName = "LogAge")]
+    [timespan]$LogAge = "3.00:00:00",
     [switch]$OutlookConnectivityIssues,
     [switch]$PerformanceIssues,
     [switch]$PerformanceMailflowIssues,
@@ -74,6 +78,8 @@ $BuildVersion = ""
 $Script:VerboseEnabled = $false
 
 if ($PSBoundParameters["Verbose"]) { $Script:VerboseEnabled = $true }
+
+if ($PSCmdlet.ParameterSetName -eq "Worth") { $Script:LogAge = New-TimeSpan -Days $DaysWorth -Hours $HoursWorth }
 
 . $PSScriptRoot\..\..\Shared\Confirm-Administrator.ps1
 . $PSScriptRoot\..\..\Shared\Confirm-ExchangeShell.ps1

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -57,7 +57,7 @@ Function Get-ArgumentList {
     $obj | Add-Member -Name DefaultTransportLogging -MemberType NoteProperty -Value $DefaultTransportLogging
     $obj | Add-Member -Name ServerInformation -MemberType NoteProperty -Value $ServerInformation
     $obj | Add-Member -Name CollectAllLogsBasedOnDaysWorth -MemberType NoteProperty -Value $CollectAllLogsBasedOnDaysWorth
-    $obj | Add-Member -Name TimeSpan -MemberType NoteProperty -Value (New-TimeSpan -Days $DaysWorth -Hours $HoursWorth)
+    $obj | Add-Member -Name TimeSpan -MemberType NoteProperty -Value $LogAge
     $obj | Add-Member -Name IISLogs -MemberType NoteProperty -Value $IISLogs
     $obj | Add-Member -Name AnyTransportSwitchesEnabled -MemberType NoteProperty -Value $script:AnyTransportSwitchesEnabled
     $obj | Add-Member -Name HostExeServerName -MemberType NoteProperty -Value ($env:COMPUTERNAME)

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -56,7 +56,7 @@ Function Get-ArgumentList {
     $obj | Add-Member -Name TransportConfig -MemberType NoteProperty -Value $TransportConfig
     $obj | Add-Member -Name DefaultTransportLogging -MemberType NoteProperty -Value $DefaultTransportLogging
     $obj | Add-Member -Name ServerInformation -MemberType NoteProperty -Value $ServerInformation
-    $obj | Add-Member -Name CollectAllLogsBasedOnDaysWorth -MemberType NoteProperty -Value $CollectAllLogsBasedOnDaysWorth
+    $obj | Add-Member -Name CollectAllLogsBasedOnLogAge -MemberType NoteProperty -Value $CollectAllLogsBasedOnLogAge
     $obj | Add-Member -Name TimeSpan -MemberType NoteProperty -Value $LogAge
     $obj | Add-Member -Name IISLogs -MemberType NoteProperty -Value $IISLogs
     $obj | Add-Member -Name AnyTransportSwitchesEnabled -MemberType NoteProperty -Value $script:AnyTransportSwitchesEnabled

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -45,7 +45,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\EWS"), ($Script:RootCopyToDirectory + "\EWS_BE_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += ("Copy-LogsBasedOnTime {0}" -f $info)
                 } else {
                     $cmdsToRun += ("Copy-FullLogFullPathRecurse {0}" -f $info)
@@ -55,7 +55,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Ews"), ($Script:RootCopyToDirectory + "\EWS_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += ("Copy-LogsBasedOnTime {0}" -f $info)
                 } else {
                     $cmdsToRun += ("Copy-FullLogFullPathRecurse {0}" -f $info)
@@ -68,7 +68,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\RPC Client Access"), ($Script:RootCopyToDirectory + "\RCA_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -78,7 +78,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\RpcHttp"), ($Script:RootCopyToDirectory + "\RCA_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -88,7 +88,7 @@ Function Invoke-RemoteMain {
             if (-not($Script:localServerObject.Edge)) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\RpcHttp"), ($Script:RootCopyToDirectory + "\RPC_Http_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -99,7 +99,7 @@ Function Invoke-RemoteMain {
         if ($Script:localServerObject.CAS -and $PassedInfo.EASLogs) {
             $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Eas"), ($Script:RootCopyToDirectory + "\EAS_Proxy_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -111,7 +111,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\Autodiscover"), ($Script:RootCopyToDirectory + "\AutoD_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -121,7 +121,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Autodiscover"), ($Script:RootCopyToDirectory + "\AutoD_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -134,7 +134,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\OWA"), ($Script:RootCopyToDirectory + "\OWA_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -144,7 +144,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\OwaCalendar"), ($Script:RootCopyToDirectory + "\OWA_Proxy_Calendar_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -152,7 +152,7 @@ Function Invoke-RemoteMain {
 
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Owa"), ($Script:RootCopyToDirectory + "\OWA_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -163,7 +163,7 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.ADDriverLogs) {
             $info = ($copyInfo -f ($Script:localExinstall + "Logging\ADDriver"), ($Script:RootCopyToDirectory + "\AD_Driver_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -175,7 +175,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox -and $Script:localServerObject.Version -eq 15) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\MAPI Client Access"), ($Script:RootCopyToDirectory + "\MAPI_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -183,7 +183,7 @@ Function Invoke-RemoteMain {
             } elseif ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\MapiHttp\Mailbox"), ($Script:RootCopyToDirectory + "\MAPI_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -193,7 +193,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Mapi"), ($Script:RootCopyToDirectory + "\MAPI_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -206,7 +206,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.Mailbox) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\ECP"), ($Script:RootCopyToDirectory + "\ECP_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -216,7 +216,7 @@ Function Invoke-RemoteMain {
             if ($Script:localServerObject.CAS) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\HttpProxy\Ecp"), ($Script:RootCopyToDirectory + "\ECP_Proxy_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -273,7 +273,7 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.OABLogs) {
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\HttpProxy\OAB"), ($Script:RootCopyToDirectory + "\OAB_Proxy_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -281,7 +281,7 @@ Function Invoke-RemoteMain {
 
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\OABGeneratorLog"), ($Script:RootCopyToDirectory + "\OAB_Generation_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -289,7 +289,7 @@ Function Invoke-RemoteMain {
 
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\OABGeneratorSimpleLog"), ($Script:RootCopyToDirectory + "\OAB_Generation_Simple_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -297,7 +297,7 @@ Function Invoke-RemoteMain {
 
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\MAPI AddressBook Service"), ($Script:RootCopyToDirectory + "\MAPI_AddressBook_Service_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -307,7 +307,7 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.PowerShellLogs) {
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\HttpProxy\PowerShell"), ($Script:RootCopyToDirectory + "\PowerShell_Proxy_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -322,7 +322,7 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.MitigationService) {
             $info = ($copyInfo -f ($Script:localExinstall + "\Logging\MitigationService"), ($Script:RootCopyToDirectory + "\Mitigation_Service_Logs"))
 
-            if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+            if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                 $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
             } else {
                 $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -342,7 +342,7 @@ Function Invoke-RemoteMain {
             if ($PassedInfo.RPCLogs) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\RPC Client Access"), ($Script:RootCopyToDirectory + "\RCA_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += "Copy-LogsBasedOnTime {0}" -f $info
                 } else {
                     $cmdsToRun += "Copy-FullLogFullPathRecurse {0}" -f $info
@@ -352,7 +352,7 @@ Function Invoke-RemoteMain {
             if ($PassedInfo.EWSLogs) {
                 $info = ($copyInfo -f ($Script:localExinstall + "Logging\EWS"), ($Script:RootCopyToDirectory + "\EWS_BE_Logs"))
 
-                if ($PassedInfo.CollectAllLogsBasedOnDaysWorth) {
+                if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
                     $cmdsToRun += ("Copy-LogsBasedOnTime {0}" -f $info)
                 } else {
                     $cmdsToRun += ("Copy-FullLogFullPathRecurse {0}" -f $info)

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -109,7 +109,7 @@ TransportConfig | Enable to collect the Transport Configuration files from the S
 WindowsSecurityLogs | Enable to collect the Windows Security Logs. Default Location: `'C:\Windows\System32\Winevt\Logs\Security.evtx'`
 AcceptEULA | Enable to accept the conditions of the script and not get prompted.
 AllPossibleLogs | Enables the collection of all default logging collection on the Server.
-CollectAllLogsBasedOnDaysWorth | Boolean to determine if you collect all the logs based off day's worth or all the logs in that directory. Default value `$true`
+CollectAllLogsBasedOnLogAge | Boolean to determine if you collect all the logs based off the log's age or all the logs in that directory. Default value `$true`
 ConnectivityLogs | Enables the following switches and their logs to be collected: `FrontEndConnectivityLogs`, `HubConnectivityLogs`, and `MailboxConnectivityLogs`
 DatabaseFailoverIssue | Enables the following switches and their logs to be collected. `DAGInformation`, `DailyPerformanceLogs`, `ExchangeServerInformation`, `Experfwiz`, `HighAvailabilityLogs`, `ManagedAvailabilityLogs`, and `ServerInformation`.
 DaysWorth | The number of days to go back to be included int the time span for log collection. Default value: 3

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -53,6 +53,12 @@ This cmdlet will collect all relevant data regarding IIS Logs (within the last 3
 .\ExchangeLogCollector.ps1 -Servers EXCH1,EXCH2 -IISLogs -RPCLogs
 ```
 
+This cmdlet will collect all relevant data regarding Message Tracking Logs and Protocol Logs for the past 3 hours from the servers EXCH1 and EXCH2 and store them at the default location of "C:\MS_Logs_Collection"
+
+```
+.\ExchangeLogCollector.ps1 -Servers EXCH1,EXCH2 -MessageTrackingLogs -ProtocolLogs -LogAge "03:00:00"
+```
+
 ## Parameters
 
 Parameter | Description |
@@ -61,7 +67,7 @@ FilePath | The Location of where you would like the data to be copied over to. T
 Servers | An array of servers that you would like to collect data from.
 ADDriverLogs | Enable to collect AD Driver Logs. Location: `V15\Logging\ADDriver`
 AppSysLogs | Collects the Windows Event Application, System, and MSExchange Management Logs. Default value `$true`
-AppSysLogsToXml | Collects the Windows Event Application and System and saves them out to XML. The date range only is from the time the script run and the value set on `DaysWorth` and `HoursWorth`. Default value: `$true`
+AppSysLogsToXml | Collects the Windows Event Application and System and saves them out to XML. The time range only is from the time the script run and the value set on `LogAge`. Default value: `$true`
 AutoDLogs | Enable to collect AutoDiscover Logs. Location: `V15\Logging\Autodiscover` and `V15\Logging\HttpProxy\Autodiscover`
 CollectFailoverMetrics | Enable to run the `CollectOverMetrics.ps1` script against the DAG. Only able to be run on an Exchange tools box or an Exchange Server.
 DAGInformation | Enable to collect the DAG Information from all different DAGs that are in the list of servers.
@@ -79,7 +85,7 @@ GetVdirs | Enable to collect the Virtual Directories of the environment.
 HighAvailabilityLogs | Enable to collect High Availability Logs. Windows Event Logs like: `Microsoft-Exchange-HighAvailability`, `Microsoft-Exchange-MailboxDatabaseFailureItems`, and `Microsoft-Windows-FailoverClustering`
 HubConnectivityLogs | Enable to collect the Hub connectivity logging. Location: `(Get-TransportService $server).ConnectivityLogPath`
 HubProtocolLogs | Enable to collect the protocol logging. Location: `(Get-TransportService $server).ReceiveProtocolLogPath` and `(Get-TransportService $server).SendProtocolLogPath`
-IISLogs | Enable to collect IIS Logs and HTTPErr Logs from the Exchange Server. Default Location: `C:\inetpub\logs\LogFiles\W3SVC1`, `C:\inetpub\logs\LogFiles\W3SVC1`, and `C:\Windows\System32\LogFiles\HTTPERR`. Only able to collect on DaysWorth and HoursWorth.
+IISLogs | Enable to collect IIS Logs and HTTPErr Logs from the Exchange Server. Default Location: `C:\inetpub\logs\LogFiles\W3SVC1`, `C:\inetpub\logs\LogFiles\W3SVC1`, and `C:\Windows\System32\LogFiles\HTTPERR`. Only able to collect on `LogAge`.
 ImapLogs | Enable to collect IMAP logging. Location: `(Get-ImapSettings -Server $server).LogFileLocation`
 MailboxConnectivityLogs | Enable to collect the connectivity logging on the mailbox server. Location: `(Get-MailboxTransportService $server).ConnectivityLogPath`
 MailboxDeliveryThrottlingLogs | Enable to collect the mailbox delivery throttling logs on the server. Location: `(Get-MailboxTransportService $server).MailboxDeliveryThrottlingLogPath`
@@ -104,13 +110,14 @@ WindowsSecurityLogs | Enable to collect the Windows Security Logs. Default Locat
 AcceptEULA | Enable to accept the conditions of the script and not get prompted.
 AllPossibleLogs | Enables the collection of all default logging collection on the Server.
 CollectAllLogsBasedOnDaysWorth | Boolean to determine if you collect all the logs based off day's worth or all the logs in that directory. Default value `$true`
+ConnectivityLogs | Enables the following switches and their logs to be collected: `FrontEndConnectivityLogs`, `HubConnectivityLogs`, and `MailboxConnectivityLogs`
 DatabaseFailoverIssue | Enables the following switches and their logs to be collected. `DAGInformation`, `DailyPerformanceLogs`, `ExchangeServerInformation`, `Experfwiz`, `HighAvailabilityLogs`, `ManagedAvailabilityLogs`, and `ServerInformation`.
 DaysWorth | The number of days to go back to be included int the time span for log collection. Default value: 3
 HoursWorth | The number of hours to go back to be included in the time span for the log collection. Default Value 0.
 DisableConfigImport | Enable to not import the `ExchangeLogCollector.ps1.json` file if it exists.
 ExmonLogmanName | A list of names that we want to collect for Exmon data. The default name is `Exmon_Trace`.
 ExperfwizLogmanName | A list of names that we want to collect performance data logs from. The default names are `Exchange_Perfwiz` and `ExPerfwiz`. (For both styles of Experfwiz)
-ConnectivityLogs | Enables the following switches and their logs to be collected: `FrontEndConnectivityLogs`, `HubConnectivityLogs`, and `MailboxConnectivityLogs`
+LogAge | A Time Span value to use instead of the DaysWorth and HoursWorth parameters. Default Value: 3.00:00:00
 OutlookConnectivityIssues | Enables the following switches and their logs to be collected: `AutoDLogs`, `DailyPerformanceLogs`, `EWSLogs`, `Experfwiz`, `IISLogs`, `MAPILogs`, `RPCLogs`, and `ServerInformation`
 PerformanceIssues | Enables the following switches and their logs to be collected: `DailyPerformanceLogs`, `Experfwiz`, and `ManagedAvailabilityLogs`
 PerformanceMailflowIssues | Enables the following switches and their logs to be collected: `DailyPerformanceLogs`, `Experfwiz`, `MessageTrackingLogs`, `QueueInformation`, and `TransportConfig`


### PR DESCRIPTION
**Reason:**
Added a new parameter of `LogAge` that uses `TimeSpan` as a better syntax for the script than using both `DaysWorth` and `HoursWorth` to set the time. 

Also changed `CollectAllLogsBasedOnDaysWorth` to `CollectAllLogsBasedOnLogAge` as `LogAge` is now the default. 