### PR TITLE
Move some AD calls into shared code

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
@@ -1,6 +1,8 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\..\..\..\Shared\ActiveDirectoryFunctions\Get-OrganizationContainer.ps1
+
 Function Get-VirtualDirectoriesLdap {
 
     $authTypeEnum = @"
@@ -34,12 +36,9 @@ Function Get-VirtualDirectoriesLdap {
     Write-Host "Collecting Virtual Directory Information..."
     Add-Type -TypeDefinition $authTypeEnum -Language CSharp
 
-    $objRootDSE = [ADSI]"LDAP://rootDSE"
-    $strConfigurationNC = $objRootDSE.configurationNamingContext
-    $objConfigurationNC = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$strConfigurationNC")
     $searcher = New-Object DirectoryServices.DirectorySearcher
     $searcher.filter = "(&(objectClass=msExchVirtualDirectory)(!objectClass=container))"
-    $searcher.SearchRoot = $objConfigurationNC
+    $searcher.SearchRoot = Get-OrganizationContainer
     $searcher.CacheResults = $false
     $searcher.SearchScope = "Subtree"
     $searcher.PageSize = 1000

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -130,10 +130,12 @@ Function Get-ExchangeAdPermissions {
                             Write-Verbose "ObjectDN: $objectDN"
 
                             # We need to pass an IdentityReference object to the constructor
+                            $groupIdentityRef = New-Object System.Security.Principal.SecurityIdentifier($group.Sid)
+
                             if ($entry.ComputerClass) {
-                                $ace = New-Object System.DirectoryServices.ActiveDirectoryAccessRule([System.Security.Principal.SecurityIdentifier]::new($group.Sid), $writePropertyRight, $denyType, $entry.ObjectTypeGuid, $inheritanceAll, $computerClassSID)
+                                $ace = New-Object System.DirectoryServices.ActiveDirectoryAccessRule($groupIdentityRef, $writePropertyRight, $denyType, $entry.ObjectTypeGuid, $inheritanceAll, $computerClassSID)
                             } else {
-                                $ace = New-Object System.DirectoryServices.ActiveDirectoryAccessRule([System.Security.Principal.SecurityIdentifier]::new($group.Sid), $writePropertyRight, $denyType, $entry.ObjectTypeGuid, $inheritanceAll)
+                                $ace = New-Object System.DirectoryServices.ActiveDirectoryAccessRule($groupIdentityRef, $writePropertyRight, $denyType, $entry.ObjectTypeGuid, $inheritanceAll)
                             }
 
                             $checkAce = $objectAcl.Access.Where({

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -103,7 +103,7 @@ Function Get-ExchangeAdPermissions {
         $adminSdHolderDN = "CN=AdminSDHolder,CN=System,$domainDN"
         $prepareDomainInfo = Get-ExchangeDomainConfigVersion -Domain $domainName
 
-        if ($null -ne $prepareDomainInfo.ObjectVersion) {
+        if ($prepareDomainInfo.DomainPreparedForExchange) {
             Write-Verbose "Working on Domain: $domainName"
             Write-Verbose "MESO object version is: $($prepareDomainInfo.ObjectVersion)"
             Write-Verbose "DomainDN: $domainDN"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -57,19 +57,17 @@ Function Get-ExchangeAdPermissions {
 
     $groupLists = @(
         (NewGroupEntry "Exchange Trusted Subsystem" @(
-            (NewMatchingEntry -ObjectTypeGuid $userCertificateSID -AdminSdHolder $true -ComputerClass $false -RootOnly $false),
             (NewMatchingEntry -ObjectTypeGuid $altSecIdentitySchemaGUID -AdminSdHolder $false -ComputerClass $true -RootOnly $false),
-            (NewMatchingEntry -ObjectTypeGuid $altSecIdentitySchemaGUID -AdminSdHolder $true -ComputerClass $false -RootOnly $true)
+            (NewMatchingEntry -ObjectTypeGuid $altSecIdentitySchemaGUID -AdminSdHolder $true -ComputerClass $true -RootOnly $false)
         )),
 
         (NewGroupEntry "Exchange Servers" @(
-            (NewMatchingEntry -ObjectTypeGuid $userCertificateSID -AdminSdHolder $false -ComputerClass $true -RootOnly $true),
-            # ComputerClass should be false, but is set to true right now - need to do some more investigation here
+            (NewMatchingEntry -ObjectTypeGuid $userCertificateSID -AdminSdHolder $false -ComputerClass $true -RootOnly $false),
             (NewMatchingEntry -ObjectTypeGuid $userCertificateSID -AdminSdHolder $true -ComputerClass $true -RootOnly $false)
         )),
 
         (NewGroupEntry "Exchange Windows Permissions" @(
-            (NewMatchingEntry -ObjectTypeGuid $managedBySID -AdminSdHolder $false -ComputerClass $true -RootOnly $true)
+            (NewMatchingEntry -ObjectTypeGuid $managedBySID -AdminSdHolder $false -ComputerClass $true -RootOnly $false)
         )))
 
     $returnedResults = New-Object 'System.Collections.Generic.List[object]'

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
@@ -21,7 +21,11 @@ Function Get-ExchangeDomainConfigVersion {
         $domainDN = $domainObject.GetDirectoryEntry().distinguishedName
         $adEntry = [ADSI]("LDAP://CN=Microsoft Exchange System Objects," + $domainDN)
         $sdFinder = New-Object System.DirectoryServices.DirectorySearcher($adEntry)
-        $mesoResult = $sdFinder.FindOne()
+        try {
+            $mesoResult = $sdFinder.FindOne()
+        } catch {
+            Write-Verbose "No result was returned"
+        }
 
         if ($null -ne $mesoResult) {
             Write-Verbose "MESO (Microsoft Exchange System Objects) container detected"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
@@ -1,15 +1,22 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
+
 Function Get-ExchangeDomainConfigVersion {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]
         $Domain
     )
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+    if ([System.String]::IsNullOrEmpty($Domain)) {
+        Write-Verbose "No domain information passed - using current domain"
+        $Domain = ([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()).Name
+    }
 
     Write-Verbose "Getting domain information for domain: $Domain"
     $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
@@ -25,6 +32,7 @@ Function Get-ExchangeDomainConfigVersion {
             $mesoResult = $sdFinder.FindOne()
         } catch {
             Write-Verbose "No result was returned"
+            Invoke-CatchActions
         }
 
         if ($null -ne $mesoResult) {

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
@@ -1,0 +1,43 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Function Get-ExchangeDomainConfigVersion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Domain
+    )
+
+    Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+    Write-Verbose "Getting domain information for domain: $Domain"
+    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+
+    Write-Verbose "Checking if domain is present"
+    if ($forest.Domains.Name.Contains($Domain)) {
+        Write-Verbose "Domain: $Domain is present in forest: $($forest.Name)"
+        $domainObject = $forest.Domains | Where-Object { $_.Name -eq $Domain }
+        $domainDN = $domainObject.GetDirectoryEntry().distinguishedName
+        $adEntry = [ADSI]("LDAP://CN=Microsoft Exchange System Objects," + $domainDN)
+        $sdFinder = New-Object System.DirectoryServices.DirectorySearcher($adEntry)
+        $mesoResult = $sdFinder.FindOne()
+
+        if ($null -ne $mesoResult) {
+            Write-Verbose "MESO (Microsoft Exchange System Objects) container detected"
+            $objectVersion = $mesoResult.Properties.objectversion
+            $whenChangedInfo = $mesoResult.Properties.whenchanged
+        } else {
+            Write-Verbose "No MESO (Microsoft Exchange System Objects) container detected"
+        }
+    } else {
+        Write-Verbose "Domain: $Domain is NOT present in forest: $($forest.Name)"
+    }
+
+    return [PSCustomObject]@{
+        Domain                    = $Domain
+        DomainPreparedForExchange = ($mesoResult.Count -gt 0)
+        ObjectVersion             = $objectVersion
+        WhenChanged               = $whenChangedInfo
+    }
+}

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
@@ -2,16 +2,14 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-TestResult.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-OrganizationContainer.ps1
+
 Function Test-DomainMultiActiveSyncVirtualDirectories {
     $params = @{
         TestName = "Multiple Active Sync Vdirs Detected"
     }
-    $rootDSE = [ADSI]("LDAP://RootDSE")
-    $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
-    $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
-    $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=msExchOrganizationContainer)", @("distinguishedName"))
-    $result = $searcher.FindOne()
-    $orgDN = $result.Properties["distinguishedName"]
+    $orgContainer = Get-OrganizationContainer
+    $orgDN = $orgContainer.Properties["distinguishedName"]
     $containerPath = [ADSI]("LDAP://CN=$env:ComputerName,CN=Servers,CN=Exchange administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,$orgDN")
     $searcher = New-Object System.DirectoryServices.DirectorySearcher($containerPath, "(objectClass=msExchMobileVirtualDirectory)", @("distinguishedName"))
     $result = $searcher.FindAll()

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-TestResult.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeContainer.ps1
+
 Function Test-DomainOtherWellKnownObjects {
-    $rootDSE = [ADSI]("LDAP://RootDSE")
-    $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
-    $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
+    $exchangeContainer = Get-ExchangeContainer
     $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=*)", @("otherWellKnownObjects", "distinguishedName"))
     $result = $searcher.FindOne()
 

--- a/Setup/SetupAssist/Checks/Domain/Test-ValidHomeMdb.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ValidHomeMdb.ps1
@@ -2,19 +2,18 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-TestResult.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Search-AllActiveDirectoryDomains.ps1
+
 Function Test-ValidHomeMDB {
     $testName = "Valid Home MDB"
-    $rootDSE = [ADSI]("LDAP://RootDSE")
-    $container = [ADSI]("GC://$($rootDSE.dnsHostName)")
     $arbitration = 0x800000
     $discovery = 0x20000000
     $publicFolder = 0x1000000000
     $recipientTypes = $arbitration -bor $discovery -bor $publicFolder
-    $searcher = New-Object System.DirectoryServices.DirectorySearcher($container,
-        "(&(objectClass=user)(mailnickname=*)(msExchRecipientTypeDetails:1.2.840.113556.1.4.804:=$recipientTypes))",
-        @("distinguishedName", "homeMDB"))
+    $filter = "(&(objectClass=user)(mailnickname=*)(msExchRecipientTypeDetails:1.2.840.113556.1.4.804:=$recipientTypes))"
+    $propsToLoad = @("distinguishedName", "homeMDB")
 
-    $results = $searcher.FindAll()
+    $results = Search-AllActiveDirectoryDomains -Filter $filter -PropertiesToLoad $propsToLoad
 
     if ($null -ne $results -and
         $results.Count -gt 0) {

--- a/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-TestResult.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-OrganizationContainer.ps1
 
 function Test-VirtualDirectoryConfiguration {
     [CmdletBinding()]
@@ -46,9 +47,7 @@ function Test-VirtualDirectoryConfiguration {
 
         $searcher = $null
         try {
-            $configDN = ([ADSI]("LDAP://RootDSE")).Properties["configurationNamingContext"][0].ToString()
-            $exchangeDN = "CN=Microsoft Exchange,CN=Services,$configDN"
-            $exchangeContainer = [ADSI]("LDAP://$exchangeDN")
+            $exchangeContainer = Get-ExchangeContainer
             $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer)
         } catch {
             New-TestResult @resultParams -Result "Failed" -Details "Failed to find Exchange configuration object."

--- a/Shared/ActiveDirectoryFunctions/Get-ActiveDirectoryAcl.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ActiveDirectoryAcl.ps1
@@ -1,0 +1,20 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-ActiveDirectoryAcl {
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.ActiveDirectorySecurity])]
+    param (
+        [Parameter()]
+        [string]
+        $DistinguishedName
+    )
+
+    $adEntry = [ADSI]("LDAP://$($DistinguishedName)")
+    $sdFinder = New-Object System.DirectoryServices.DirectorySearcher($adEntry, "(objectClass=*)", [string[]]("distinguishedName", "ntSecurityDescriptor"), [System.DirectoryServices.SearchScope]::Base)
+    $sdResult = $sdFinder.FindOne()
+    $ntsdProp = $sdResult.Properties["ntSecurityDescriptor"][0]
+    $adSec = New-Object System.DirectoryServices.ActiveDirectorySecurity
+    $adSec.SetSecurityDescriptorBinaryForm($ntsdProp)
+    return $adSec
+}

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
@@ -1,0 +1,13 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-ExchangeContainer {
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.DirectoryEntry])]
+    param ()
+
+    $rootDSE = [ADSI]("LDAP://RootDSE")
+    $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
+    $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
+    return $exchangeContainer
+}

--- a/Shared/ActiveDirectoryFunctions/Get-OrganizationContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-OrganizationContainer.ps1
@@ -1,0 +1,14 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Get-ExchangeContainer.ps1
+
+function Get-OrganizationContainer {
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.DirectoryEntry])]
+    param ()
+
+    $exchangeContainer = Get-ExchangeContainer
+    $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=msExchOrganizationContainer)", @("distinguishedName"))
+    return $searcher.FindOne().GetDirectoryEntry()
+}

--- a/Shared/ActiveDirectoryFunctions/Search-AllActiveDirectoryDomains.ps1
+++ b/Shared/ActiveDirectoryFunctions/Search-AllActiveDirectoryDomains.ps1
@@ -1,0 +1,33 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Search-AllActiveDirectoryDomains {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Filter,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $PropertiesToLoad,
+
+        [Parameter()]
+        [bool]
+        $CacheResults = $false
+    )
+
+    $rootDSE = [ADSI]("GC://RootDSE")
+    $container = [ADSI]("GC://$($rootDSE.dnsHostName)")
+    $searcher = $null
+    if ($null -ne $PropertiesToLoad) {
+        $searcher = New-Object System.DirectoryServices.DirectorySearcher($container, $Filter, $PropertiesToLoad)
+    } else {
+        $searcher = New-Object System.DirectoryServices.DirectorySearcher($container, $Filter)
+    }
+
+    $searcher.PageSize = 1000
+    $searcher.CacheResults = $CacheResults
+
+    return $searcher.FindAll()
+}


### PR DESCRIPTION
* Add Get-ActiveDirectoryAcl for retrieving AD ACLs without
  depending on the ActiveDirectory module and PSDrive.
* Add Get-ExchangeContainer, Get-OrganizationContainer, and
  Search-AllActiveDirectoryDomains to remove repetitive code
  from various scripts.