### PR TITLE
Health Checker Improved logging for Error context

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -3,6 +3,25 @@
 
 Function Get-ErrorsThatOccurred {
 
+    Function WriteErrorInformation {
+        [CmdletBinding()]
+        param(
+            [object]$CurrentError
+        )
+        Write-Verbose "$($CurrentError.CategoryInfo.Activity) : $($CurrentError.ToString())"
+
+        if ($null -ne $CurrentError.Exception -and
+            $null -ne $CurrentError.Exception.StackTrace) {
+            Write-Verbose "Inner Exception: $($CurrentError.Exception.StackTrace)"
+        }
+
+        if ($null -ne $CurrentError.ScriptStackTrace) {
+            Write-Verbose "Script Stack: $($CurrentError.ScriptStackTrace)"
+        }
+
+        Write-Verbose "-----------------------------------`r`n`r`n"
+    }
+
     if ($Error.Count -gt 0) {
         Write-Grey(" "); Write-Grey(" ")
         Function Write-Errors {
@@ -18,12 +37,7 @@ Function Get-ErrorsThatOccurred {
 
                         if ($null -eq $handledError) {
                             Write-Verbose "Error Index: $index"
-                            Write-Verbose $currentError
-
-                            if ($null -ne $currentError.ScriptStackTrace) {
-                                Write-Verbose $currentError.ScriptStackTrace
-                            }
-                            Write-Verbose "-----------------------------------`r`n`r`n"
+                            WriteErrorInformation $currentError
                         }
                     }
 
@@ -38,12 +52,7 @@ Function Get-ErrorsThatOccurred {
 
                         if ($null -ne $handledError) {
                             Write-Verbose "Error Index: $index"
-                            Write-Verbose $handledError
-
-                            if ($null -ne $handledError.ScriptStackTrace) {
-                                Write-Verbose $handledError.ScriptStackTrace
-                            }
-                            Write-Verbose "-----------------------------------`r`n`r`n"
+                            WriteErrorInformation $handledError
                         }
                     }
         }


### PR DESCRIPTION
**Issue:**
While you can still determine the cause most of the time, it is made clearer if we can pull more information out of the errors that we do and do not handle. 

**Reason:**
Changing the log output from something like this: 

![image](https://user-images.githubusercontent.com/22776718/167753446-c7e6982e-d5ac-42a3-be9c-bb6ea9ec8782.png)
![image](https://user-images.githubusercontent.com/22776718/167753513-5b3f7a87-9416-45f0-849a-c7df97c84fb1.png)


To this: 

![image](https://user-images.githubusercontent.com/22776718/167753664-34f0b6c1-c064-4770-b444-cf4d47198003.png)
![image](https://user-images.githubusercontent.com/22776718/167753741-a0e833f6-0bb9-4d45-a118-8a0299c4139c.png)

Quicker to see the cause was when calling `Remove-PSDrive` for the issue. 

**Fix:**
Pull out Cmdlet information and inner exception stack if any is present. 

**Validation:**
Lab tested. 

