### PR TITLE
Disable Async Notification

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -71,6 +71,19 @@ Function Invoke-AnalyzerFrequentConfigurationIssues {
         -DisplayTestingValue ($exchangeInformation.RegistryValues.CtsProcessorAffinityPercentage) `
         -HtmlName "CtsProcessorAffinityPercentage"
 
+    $displayValue = $exchangeInformation.RegistryValues.DisableAsyncNotification
+    $displayWriteType = "Grey"
+
+    if ($displayValue -ne 0) {
+        $displayWriteType = "Yellow"
+        $displayValue = "$($exchangeInformation.RegistryValues.DisableAsyncNotification) Warning: This value should be set back to 0 after you no longer need it for the workaround described in http://support.microsoft.com/kb/5013118"
+    }
+
+    $AnalyzeResults | Add-AnalyzedResultInformation -Name "Disable Async Notification" -Details $displayValue `
+        -DisplayGroupingKey $keyFrequentConfigIssues `
+        -DisplayWriteType $displayWriteType `
+        -DisplayTestingValue $true
+
     $displayValue = $osInformation.CredentialGuardEnabled
     $displayWriteType = "Grey"
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
@@ -31,9 +31,17 @@ Function Get-ExchangeRegistryValues {
         CatchActionFunction = $CatchActionFunction
     }
 
+    $disableAsyncParams = @{
+        MachineName         = $MachineName
+        SubKey              = "SOFTWARE\Microsoft\ExchangeServer\v15"
+        GetValue            = "DisableAsyncNotification"
+        CatchActionFunction = $CatchActionFunction
+    }
+
     return [PSCustomObject]@{
         CtsProcessorAffinityPercentage = [int](Get-RemoteRegistryValue @ctsParams)
         FipsAlgorithmPolicyEnabled     = [int](Get-RemoteRegistryValue @fipsParams)
         DisableGranularReplication     = [int](Get-RemoteRegistryValue @blockReplParams)
+        DisableAsyncNotification       = [int](Get-RemoteRegistryValue @disableAsyncParams)
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
@@ -10,32 +10,29 @@ Function Get-ExchangeRegistryValues {
     )
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
-    $ctsParams = @{
+    $baseParams = @{
         MachineName         = $MachineName
-        SubKey              = "SOFTWARE\Microsoft\ExchangeServer\v15\Search\SystemParameters"
-        GetValue            = "CtsProcessorAffinityPercentage"
         CatchActionFunction = $CatchActionFunction
     }
 
-    $fipsParams = @{
-        MachineName         = $MachineName
-        SubKey              = "SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy"
-        GetValue            = "Enabled"
-        CatchActionFunction = $CatchActionFunction
+    $ctsParams = $baseParams + @{
+        SubKey   = "SOFTWARE\Microsoft\ExchangeServer\v15\Search\SystemParameters"
+        GetValue = "CtsProcessorAffinityPercentage"
     }
 
-    $blockReplParams = @{
-        MachineName         = $MachineName
-        SubKey              = "SOFTWARE\Microsoft\ExchangeServer\v15\Replay\Parameters"
-        GetValue            = "DisableGranularReplication"
-        CatchActionFunction = $CatchActionFunction
+    $fipsParams = $baseParams + @{
+        SubKey   = "SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy"
+        GetValue = "Enabled"
     }
 
-    $disableAsyncParams = @{
-        MachineName         = $MachineName
-        SubKey              = "SOFTWARE\Microsoft\ExchangeServer\v15"
-        GetValue            = "DisableAsyncNotification"
-        CatchActionFunction = $CatchActionFunction
+    $blockReplParams = $baseParams + @{
+        SubKey   = "SOFTWARE\Microsoft\ExchangeServer\v15\Replay\Parameters"
+        GetValue = "DisableGranularReplication"
+    }
+
+    $disableAsyncParams = $baseParams + @{
+        SubKey   = "SOFTWARE\Microsoft\ExchangeServer\v15"
+        GetValue = "DisableAsyncNotification"
     }
 
     return [PSCustomObject]@{

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -107,7 +107,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
 
-            $Script:ActiveGrouping.Count | Should -Be 7
+            $Script:ActiveGrouping.Count | Should -Be 8
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -108,7 +108,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
 
-            $Script:ActiveGrouping.Count | Should -Be 7
+            $Script:ActiveGrouping.Count | Should -Be 8
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.Tests.ps1
@@ -109,7 +109,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
 
-            $Script:ActiveGrouping.Count | Should -Be 7
+            $Script:ActiveGrouping.Count | Should -Be 8
         }
 
         It "Display Results - Security Settings" {
@@ -213,7 +213,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-ExchangeAdSchemaClass -Exactly 1
             Assert-MockCalled Get-WmiObjectHandler -Exactly 6
             Assert-MockCalled Invoke-ScriptBlockHandler -Exactly 4
-            Assert-MockCalled Get-RemoteRegistryValue -Exactly 9
+            Assert-MockCalled Get-RemoteRegistryValue -Exactly 10
             Assert-MockCalled Get-NETFrameworkVersion -Exactly 1
             Assert-MockCalled Get-DotNetDllFileVersions -Exactly 1
             Assert-MockCalled Get-NicPnpCapabilitiesSetting -Exactly 1
@@ -345,6 +345,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
         BeforeAll {
             Mock Get-RemoteRegistryValue -ParameterFilter { $GetValue -eq "KeepAliveTime" } -MockWith { return 1800000 }
             Mock Get-RemoteRegistryValue -ParameterFilter { $GetValue -eq "DisableGranularReplication" } -MockWith { return 1 }
+            Mock Get-RemoteRegistryValue -ParameterFilter { $GetValue -eq "DisableAsyncNotification" } -MockWith { return 1 }
             Mock Get-OrganizationConfig { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOrganizationConfig1.xml" }
             Mock Get-OwaVirtualDirectory { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOwaVirtualDirectory2.xml" }
             Mock Get-AcceptedDomain { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetAcceptedDomain_Bad.xml" }
@@ -366,6 +367,10 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
         It "DisableGranularReplication" {
             TestObjectMatch "DisableGranularReplication" $true -WriteType "Red"
+        }
+
+        It "Disable Async Notification" {
+            TestObjectMatch "Disable Async Notification" $true -WriteType "Yellow"
         }
 
         It "Enabled Domains" {

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -48,6 +48,7 @@ Mock Get-RemoteRegistryValue {
         "CtsProcessorAffinityPercentage" { return 0 }
         "Enabled" { return 0 }
         "DisableGranularReplication" { return 0 }
+        "DisableAsyncNotification" { return 0 }
         Default { throw "Failed to find GetValue: $GetValue" }
     }
 }


### PR DESCRIPTION
**Reason:**
Set the `DisableAsyncNotification` back to 0 after it is no longer needed.

**Fix:**
Check the registry value and see if it isn't set to 0 and report it if it isn't with a warning. 

Resolved #960 

**Validation:**
Lab and Pester Tested