### PR TITLE
Break up and refactor CodeFormatter

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -10,6 +10,11 @@ param(
 #Requires -Version 7
 
 . $PSScriptRoot\Load-Module.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckFileHasNewlineAtEndOfFile.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckMarkdownFileHasNoBOM.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckScriptFileHasBOM.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckScriptFileHasComplianceHeader.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckScriptFormat.ps1
 
 if (-not (Load-Module -Name PSScriptAnalyzer -MinimumVersion "1.20")) {
     throw "PSScriptAnalyzer module could not be loaded"
@@ -21,110 +26,36 @@ if (-not (Load-Module -Name EncodingAnalyzer)) {
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
 
-$scriptFiles = Get-ChildItem -Path $repoRoot -Directory | Where-Object {
-    $_.Name -ne "dist" } | ForEach-Object { Get-ChildItem -Path $_.FullName -Include "*.ps1", "*.psm1" -Recurse } | ForEach-Object { $_.FullName }
-$filesFailed = $false
+$filesToCheck = Get-ChildItem -Path $repoRoot -Directory | Where-Object {
+    $_.Name -ne "dist" } | ForEach-Object {
+    Get-ChildItem -Path $_.FullName -Include "*.ps1", "*.psm1", "*.md" -Recurse
+}
 
-# MD files must NOT have a BOM
-Get-ChildItem -Path $repoRoot -Include *.md -Recurse | ForEach-Object {
-    $encoding = Get-PsOneEncoding $_
-    if ($encoding.BOM) {
-        Write-Warning "MD file has BOM: $($_.FullName)"
-        if ($Save) {
-            try {
-                $content = Get-Content $_
-                Set-Content -Path $_.FullName -Value $content -Encoding utf8NoBOM -Force
-                Write-Warning "Saved $($_.FullName) without BOM."
-            } catch {
-                $filesFailed = $true
-                throw
-            }
-        } else {
-            $filesFailed = $true
-        }
+$errorCount = 0
+
+foreach ($fileInfo in $filesToCheck) {
+    $errorCount += (CheckFileHasNewlineAtEndOfFile $fileInfo $Save) ? 1 : 0
+    $errorCount += (CheckMarkdownFileHasNoBOM $fileInfo $Save) ? 1 : 0
+    $errorCount += (CheckScriptFileHasBOM $fileInfo $Save) ? 1 : 0
+    $errorCount += (CheckScriptFileHasComplianceHeader $fileInfo $Save) ? 1 : 0
+
+    # This one is tricky. It returns $true or $false like the others, but in the case
+    # of an error, we also want to get the diff output. Piping to Out-Host from within
+    # the function loses the colorization, as does redirection. I can't find any way
+    # for the function to output the diff while preserving the color. So we unfortunately
+    # have to handle the output here.
+    $results = @(CheckScriptFormat $fileInfo $Save)
+    if ($results[0]) {
+        git -c color.status=always diff ($($results[1]) | git hash-object -w --stdin) ($($results[2]) | git hash-object -w --stdin)
     }
 }
 
-foreach ($file in $scriptFiles) {
-    # PS1 files must have a BOM
-    $encoding = Get-PsOneEncoding $file
-    if (-not $encoding.BOM) {
-        Write-Warning "File has no BOM: $file"
-        if ($Save) {
-            try {
-                $content = Get-Content $file
-                Set-Content -Path $file -Value $content -Encoding utf8BOM -Force
-                Write-Warning "Saved $file with BOM."
-            } catch {
-                $filesFailed = $true
-                throw
-            }
-        } else {
-            $filesFailed = $true
-        }
-    }
+$maxRetries = 5
 
-    #Check for compliance
-    $scriptContent = New-Object 'System.Collections.Generic.List[string]'
-    $scriptContent.AddRange([IO.File]::ReadAllLines($file))
-
-    if (-not ($scriptContent[0].Contains("# Copyright (c) Microsoft Corporation.")) -or
-        -not ($scriptContent[1].Contains("# Licensed under the MIT License."))) {
-
-        Write-Warning "File doesn't have header compliance set: $file"
-        if ($Save) {
-            try {
-                $scriptContent.Insert(0, "")
-                $scriptContent.Insert(0, "# Licensed under the MIT License.")
-                $scriptContent.Insert(0, "# Copyright (c) Microsoft Corporation.")
-                Set-Content -Path $file -Value $scriptContent -Encoding utf8BOM
-            } catch {
-                $filesFailed = $true
-                throw
-            }
-        } else {
-            $filesFailed = $true
-        }
-    }
-
-    $reloadFile = $false
-    $before = Get-Content $file -Raw
-    $after = Invoke-Formatter -ScriptDefinition $before -Settings $repoRoot\PSScriptAnalyzerSettings.psd1
-
-    if ($before -ne $after) {
-        Write-Warning ("{0}:" -f $file)
-        Write-Warning ("Failed to follow the same format defined in the repro")
-        if ($Save) {
-            try {
-                Set-Content -Path $file -Value $after -Encoding utf8NoBOM
-                Write-Information "Saved $file with formatting corrections."
-                $reloadFile = $true
-            } catch {
-                $filesFailed = $true
-                Write-Warning "Failed to save $file with formatting corrections."
-            }
-        } else {
-            $filesFailed = $true
-            git diff ($($before) | git hash-object -w --stdin) ($($after) | git hash-object -w --stdin)
-        }
-    }
-
-    if ($reloadFile) {
-        $before = Get-Content -Path $file -Raw
-    }
-
-    if (-not ([string]::IsNullOrWhiteSpace($before[-1]))) {
-        Write-Warning $file
-        Write-Warning "Failed to have a whitespace at the end of the file"
-        $filesFailed = $true
-    }
-
-    $maxRetries = 5
-
+foreach ($fileInfo in $filesToCheck) {
     for ($i = 0; $i -lt $maxRetries; $i++) {
-
         try {
-            $analyzerResults = Invoke-ScriptAnalyzer -Path $file -Settings $repoRoot\PSScriptAnalyzerSettings.psd1 -ErrorAction Stop
+            $analyzerResults = Invoke-ScriptAnalyzer -Path $FileInfo.FullName -Settings $repoRoot\PSScriptAnalyzerSettings.psd1 -ErrorAction Stop
             if ($null -ne $analyzerResults) {
                 $filesFailed = $true
                 $analyzerResults | Format-Table -AutoSize
@@ -137,12 +68,12 @@ foreach ($file in $scriptFiles) {
             Start-Sleep -Seconds 5
         }
     }
-
-    if ($i -eq $maxRetries) {
-        $filesFailed = $true
-    }
 }
 
-if ($filesFailed) {
-    throw "Failed to match coding formatting requirements"
+if ($i -eq $maxRetries) {
+    $errorCount += 1
+}
+
+if ($errorCount -gt 0) {
+    throw "Failed to match formatting requirements"
 }

--- a/.build/CodeFormatterChecks/CheckFileHasNewlineAtEndOfFile.ps1
+++ b/.build/CodeFormatterChecks/CheckFileHasNewlineAtEndOfFile.ps1
@@ -1,0 +1,40 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckFileHasNewlineAtEndOfFile {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    $content = Get-Content -Path $FileInfo.FullName -Raw
+
+    <#
+        If developing on Windows, we expect the file to end with `r`n. If developing on Linux, we expect the file to end with `n.
+        Therefore, this check should work in both scenarios. In both cases, git should ensure that what is actually committed is
+        a file with just `n, thanks to autocrlf which defaults to true on Windows.
+    #>
+    if (-not ("`n" -eq $content[-1])) {
+        if ($Save) {
+            try {
+                # Set-Content automatically adds a newline, so we don't need to add it ourselves.
+                Set-Content -Path $FileInfo.FullName -Value $content -Encoding utf8BOM
+                Write-Host "Saved with newline at end of file: $($FileInfo.FullName)"
+                $false
+            } catch {
+                Write-Warning "Failed to save with newline at end: $($FileInfo.FullName)"
+                $true
+            }
+        } else {
+            Write-Warning "File has no newline at end of file: $($FileInfo.FullName)"
+            $true
+        }
+    }
+}

--- a/.build/CodeFormatterChecks/CheckMarkdownFileHasNoBOM.ps1
+++ b/.build/CodeFormatterChecks/CheckMarkdownFileHasNoBOM.ps1
@@ -1,0 +1,38 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckMarkdownFileHasNoBOM {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    if ($FileInfo.Extension -eq ".md") {
+        $encoding = Get-PsOneEncoding $FileInfo
+        if ($encoding.BOM) {
+            if ($Save) {
+                try {
+                    $content = Get-Content $FileInfo.FullName
+                    Set-Content -Path $FileInfo.FullName -Value $content -Encoding utf8NoBOM -Force
+                    Write-Host "Removed BOM: $($FileInfo.FullName)"
+                    $false
+                } catch {
+                    Write-Warning "MD file has BOM and couldn't be fixed automatically: $($FileInfo.FullName). Exception: $($_.Exception)"
+                    $true
+                }
+            } else {
+                Write-Warning "Markdown file has BOM: $($FileInfo.FullName)"
+                $true
+            }
+        }
+    } else {
+        $false
+    }
+}

--- a/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
+++ b/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
@@ -1,0 +1,52 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckScriptFileHasBOM {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    <#
+        We require scripts to have a BOM because:
+
+        https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding
+
+        "If you need to use non-Ascii characters in your scripts, save them as UTF-8 with BOM.
+        Without the BOM, Windows PowerShell misinterprets your script as being encoded in the
+        legacy "ANSI" codepage. Conversely, files that do have the UTF-8 BOM can be problematic
+        on Unix-like platforms."
+
+        Since these scripts are purely for Exchange and Exchange Online, we expect they will usually
+        be run from Windows, so we require a BOM to ensure they are seen by Windows Powershell as
+        Unicode, not ANSI.
+    #>
+    if ($FileInfo.Extension -eq ".ps1" -or $FileInfo.Extension -eq ".psm1") {
+        $encoding = Get-PsOneEncoding $FileInfo
+        if (-not $encoding.BOM) {
+            if ($Save) {
+                try {
+                    $content = Get-Content $FileInfo.FullName
+                    Set-Content -Path $FileInfo.FullName -Value $content -Encoding utf8BOM -Force
+                    Write-Host "Added BOM: $($FileInfo.FullName)"
+                    $false
+                } catch {
+                    Write-Warning "File has no BOM and couldn't be fixed automatically: $($FileInfo.FullName). Exception: $($_.Exception)";
+                    $true
+                }
+            } else {
+                Write-Warning "File has no BOM: $($FileInfo.FullName)"
+                $true
+            }
+        }
+    } else {
+        $false
+    }
+}

--- a/.build/CodeFormatterChecks/CheckScriptFileHasComplianceHeader.ps1
+++ b/.build/CodeFormatterChecks/CheckScriptFileHasComplianceHeader.ps1
@@ -1,0 +1,44 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckScriptFileHasComplianceHeader {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    if ($FileInfo.Extension -eq ".ps1" -or $FileInfo.Extension -eq ".psm1") {
+        $scriptContent = New-Object 'System.Collections.Generic.List[string]'
+        $scriptContent.AddRange([IO.File]::ReadAllLines($($FileInfo.FullName)))
+
+        if (-not ($scriptContent[0].Contains("# Copyright (c) Microsoft Corporation.")) -or
+            -not ($scriptContent[1].Contains("# Licensed under the MIT License."))) {
+
+            if ($Save) {
+                try {
+                    $scriptContent.Insert(0, "")
+                    $scriptContent.Insert(0, "# Licensed under the MIT License.")
+                    $scriptContent.Insert(0, "# Copyright (c) Microsoft Corporation.")
+                    Set-Content -Path $FileInfo.FullName -Value $scriptContent -Encoding utf8BOM
+                    Write-Host "Added compliance header: $($FileInfo.FullName)"
+                    $false
+                } catch {
+                    Write-Warning "Failed to add compliance header: $($FileInfo.FullName). Exception: $($_.Exception)"
+                    $true
+                }
+            } else {
+                Write-Warning "File has no compliance header: $($FileInfo.FullName)"
+                $true
+            }
+        }
+    } else {
+        $false
+    }
+}

--- a/.build/CodeFormatterChecks/CheckScriptFormat.ps1
+++ b/.build/CodeFormatterChecks/CheckScriptFormat.ps1
@@ -1,0 +1,44 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckScriptFormat {
+    [CmdletBinding()]
+    [OutputType([boolean], [string], [string])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    if ($FileInfo.Extension -eq ".ps1" -or $FileInfo.Extension -eq ".psm1") {
+        $before = Get-Content $FileInfo.FullName -Raw
+        $after = Invoke-Formatter -ScriptDefinition $before -Settings $PSScriptRoot\..\..\PSScriptAnalyzerSettings.psd1
+
+        if ($before -ne $after) {
+            if ($Save) {
+                try {
+                    # Invoke-Formatter likes to put two newlines at the end of the file. So, here we TrimEnd(),
+                    # and then we let Set-Content automatically add a single newline.
+                    $after = $after.TrimEnd()
+                    Set-Content -Path $FileInfo.FullName -Value $after -Encoding utf8BOM
+                    Write-Host "Saved with formatting corrections: $($FileInfo.FullName)"
+                    $false
+                } catch {
+                    Write-Warning "Failed to save with formatting corrections: $($FileInfo.FullName)"
+                    $true
+                }
+            } else {
+                Write-Warning "Code format does not meet requirements: $($FileInfo.FullName)"
+                $true
+                $before
+                $after
+            }
+        }
+    } else {
+        $false
+    }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@ Short description of the fix
 
 **Validation:**
 Provide if applicable
+

--- a/docs/Databases/VSSTester.md
+++ b/docs/Databases/VSSTester.md
@@ -41,3 +41,4 @@ Here are the steps to verify that the local Administrators group is allowed to t
 9. Click Okay
 10. Click Apply and Okay
 11. Restart the Computer
+

--- a/docs/Diagnostics/HealthChecker/AMSIIntegration.md
+++ b/docs/Diagnostics/HealthChecker/AMSIIntegration.md
@@ -26,3 +26,4 @@ Yes
 [Released: June 2021 Quarterly Exchange Updates](https://techcommunity.microsoft.com/t5/exchange-team-blog/released-june-2021-quarterly-exchange-updates/ba-p/2459826)
 
 [More about AMSI integration with Exchange Server](https://techcommunity.microsoft.com/t5/exchange-team-blog/more-about-amsi-integration-with-exchange-server/ba-p/2572371)
+

--- a/docs/Diagnostics/HealthChecker/CTSProcessorAffinityPercentageCheck.md
+++ b/docs/Diagnostics/HealthChecker/CTSProcessorAffinityPercentageCheck.md
@@ -9,3 +9,4 @@ This can cause an impact to the server's search performance. This should never b
 **Included in HTML Report?**
 
 Yes
+

--- a/docs/Diagnostics/HealthChecker/CertificateCheck.md
+++ b/docs/Diagnostics/HealthChecker/CertificateCheck.md
@@ -32,3 +32,4 @@ We also perform the following checks:
 **Included in HTML Report?**
 
 Yes
+

--- a/docs/Diagnostics/HealthChecker/CredentialGuardCheck.md
+++ b/docs/Diagnostics/HealthChecker/CredentialGuardCheck.md
@@ -11,3 +11,4 @@ Yes
 **Additional resources:**
 
 [Manage Windows Defender Credential Guard](https://docs.microsoft.com/windows/security/identity-protection/credential-guard/credential-guard-manage)
+

--- a/docs/Diagnostics/HealthChecker/DownloadDomainCheck.md
+++ b/docs/Diagnostics/HealthChecker/DownloadDomainCheck.md
@@ -17,3 +17,4 @@ Yes
 **Additional resources:**
 
 [How to configure the Download Domain feature (see FAQ section)](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1730)
+

--- a/docs/Diagnostics/HealthChecker/EEMSCheck.md
+++ b/docs/Diagnostics/HealthChecker/EEMSCheck.md
@@ -46,3 +46,4 @@ Yes
 [Exchange Emergency Mitigation (EM) service](https://docs.microsoft.com/exchange/exchange-emergency-mitigation-service?view=exchserver-2019)
 
 [Mitigations Cloud endpoint is not reachable](https://docs.microsoft.com/exchange/plan-and-deploy/deployment-ref/ms-exch-setupreadiness-MitigationsCloudEndpointUnreachable?view=exchserver-2019)
+

--- a/docs/Diagnostics/HealthChecker/ExchangeServerMaintenanceCheck.md
+++ b/docs/Diagnostics/HealthChecker/ExchangeServerMaintenanceCheck.md
@@ -22,3 +22,4 @@ Yes
 **Additional resources:**
 
 [Determine the requestor that changed Server component state](https://docs.microsoft.com/en-us/exchange/troubleshoot/administration/requestor-changed-server-component)
+

--- a/docs/Diagnostics/HealthChecker/FIPFSCheck.md
+++ b/docs/Diagnostics/HealthChecker/FIPFSCheck.md
@@ -21,3 +21,4 @@ Yes
 **Additional resources:**
 
 [Email Stuck in Exchange On-premises Transport Queues](https://techcommunity.microsoft.com/t5/exchange-team-blog/email-stuck-in-exchange-on-premises-transport-queues/ba-p/3049447)
+

--- a/docs/Diagnostics/HealthChecker/GeneralHardwareInformation.md
+++ b/docs/Diagnostics/HealthChecker/GeneralHardwareInformation.md
@@ -62,3 +62,4 @@ Yes
 [5 - Hardware requirements for Exchange 2016](https://docs.microsoft.com/exchange/plan-and-deploy/system-requirements?view=exchserver-2016#hardware-requirements-for-exchange-2016)
 
 [5 - Hardware requirements for Exchange 2019](https://docs.microsoft.com/exchange/plan-and-deploy/system-requirements?view=exchserver-2019#hardware-requirements-for-exchange-2019)
+

--- a/docs/Diagnostics/HealthChecker/HyperThreadingCheck.md
+++ b/docs/Diagnostics/HealthChecker/HyperThreadingCheck.md
@@ -11,3 +11,4 @@ Yes
 **Additional resources:**
 
 [Exchange 2013 Sizing and Configuration Recommendations - Processing](https://docs.microsoft.com/exchange/exchange-2013-sizing-and-configuration-recommendations-exchange-2013-help#processing)
+

--- a/docs/Diagnostics/HealthChecker/IPv6EnabledCheck.md
+++ b/docs/Diagnostics/HealthChecker/IPv6EnabledCheck.md
@@ -15,3 +15,4 @@ Yes
 [Disabling IPv6 And Exchange – Going All The Way](https://blog.rmilne.ca/2014/10/29/disabling-ipv6-and-exchange-going-all-the-way/)
 
 [Guidance for configuring IPv6 in Windows for advanced users](https://support.microsoft.com/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users)
+

--- a/docs/Diagnostics/HealthChecker/LMCompatibilityLevelInformationCheck.md
+++ b/docs/Diagnostics/HealthChecker/LMCompatibilityLevelInformationCheck.md
@@ -9,3 +9,4 @@ Yes
 **Additional resources:**
 
 [Network security: LAN Manager authentication level](https://docs.microsoft.com/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level)
+

--- a/docs/Diagnostics/HealthChecker/MAPIFrontEndAppPoolGCModeCheck.md
+++ b/docs/Diagnostics/HealthChecker/MAPIFrontEndAppPoolGCModeCheck.md
@@ -34,3 +34,4 @@ Yes
 [Fundamentals of garbage collection](https://docs.microsoft.com/dotnet/standard/garbage-collection/fundamentals)
 
 [Workstation and server garbage collection](https://docs.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc)
+

--- a/docs/Diagnostics/HealthChecker/NETFrameworkSupportabilityCheck.md
+++ b/docs/Diagnostics/HealthChecker/NETFrameworkSupportabilityCheck.md
@@ -11,3 +11,4 @@ Yes
 **Additional resources:**
 
 [Microsoft .NET Framework Supportability Matrix](https://docs.microsoft.com/exchange/plan-and-deploy/supportability-matrix?view=exchserver-2019#microsoft-net-framework)
+

--- a/docs/Diagnostics/HealthChecker/NumaBiosCheck.md
+++ b/docs/Diagnostics/HealthChecker/NumaBiosCheck.md
@@ -21,3 +21,4 @@ Yes
 [Exchange performance:HP NUMA BIOS settings](https://ingogegenwarth.wordpress.com/2017/07/27/numa-settings/)
 
 [Exchange 2016 users unable to edit Distribution Group membership using Outlook](https://docs.microsoft.com/archive/blogs/dannypexchange/exchange-2016-users-unable-to-edit-distribution-group-membership-when-outlook)
+

--- a/docs/Diagnostics/HealthChecker/OpenRelayDomain.md
+++ b/docs/Diagnostics/HealthChecker/OpenRelayDomain.md
@@ -30,3 +30,4 @@ Yes
 **Additional resources:**
 
 [Allow anonymous relay on Exchange servers](https://docs.microsoft.com/en-us/Exchange/mail-flow/connectors/allow-anonymous-relay?view=exchserver-2019)
+

--- a/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
+++ b/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
@@ -17,3 +17,4 @@ Yes
 **Additional Information**
 
 [Large packet loss in the guest OS using VMXNET3 in ESXi (2039495)](https://kb.vmware.com/s/article/2039495)
+

--- a/docs/Diagnostics/HealthChecker/PagefileSizeCheck.md
+++ b/docs/Diagnostics/HealthChecker/PagefileSizeCheck.md
@@ -27,3 +27,4 @@ Yes
 [PageFile requirements for Exchange 2016](https://docs.microsoft.com/exchange/plan-and-deploy/system-requirements?view=exchserver-2016#hardware-requirements-for-exchange-2016)
 
 [PageFile requirements for Exchange 2013](https://docs.microsoft.com/exchange/exchange-2013-system-requirements-exchange-2013-help#hardware)
+

--- a/docs/Diagnostics/HealthChecker/ProcessorCheck.md
+++ b/docs/Diagnostics/HealthChecker/ProcessorCheck.md
@@ -63,3 +63,4 @@ Yes
 [Exchange 2013 Sizing](https://docs.microsoft.com/exchange/exchange-2013-sizing-and-configuration-recommendations-exchange-2013-help#exchange-2013-sizing)
 
 [Hardware requirements for Exchange 2016](https://docs.microsoft.com/exchange/plan-and-deploy/system-requirements?view=exchserver-2016#hardware-requirements-for-exchange-2016)
+

--- a/docs/Diagnostics/HealthChecker/RPCMinConnectionTimeoutCheck.md
+++ b/docs/Diagnostics/HealthChecker/RPCMinConnectionTimeoutCheck.md
@@ -13,3 +13,4 @@ Yes
 **Additional resources:**
 
 [Outlook Anywhere Network Timeout Issue](https://docs.microsoft.com/archive/blogs/messaging_with_communications/outlook-anywhere-network-timeout-issue)
+

--- a/docs/Diagnostics/HealthChecker/RSSEnabledCheck.md
+++ b/docs/Diagnostics/HealthChecker/RSSEnabledCheck.md
@@ -13,3 +13,4 @@ Yes
 **Additional resources:**
 
 [Introduction to Receive Side Scaling](https://docs.microsoft.com/windows-hardware/drivers/network/introduction-to-receive-side-scaling)
+

--- a/docs/Diagnostics/HealthChecker/SMBv1Check.md
+++ b/docs/Diagnostics/HealthChecker/SMBv1Check.md
@@ -13,3 +13,4 @@ Yes
 **Additional resources:**
 
 [Exchange Server and SMBv1](https://techcommunity.microsoft.com/t5/exchange-team-blog/exchange-server-and-smbv1/ba-p/1165615)
+

--- a/docs/Diagnostics/HealthChecker/SleepyNICCheck.md
+++ b/docs/Diagnostics/HealthChecker/SleepyNICCheck.md
@@ -19,3 +19,4 @@ Yes
 **Additional resources:**
 
 [Information about power management setting on a network adapter](https://support.microsoft.com/kb/2740020)
+

--- a/docs/Diagnostics/HealthChecker/TCPIPSettingsCheck.md
+++ b/docs/Diagnostics/HealthChecker/TCPIPSettingsCheck.md
@@ -19,3 +19,4 @@ Yes
 **Additional resources:**
 
 [Checklist for Troubleshooting Performance Related issues in Exchange 2013, 2016 and 2019 (on-prem)](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Checklist-for-troubleshooting-Outlook-connectivity-in-Exchange/ba-p/604792)
+

--- a/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
+++ b/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
@@ -17,3 +17,4 @@ Yes
 [Exchange Server TLS guidance Part 2: Enabling TLS 1.2 and Identifying Clients Not Using It](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-Part-2-Enabling-TLS-1-2-and/ba-p/607761)
 
 [Exchange Server TLS guidance Part 3: Turning Off TLS 1.0/1.1](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-Part-3-Turning-Off-TLS-1-0-1-1/ba-p/607898)
+

--- a/docs/Diagnostics/HealthChecker/VisualCRedistributableVersionCheck.md
+++ b/docs/Diagnostics/HealthChecker/VisualCRedistributableVersionCheck.md
@@ -15,3 +15,4 @@ Yes
 [Exchange Server 2019 prerequisites](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2019)
 
 [Exchange Server 2016 prerequisites](https://docs.microsoft.com/exchange/plan-and-deploy/prerequisites?view=exchserver-2016)
+

--- a/docs/Diagnostics/HealthChecker/VulnerabilityCheck.md
+++ b/docs/Diagnostics/HealthChecker/VulnerabilityCheck.md
@@ -12,3 +12,4 @@ The script performs different checks to detect vulnerabilities which may lead in
 **Included in HTML Report?**
 
 Yes
+

--- a/docs/Diagnostics/HealthChecker/index.md
+++ b/docs/Diagnostics/HealthChecker/index.md
@@ -98,3 +98,4 @@ AnalyzeDataOnly | Switch to analyze the existing HealthChecker XML files. The re
 SkipVersionCheck | No version check is performed when this switch is used.
 SaveDebugLog | The debug log is kept even if the script is executed successfully.
 ScriptUpdateOnly | Switch to check for the latest version of the script and perform an auto update if a newer version was found. Can be run on any machine with internet connectivity. No elevated permissions or EMS are required.
+

--- a/docs/Performance/ExPerfWiz.md
+++ b/docs/Performance/ExPerfWiz.md
@@ -104,3 +104,4 @@ Server|Name of the server to stop the collector set on.|Local Machine
 * The default duration is 8 hours to save on disk space meaning that the data collection will stop after 8 hours.
 * Using -Threads should only be done if needed to troubleshoot the issue.  It will SIGNIFICANTLY increase the size of the resulting perfmon files.
 * Do not stop the log gathering thru the Perfmon GUI that can result in an unreadable log file.  Always stop the data gathering with Stop-Experfwiz.
+

--- a/docs/Search/Troubleshoot-ModernSearch.md
+++ b/docs/Search/Troubleshoot-ModernSearch.md
@@ -65,3 +65,4 @@ This is an example of how to run the script to get all the active mailboxes on a
 ```
 .\Troubleshoot-ModernSearch.ps1 -Server "Solo-E19A"
 ```
+


### PR DESCRIPTION
While writing up a new user guide, I noticed some issues with CodeFormatter. I want to address those issues so I don't have to explain them in the new user guide.

Test case:

![image](https://user-images.githubusercontent.com/4518572/164127428-6df97e83-f71b-4d19-8ef6-616f0bd5aa1d.png)

CodeFormatter without -Save:

![image](https://user-images.githubusercontent.com/4518572/164127452-d674abe7-7942-4948-98a2-5977112fc9f5.png)

Issues with the above output:

* Some warnings are on one line, while others use two separate lines.
* The order of the tests is weird. We have three tests, then some diff output, then another test, then the script analyzer output.

CodeFormatter with -Save:

![image](https://user-images.githubusercontent.com/4518572/164127612-1e965215-9b4d-43fc-b679-f0a69109c707.png)

Issues with the above output:

* We repeatedly fix the same issues. This is because the format fix actually removes the BOM.

Resulting script from -Save:

![image](https://user-images.githubusercontent.com/4518572/164127772-45de97aa-88d9-45e0-8ecc-8e8895c9672b.png)

Issues with the above:

* We end up with TWO newlines at the end. This appears to be something that Invoke-Formatter likes to do.

This refactoring has a few goals:

* Break each test into its own script file.
* Consistently use a single line of output for each test.
* Perform all other tests first, THEN do the format and diff, THEN do PSScriptAnalyzer checks.
* Only add a single newline.
* Enforce newline at EOF on markdown files too.
* Fix everything in one pass.
* Don't display warnings when we were able to fix things. They should be informationals in that case.

New output without -Save using the same test case:

![image](https://user-images.githubusercontent.com/4518572/164128165-d48cf792-118e-4119-b063-6bc533b466b3.png)

New output with -Save using the same test case:

![image](https://user-images.githubusercontent.com/4518572/164128191-9b1c62d6-bebd-4dc1-9d3b-41e35405eb8a.png)

Resulting test file:

![image](https://user-images.githubusercontent.com/4518572/164128257-4f624952-c859-42bc-9dcb-d56c0b6f3ded.png)
