### PR TITLE
Add SHA256 file hashes to release notes

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -128,16 +128,6 @@ $scriptFiles | ForEach-Object {
     }
 }
 
-# Generate version text for release description
-
-$versionFile = "$distFolder\ScriptVersions.txt"
-New-Item -Path $versionFile -ItemType File | Out-Null
-"Script | Version" | Out-File $versionFile -Append
-"-------|--------" | Out-File $versionFile -Append
-foreach ($script in $scriptVersions) {
-    "$($script.File) | $($script.Version)" | Out-File $versionFile -Append
-}
-
 # Generate version CSV for script version checks
 
 $scriptVersions | Export-Csv -Path "$distFolder\ScriptVersions.csv" -NoTypeInformation

--- a/.build/BuildScriptVersions.ps1
+++ b/.build/BuildScriptVersions.ps1
@@ -16,14 +16,12 @@ if (Test-Path -Path $scriptVersionsCsv) {
     $versionsFileCSV = ConvertFrom-Csv -InputObject (Get-Content -Path $scriptVersionsCsv)
 
     # Generate final ScriptVersions.txt file (with SHA256 hash) for release description
-
     $versionFile = "$distFolder\ScriptVersions.txt"
     New-Item -Path $versionFile -ItemType File -Force | Out-Null
     "Script | Version | SHA256 Hash" | Out-File $versionFile -Append
     "-------|---------|------------" | Out-File $versionFile -Append
     foreach ($script in $versionsFileCSV) {
-        $fullFilePath = "$($distFolder)\$($script.File)"
-        $sha256Hash = $((Get-FileHash -Path $fullFilePath).Hash)
+        $sha256Hash = $((Get-FileHash -Path "$($distFolder)\$($script.File)").Hash)
         "$($script.File) | $($script.Version) | $sha256Hash" | Out-File $versionFile -Append
         Write-Host ("File: '{0}' Version: '{1}' Hash: '{2}' added" -f $script.File, $script.Version, $sha256Hash)
     }

--- a/.build/BuildScriptVersions.ps1
+++ b/.build/BuildScriptVersions.ps1
@@ -22,9 +22,12 @@ if (Test-Path -Path $scriptVersionsCsv) {
     "-------|---------|------------" | Out-File $versionFile -Append
     foreach ($script in $versionsFileCSV) {
         $sha256Hash = $((Get-FileHash -Path "$($distFolder)\$($script.File)").Hash)
+        $script | Add-Member -MemberType NoteProperty -Name SHA256Hash -Value $sha256Hash
         "$($script.File) | $($script.Version) | $sha256Hash" | Out-File $versionFile -Append
         Write-Host ("File: '{0}' Version: '{1}' Hash: '{2}' added" -f $script.File, $script.Version, $sha256Hash)
     }
+
+    $versionsFileCSV | Export-Csv -Path $scriptVersionsCsv
 } else {
     # Skip re-creation if ScriptVersions.csv doesn't exist
     Write-Host ("File: '{0}' not found. Skipping 'ScriptVersions.txt' re-creation" -f $scriptVersionsCsv)

--- a/.build/BuildScriptVersions.ps1
+++ b/.build/BuildScriptVersions.ps1
@@ -27,7 +27,7 @@ if (Test-Path -Path $scriptVersionsCsv) {
         Write-Host ("File: '{0}' Version: '{1}' Hash: '{2}' added" -f $script.File, $script.Version, $sha256Hash)
     }
 
-    $versionsFileCSV | Export-Csv -Path $scriptVersionsCsv
+    $versionsFileCSV | Export-Csv -Path $scriptVersionsCsv -NoTypeInformation
 } else {
     # Skip re-creation if ScriptVersions.csv doesn't exist
     Write-Host ("File: '{0}' not found. Skipping 'ScriptVersions.txt' re-creation" -f $scriptVersionsCsv)

--- a/.build/BuildScriptVersions.ps1
+++ b/.build/BuildScriptVersions.ps1
@@ -1,0 +1,33 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[CmdletBinding()]
+param (
+
+)
+
+#Requires -Version 7
+
+$repoRoot = Get-Item "$PSScriptRoot\.."
+$distFolder = "$repoRoot\dist"
+$scriptVersionsCsv = "$distFolder\ScriptVersions.csv"
+
+if (Test-Path -Path $scriptVersionsCsv) {
+    $versionsFileCSV = ConvertFrom-Csv -InputObject (Get-Content -Path $scriptVersionsCsv)
+
+    # Generate final ScriptVersions.txt file (with SHA256 hash) for release description
+
+    $versionFile = "$distFolder\ScriptVersions.txt"
+    New-Item -Path $versionFile -ItemType File -Force | Out-Null
+    "Script | Version | SHA256 Hash" | Out-File $versionFile -Append
+    "-------|---------|------------" | Out-File $versionFile -Append
+    foreach ($script in $versionsFileCSV) {
+        $fullFilePath = "$($distFolder)\$($script.File)"
+        $sha256Hash = $((Get-FileHash -Path $fullFilePath).Hash)
+        "$($script.File) | $($script.Version) | $sha256Hash" | Out-File $versionFile -Append
+        Write-Host ("File: '{0}' Version: '{1}' Hash: '{2}' added" -f $script.File, $script.Version, $sha256Hash)
+    }
+} else {
+    # Skip re-creation if ScriptVersions.csv doesn't exist
+    Write-Host ("File: '{0}' not found. Skipping 'ScriptVersions.txt' re-creation" -f $scriptVersionsCsv)
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,11 @@ steps:
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
 
+- pwsh: |
+    cd .\.build
+    .\BuildScriptVersions.ps1
+  displayName: "Build final ScriptVersions.txt file containing file hashes"
+
 - task: GitHubRelease@0
   displayName: 'Create GitHub Release - Draft'
   condition: and(succeeded(), ne (variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ steps:
 - pwsh: |
     cd .\.build
     .\BuildScriptVersions.ps1
-  displayName: "Build final ScriptVersions.txt file containing file hashes"
+  displayName: "Build ScriptVersions.txt"
 
 - pwsh: |
     Get-Content dist\ScriptVersions.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,17 +31,6 @@ steps:
     .\Pester.ps1
   displayName: "Running Invoke-Pester"
 
-- pwsh: |
-    Get-Content dist\ScriptVersions.txt
-  displayName: "Display Script Versions file"
-
-- pwsh: |
-    $tag = "v$((Get-Date).ToString(`"yy.MM.dd.HHmm`"))"
-    Write-Host "##vso[task.setvariable variable=ReleaseTagValue]$tag"
-    (Get-Content .\dist\ScriptVersions.txt) -replace '^(\S+.ps1)', ('[$1](https://github.com/microsoft/CSS-Exchange/releases/download/' + $tag + '/$1)') | Out-File dist\ScriptVersions.txt
-    Get-Content dist\ScriptVersions.txt
-  displayName: "Setting Script Versions text file"
-
 - task: EsrpCodeSigning@1
   condition: and(succeeded(), ne (variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release'))
   inputs:
@@ -88,6 +77,17 @@ steps:
     cd .\.build
     .\BuildScriptVersions.ps1
   displayName: "Build final ScriptVersions.txt file containing file hashes"
+
+  - pwsh: |
+    Get-Content dist\ScriptVersions.txt
+  displayName: "Display Script Versions file"
+
+- pwsh: |
+    $tag = "v$((Get-Date).ToString(`"yy.MM.dd.HHmm`"))"
+    Write-Host "##vso[task.setvariable variable=ReleaseTagValue]$tag"
+    (Get-Content .\dist\ScriptVersions.txt) -replace '^(\S+.ps1)', ('[$1](https://github.com/microsoft/CSS-Exchange/releases/download/' + $tag + '/$1)') | Out-File dist\ScriptVersions.txt
+    Get-Content dist\ScriptVersions.txt
+  displayName: "Setting Script Versions text file"
 
 - task: GitHubRelease@0
   displayName: 'Create GitHub Release - Draft'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ steps:
     .\BuildScriptVersions.ps1
   displayName: "Build final ScriptVersions.txt file containing file hashes"
 
-  - pwsh: |
+- pwsh: |
     Get-Content dist\ScriptVersions.txt
   displayName: "Display Script Versions file"
 


### PR DESCRIPTION
**Description:**
Write out the SHA256 checksum for each script on the release page. We must create the file hash post script signing to make sure that the hash is accurate. We simply read the `ScriptVersions.csv` file which was created during `Build.ps1` run and ~~overwrite~~ create the `ScriptVersions.txt` ~~which was also initially created during Build.ps1 run~~. We also add the file hash to the `ScriptVersions.csv`.