### PR TITLE
Check CU has fixed CVE-2021-1730

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-1730.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-1730.ps1
@@ -21,9 +21,11 @@ Function Invoke-AnalyzerSecurityCve-2021-1730 {
     #Workaround: N/A
 
     if (((($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) -and
-                ($SecurityObject.CU -ge [HealthChecker.ExchangeCULevel]::CU18)) -or
+                ($SecurityObject.CU -ge [HealthChecker.ExchangeCULevel]::CU18) -and
+                ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU23)) -or
             (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) -and
-                ($SecurityObject.CU -ge [HealthChecker.ExchangeCULevel]::CU7))) -and
+                ($SecurityObject.CU -ge [HealthChecker.ExchangeCULevel]::CU7) -and
+                ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU12))) -and
         $SecurityObject.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) {
 
         $downloadDomainsEnabled = $SecurityObject.ExchangeInformation.EnableDownloadDomains


### PR DESCRIPTION
**Issue:**
CVE-2021-1730 was fixed in CU12(2019) or CU23(2016) but the script shows an alert with those versions and newer.

**Reason:**
Avoid confusions.

**Fix:**
include the new version in the verification of the vulnerability.

**Validation:**


