### PR TITLE
Update Invoke-EnableExtraTracing.ps1

### DIFF
--- a/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
@@ -9,13 +9,12 @@ function Invoke-EnableExTRATracing {
             [string]$LogmanName
         )
         logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
-        
+
         if ($LASTEXITCODE) {
             Write-Host "Exchange Trace data Collector set already created. Removing it and trying again"
             logman delete $LogmanName -s $ComputerName
-            
+
             logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
-            
         }
 
         if ($LASTEXITCODE) {
@@ -31,7 +30,7 @@ function Invoke-EnableExTRATracing {
         Invoke-ExtraTracingCreate -ComputerName $serverName -LogmanName "VSSTester"
         "Starting Exchange Trace data collector..."
         logman start VSSTester
-        
+
         if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
@@ -53,7 +52,7 @@ function Invoke-EnableExTRATracing {
         #start trace on passive copy
         "Starting Exchange Trace data collector on $serverName..."
         logman start VSSTester-Passive -s $serverName
-        
+
         if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
@@ -61,7 +60,7 @@ function Invoke-EnableExTRATracing {
         #start trace on active copy
         "Starting Exchange Trace data collector on $dbMountedOn..."
         logman start VSSTester-Active -s $dbMountedOn
-        
+
         if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit

--- a/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
@@ -8,19 +8,17 @@ function Invoke-EnableExTRATracing {
             [string]$ComputerName,
             [string]$LogmanName
         )
-        [array]$results = logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
-        $results
-
-        if ($results[-1] -eq "Data Collector already exists.") {
+        logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
+        
+        if ($LASTEXITCODE) {
             Write-Host "Exchange Trace data Collector set already created. Removing it and trying again"
-            [array]$results = logman delete $LogmanName -s $ComputerName
-            $results
-
-            [array]$results = logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
-            $results
+            logman delete $LogmanName -s $ComputerName
+            
+            logman create trace $LogmanName -p '{79bb49e6-2a2c-46e4-9167-fa122525d540}' -o $path\$LogmanName.etl -ow -s $ComputerName -mode globalsequence
+            
         }
 
-        if ($results[-1] -ne "The command completed successfully.") {
+        if ($LASTEXITCODE) {
             Write-Host "Failed to create the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
         }
@@ -32,10 +30,9 @@ function Invoke-EnableExTRATracing {
         "Creating Exchange Trace data collector set..."
         Invoke-ExtraTracingCreate -ComputerName $serverName -LogmanName "VSSTester"
         "Starting Exchange Trace data collector..."
-        [array]$results = logman start VSSTester
-        $results
-
-        if ($results[-1] -ne "The command completed successfully.") {
+        logman start VSSTester
+        
+        if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
         }
@@ -55,19 +52,17 @@ function Invoke-EnableExTRATracing {
         Invoke-ExtraTracingCreate -ComputerName $dbMountedOn -LogmanName "VSSTester-Active"
         #start trace on passive copy
         "Starting Exchange Trace data collector on $serverName..."
-        [array]$results = logman start VSSTester-Passive -s $serverName
-        $results
-
-        if ($results[-1] -ne "The command completed successfully.") {
+        logman start VSSTester-Passive -s $serverName
+        
+        if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
         }
         #start trace on active copy
         "Starting Exchange Trace data collector on $dbMountedOn..."
-        [array]$results = logman start VSSTester-Active -s $dbMountedOn
-        $results
-
-        if ($results[-1] -ne "The command completed successfully.") {
+        logman start VSSTester-Active -s $dbMountedOn
+        
+        if ($LASTEXITCODE) {
             Write-Host "Failed to start the extra trace. Stopping the VSSTester Script" -ForegroundColor Red
             exit
         }


### PR DESCRIPTION
**Issue:**
I tried to run the VSStester in an environment with a non-English language in the OS and it fails 

**Reason:**
To allow the script in any language.

**Fix:**
Short description of the fix
VSStester use a localized string in the comparison.
If we use the LASTEXITCODE variable instead of the result and we verify that we receive 0 as result should work for any language.

**Validation:**
