### PR TITLE
Make group membership check language agnostic

### DIFF
--- a/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
@@ -28,39 +28,39 @@ Function Test-UserGroupMemberOf {
 
     $groupRequirements = @(
         @{
-            Name       = "Organization Management"
-            RoleString = "Organization Management"
-            Reason     = "User must be in the Organization Management Group"
+            Name   = "Organization Management"
+            Role   = "Organization Management"
+            Reason = "User must be in the Organization Management Group"
         }
     )
 
     if ($PrepareSchemaRequired) {
         $groupRequirements += @{
-            Name       = "Schema Admins"
-            RoleString = (Get-WellKnownGroupSid "Schema Admins")
-            Reason     = "User must be in Schema Admins to update Schema which is required."
+            Name   = "Schema Admins"
+            Role   = (Get-WellKnownGroupSid "Schema Admins")
+            Reason = "User must be in Schema Admins to update Schema which is required."
         }
     }
 
     if ($PrepareAdRequired) {
         $groupRequirements += @{
-            Name       = "Enterprise Admins"
-            RoleString = (Get-WellKnownGroupSid "Enterprise Admins")
-            Reason     = "User must be Enterprise Admins to do PrepareSchema or PrepareAD."
+            Name   = "Enterprise Admins"
+            Role   = (Get-WellKnownGroupSid "Enterprise Admins")
+            Reason = "User must be Enterprise Admins to do PrepareSchema or PrepareAD."
         }
 
         $groupRequirements += @{
-            Name       = "Domain Admins"
-            RoleString = (Get-WellKnownGroupSid "Domain Admins")
-            Reason     = "User must be in Domain Admins to do PrepareAD which is required."
+            Name   = "Domain Admins"
+            Role   = (Get-WellKnownGroupSid "Domain Admins")
+            Reason = "User must be in Domain Admins to do PrepareAD which is required."
         }
     }
 
     $principal = (New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent()))
 
     foreach ($group in $groupRequirements) {
-        if ($principal.IsInRole($group.RoleString)) {
-            $params.Details = "$($group.Name) $($group.RoleString)"
+        if ($principal.IsInRole($group.Role)) {
+            $params.Details = "$($group.Name) $($group.Role)"
             New-TestResult @params -Result "Passed"
         } else {
             New-TestResult @params -Result "Failed" -ReferenceInfo $group.Reason

--- a/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Confirm-Administrator.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-WellKnownGroupSid.ps1
 . $PSScriptRoot\..\New-TestResult.ps1
 Function Test-UserGroupMemberOf {
     [CmdletBinding()]
@@ -9,42 +10,6 @@ Function Test-UserGroupMemberOf {
         [bool]$PrepareAdRequired,
         [bool]$PrepareSchemaRequired
     )
-
-    function GetGroupMatches($whoamiOutput, $groupName) {
-        $m = @($whoamiOutput | Select-String "(^\w+\\$($groupName))\s+")
-        if ($m.Count -eq 0) { return $m }
-        return $m | ForEach-Object {
-            [PSCustomObject]@{
-                GroupName = ($_.Matches.Groups[1].Value)
-                SID       = (GetSidFromLine $_.Line)
-            }
-        }
-    }
-
-    Function GetSidFromLine ([string]$Line) {
-        $startIndex = $Line.IndexOf("S-")
-        return $Line.Substring($startIndex,
-            $Line.IndexOf(" ", $startIndex) - $startIndex)
-    }
-
-    Function TestGroupResult($WhoamiOutput, $GroupName) {
-        [array]$g = GetGroupMatches $WhoamiOutput $GroupName
-        $params = @{
-            TestName = $GroupName
-            Details  = "Not a member of the $GroupName Group"
-        }
-
-        if ($g.Count -gt 0) {
-            $params.Details = "$($g.GroupName) $($g.SID)"
-            New-TestResult @params -Result "Passed"
-        } elseif ($GroupName -eq "Schema Admins") {
-            New-TestResult @params -Result "Failed" -ReferenceInfo "User must be in Schema Admins to update Schema which is required."
-        } elseif ($GroupName -eq "Enterprise Admins") {
-            New-TestResult @params -Result "Failed" -ReferenceInfo "User must be Enterprise Admins to do PrepareSchema or PrepareAD"
-        } else {
-            New-TestResult @params -Result "Failed"
-        }
-    }
 
     $whoami = whoami
     $whoamiAllOutput = whoami /all
@@ -61,15 +26,44 @@ Function Test-UserGroupMemberOf {
         New-TestResult @params -Result "Failed"
     }
 
-    TestGroupResult $whoamiAllOutput "Organization Management"
+    $groupRequirements = @(
+        @{
+            Name       = "Organization Management"
+            RoleString = "Organization Management"
+            Reason     = "User must be in the Organization Management Group"
+        }
+    )
 
     if ($PrepareSchemaRequired) {
-        TestGroupResult $whoamiAllOutput "Schema Admins"
+        $groupRequirements += @{
+            Name       = "Schema Admins"
+            RoleString = (Get-WellKnownGroupSid "Schema Admins")
+            Reason     = "User must be in Schema Admins to update Schema which is required."
+        }
     }
 
     if ($PrepareAdRequired) {
-        TestGroupResult $whoamiAllOutput "Domain Admins"
-        TestGroupResult $whoamiAllOutput "Enterprise Admins"
+        $groupRequirements += @{
+            Name       = "Enterprise Admins"
+            RoleString = (Get-WellKnownGroupSid "Enterprise Admins")
+            Reason     = "User must be Enterprise Admins to do PrepareSchema or PrepareAD."
+        }
+
+        $groupRequirements += @{
+            Name       = "Domain Admins"
+            RoleString = (Get-WellKnownGroupSid "Domain Admins")
+            Reason     = "User must be in Domain Admins to do PrepareAD which is required."
+        }
+    }
+
+    $principal = (New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent()))
+
+    foreach ($group in $groupRequirements) {
+        if ($principal.IsInRole($group.RoleString)) {
+            $params.Details = "$($group.Name) $($group.RoleString)"
+            New-TestResult @params -Result "Passed"
+        } else {
+            New-TestResult @params -Result "Failed" -ReferenceInfo $group.Reason
+        }
     }
 }
-

--- a/Shared/Get-WellKnownGroupSid.ps1
+++ b/Shared/Get-WellKnownGroupSid.ps1
@@ -3,7 +3,7 @@
 
 <#
 .SYNOPSIS
-    Returns the SID of the desired group in string format.
+    Returns the SID of the desired group.
 .DESCRIPTION
     Long description
 .EXAMPLE
@@ -21,7 +21,7 @@
 #>
 function Get-WellKnownGroupSid {
     [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([System.Security.Principal.SecurityIdentifier])]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateSet("Enterprise Admins", "Schema Admins", "Domain Admins")]
@@ -39,13 +39,13 @@ function Get-WellKnownGroupSid {
 
     switch ($GroupType) {
         "Enterprise Admins" {
-            return "${rootDomainSid}-519"
+            return New-Object System.Security.Principal.SecurityIdentifier("${rootDomainSid}-519")
         }
         "Schema Admins" {
-            return "${rootDomainSid}-518"
+            return New-Object System.Security.Principal.SecurityIdentifier("${rootDomainSid}-518")
         }
         "Domain Admins" {
-            return "${computerDomainSid}-512"
+            return New-Object System.Security.Principal.SecurityIdentifier("${computerDomainSid}-512")
         }
     }
 }

--- a/Shared/Get-WellKnownGroupSid.ps1
+++ b/Shared/Get-WellKnownGroupSid.ps1
@@ -1,0 +1,51 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Returns the SID of the desired group in string format.
+.DESCRIPTION
+    Long description
+.EXAMPLE
+    PS C:\> Get-WellKnownGroupSid -GroupType "Enterprise Admins"
+
+    Returns the SID of the Enterprise Admins group.
+.EXAMPLE
+    PS C:\> Get-WellKnownGroupSid -GroupType "Schema Admins"
+
+    Returns the SID of the Schema Admins group.
+.EXAMPLE
+    PS C:\> Get-WellKnownGroupSid -GroupType "Domain Admins"
+
+    Returns the SID of the Domain Admins group from the domain that the current computer is in.
+#>
+function Get-WellKnownGroupSid {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Enterprise Admins", "Schema Admins", "Domain Admins")]
+        [string]
+        $GroupType
+    )
+
+    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+
+    $rootDomainSidBytes = [byte[]] $forest.RootDomain.GetDirectoryEntry().Properties["objectSid"][0]
+    $rootDomainSid = New-Object System.Security.Principal.SecurityIdentifier($rootDomainSidBytes, 0)
+
+    $computerDomainSidBytes = [byte[]] [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().GetDirectoryEntry().Properties["objectSid"][0]
+    $computerDomainSid = New-Object System.Security.Principal.SecurityIdentifier($computerDomainSidBytes, 0)
+
+    switch ($GroupType) {
+        "Enterprise Admins" {
+            return "${rootDomainSid}-519"
+        }
+        "Schema Admins" {
+            return "${rootDomainSid}-518"
+        }
+        "Domain Admins" {
+            return "${computerDomainSid}-512"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1006.

* Add a helper function to retrieve the SIDs of well-known AD groups such as Enterprise Admins and Schema Admins.
* Change SetupAssist to use IsInRole rather than parsing the whoami output. We _could_ continue parsing the whoami and look for the SIDs, but IsInRole seems like a cleaner way to do this.

Note that Get-WellKnownGroupSid returns the SID for the Domain Admins group which resides in the domain that the computer is joined to. Is there a scenario where we would want a different Domain Admins SID?

I tested the helper function on a Spanish forest and it works, but I don't have Exchange installed in this forest to do a full test:

```powershell
PS C:\> Get-WellKnownGroupSid "Enterprise Admins"
S-1-5-21-26643861-2199645782-2938786794-519
PS C:\> (New-Object System.Security.Principal.SecurityIdentifier(Get-WellKnownGroupSid "Enterprise Admins")).Translate([System.Security.Principal.NTAccount])

Value
-----
ESDOM\Administradores de empresas
```

Example CSV output in the successful case:

![image](https://user-images.githubusercontent.com/4518572/167492453-36944d2e-774b-4935-8329-f7b6d76f2ad8.png)
