### PR TITLE
Exchange Server March 2022 Security Updates

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -148,6 +148,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "1497.28" `
                 -CVENames "CVE-2022-21855", "CVE-2022-21846", "CVE-2022-21969"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "1497.33" `
+                -CVENames "CVE-2022-23277"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {
 
@@ -278,6 +281,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "2308.21", "2375.18" `
                 -CVENames "CVE-2022-21855", "CVE-2022-21846", "CVE-2022-21969"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "2308.27", "2375.24" `
+                -CVENames "CVE-2022-23277", "CVE-2022-24463"
         }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
 
@@ -381,6 +387,9 @@ Function Invoke-AnalyzerSecurityCveCheck {
             TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
                 -SecurityFixedBuilds "922.20", "986.15" `
                 -CVENames "CVE-2022-21855", "CVE-2022-21846", "CVE-2022-21969"
+            TestVulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision `
+                -SecurityFixedBuilds "922.27", "986.22" `
+                -CVENames "CVE-2022-23277", "CVE-2022-24463"
         }
     } else {
         Write-Verbose "Unknown Version of Exchange"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -125,6 +125,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
 
             $cveTests = $Script:ActiveGrouping.TestingValue | Where-Object { $_.StartsWith("CVE") }
             $cveTests.Contains("CVE-2020-1147") | Should -Be $true
+            $cveTests.Count | Should -Be 42
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -129,10 +129,11 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
 
             $cveTests = GetObject "Security Vulnerability"
             $cveTests.Contains("CVE-2020-1147") | Should -Be $true
+            $cveTests.Count | Should -Be 12
             $downlaodDomains = GetObject "CVE-2021-1730"
             $downlaodDomains.DownloadDomainsEnabled | Should -Be "false"
 
-            $Script:ActiveGrouping.Count | Should -Be 11
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
     }
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
@@ -131,6 +131,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
             $cveTests = GetObject "Security Vulnerability"
             $cveTests.Contains("CVE-2020-1147") | Should -Be $true
+            $cveTests.Count | Should -Be 12
             $downloadDomains = GetObject "CVE-2021-1730"
             $downloadDomains.DownloadDomainsEnabled | Should -Be "False"
         }


### PR DESCRIPTION
**Description:**
Added check for March 2022 Exchange Security Updates:

**Exchange 2013:**

- CVE-2022-23277

**Exchange 2016/2019:**

- CVE-2022-23277
- CVE-2022-24463