### PR TITLE
Remove non-digits before parsing size string

### DIFF
--- a/PublicFolders/SourceSideValidations/Get-Statistics.ps1
+++ b/PublicFolders/SourceSideValidations/Get-Statistics.ps1
@@ -46,7 +46,8 @@ function Get-Statistics {
 
                 [Int64]$totalItemSize = -1
                 if ($_.TotalItemSize.ToString() -match "\(([\d|,|.]+) bytes\)") {
-                    $totalItemSize = [Int64]::Parse($Matches[1], "AllowThousands")
+                    $numberString = $Matches[1] -replace "\D", ""
+                    $totalItemSize = [Int64]::Parse($numberString)
                 }
 
                 [PSCustomObject]@{


### PR DESCRIPTION
Exchange can represent folder sizes separated by commas even when
the locale says the CurrencyGroupSeparator is something other than
a comma. This makes AllowThousands fail to remove the group
separators.

Instead of relying on AllowThousands, we now remove all non-digits
before parsing the string.

Fixes #901 