### PR TITLE
Add System Up Time to HTML Report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -35,8 +35,7 @@ Function Invoke-AnalyzerOsInformation {
 
     $AnalyzeResults | Add-AnalyzedResultInformation -Name "System Up Time" -Details $upTime `
         -DisplayGroupingKey $keyOSInformation `
-        -DisplayTestingValue ($osInformation.ServerBootUp) `
-        -AddHtmlDetailRow $false
+        -DisplayTestingValue ($osInformation.ServerBootUp)
 
     $AnalyzeResults | Add-AnalyzedResultInformation -Name "Time Zone" -Details ($osInformation.TimeZone.CurrentTimeZone) `
         -DisplayGroupingKey $keyOSInformation `


### PR DESCRIPTION
**Issue:**
Request from a user.

**Fix:**
Removed line that denied the `System Up Time` from being in the HTML Report. 

Resolved #982 

**Validation:**
Lab Tested

![image](https://user-images.githubusercontent.com/22776718/164724081-8beb58ee-d847-4cca-ae40-c9ae805dfcb3.png)

