### PR TITLE
Exchange Log Collector Changes

### DIFF
--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
@@ -2,103 +2,111 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Copy-BulkItems.ps1
+<#
+    Copy Log Directory Based Off Time.
+    The IncludeSubDirectory bool set to false should only be use if we don't want to include sub directories
+    Otherwise, in each sub directory try to collect logs based off the TimeSpan.
+    If there is a directory that doesn't contain logs within the TimeSpan,
+    Collect the latest log or provide there is no logs in the directory
+#>
 Function Copy-LogsBasedOnTime {
     param(
-        [Parameter(Mandatory = $false)][string]$LogPath,
-        [Parameter(Mandatory = $true)][string]$CopyToThisLocation
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [Parameter(Mandatory = $true)][string]$CopyToThisLocation,
+        [Parameter(Mandatory = $true)][bool]$IncludeSubDirectory
     )
-    Write-Verbose("Function Enter: Copy-LogsBasedOnTime")
-    Write-Verbose("Passed: [string]LogPath: {0} | [string]CopyToThisLocation: {1}" -f $LogPath, $CopyToThisLocation)
+    begin {
+        Function NoFilesInLocation {
+            param(
+                [string]$Value = "No data in the location"
+            )
+            $line = "It doesn't look like you have any data in this location $LogPath."
 
-    if ([string]::IsNullOrEmpty($LogPath)) {
-        Write-Verbose("Failed to provide a valid log path to copy.")
-        return
-    }
+            if (-not ($IncludeSubDirectory)) {
+                Write-Host $line -ForegroundColor "Yellow"
+            } else {
+                Write-Verbose $line
+            }
 
-    New-Item -ItemType Directory -Path $CopyToThisLocation -Force | Out-Null
-
-    Function NoFilesInLocation {
-        param(
-            [Parameter(Mandatory = $true)][string]$CopyFromLocation,
-            [Parameter(Mandatory = $true)][string]$CopyToLocation
-        )
-        Write-Host "It doesn't look like you have any data in this location $CopyFromLocation." -ForegroundColor "Yellow"
-        #Going to place a file in this location so we know what happened
-        $tempFile = $CopyToLocation + "\NoFilesDetected.txt"
-        New-Item $tempFile -ItemType File -Value $LogPath | Out-Null
-        Start-Sleep 1
-    }
-
-    $copyFromDate = [DateTime]::Now - $PassedInfo.TimeSpan
-    Write-Verbose("Copy From Date: {0}" -f $copyFromDate)
-    $skipCopy = $false
-    if (!(Test-Path $LogPath)) {
-        #if the directory isn't there, we need to handle it
-        NoFilesInLocation -CopyFromLocation $LogPath -CopyToLocation $CopyToThisLocation
-        Write-Verbose("Function Exit: Copy-LogsBasedOnTime")
-        return
-    }
-    #We are not copying files recurse so we need to not include possible directories or we will throw an error
-    $files = Get-ChildItem $LogPath | Sort-Object LastWriteTime -Descending | Where-Object { $_.LastWriteTime -ge $copyFromDate -and $_.Mode -notlike "d*" }
-    #if we don't have any logs, we want to attempt to copy something
-
-    if ($null -eq $files) {
-        <#
-                There are a few different reasons to get here
-                1. We don't have any files in the timeframe request in the directory that we are looking at
-                2. We have sub directories that we need to look into and look at those files (Only if we don't have files in the currently location so we aren't pulling files like the index files from message tracking)
-            #>
-        Write-Verbose("Copy-LogsBasedOnTime: Failed to find any logs in the directory provided, need to do a deeper look to find some logs that we want.")
-        $allFiles = Get-ChildItem $LogPath | Sort-Object LastWriteTime -Descending
-        Write-Verbose("Displaying all items in the directory: {0}" -f $LogPath)
-        foreach ($file in $allFiles) {
-            Write-Verbose("File Name: {0} Last Write Time: {1}" -f $file.Name, $file.LastWriteTime)
+            $params = @{
+                Path     = "$CopyToThisLocation\NoFilesDetected.txt"
+                ItemType = "File"
+                Value    = $( "Location: $LogPath`r`n$Value" )
+            }
+            New-Item @params | Out-Null
         }
 
-        #Let's see if we have any files in this location while having directories
-        $directories = $allFiles | Where-Object { $_.Mode -like "d*" }
-        $filesInDirectory = $allFiles | Where-Object { $_.Mode -notlike "d*" }
+        Function CopyItemsFromDirectory {
+            param(
+                [object]$AllItems,
+                [string]$CopyToLocation
+            )
 
-        if (($null -ne $directories) -and
-            ($null -ne $filesInDirectory)) {
-            #This means we should be looking in the sub directories not the current directory so let's re-do that logic to try to find files in that timeframe.
-            foreach ($dir in $directories) {
-                $newLogPath = $dir.FullName
-                $newCopyToThisLocation = "{0}\{1}" -f $CopyToThisLocation, $dir.Name
-                New-Item -ItemType Directory -Path $newCopyToThisLocation -Force | Out-Null
-                $files = Get-ChildItem $newLogPath | Sort-Object LastWriteTime -Descending | Where-Object { $_.LastWriteTime -ge $copyFromDate -and $_.Mode -notlike "d*" }
+            if ($null -eq $AllItems) {
+                Write-Verbose "No items were found in the directory."
+                NoFilesInLocation
+            } else {
+                $timeRangeFiles = $AllItems | Where-Object { $_.LastWriteTime -ge $copyFromDate }
 
-                if ($null -eq $files) {
-                    NoFilesInLocation -CopyFromLocation $newLogPath -CopyToLocation $newCopyToThisLocation
+                if ($null -eq $timeRangeFiles) {
+                    Write-Verbose "no files found in the range. Getting the last file."
+                    Copy-BulkItems -CopyToLocation $CopyToLocation -ItemsToCopyLocation $AllItems[0].FullName
                 } else {
-                    Write-Verbose("Found {0} number of files at the location {1}" -f $files.Count, $newLogPath)
-                    $filesFullPath = @()
-                    $files | ForEach-Object { $filesFullPath += $_.VersionInfo.FileName }
-                    Copy-BulkItems -CopyToLocation $newCopyToThisLocation -ItemsToCopyLocation $filesFullPath
-                    Invoke-ZipFolder -Folder $newCopyToThisLocation
+                    Write-Verbose "Found files within the time range."
+                    $timeRangeFiles | ForEach-Object { Write-Verbose "$($_.FullName)" }
+                    $copyItemPaths = $timeRangeFiles | ForEach-Object { $_.FullName }
+                    Copy-BulkItems -CopyToLocation $CopyToLocation -ItemsToCopyLocation $copyItemPaths
                 }
+                Invoke-ZipFolder -Folder $CopyToLocation
             }
-            Write-Verbose("Function Exit: Copy-LogsBasedOnTime")
+        }
+
+        Write-Verbose "Function Enter: $($MyInvocation.MyCommand)"
+        Write-Verbose "LogPath: '$LogPath' | CopyToThisLocation: '$CopyToThisLocation'"
+        $copyFromDate = [DateTime]::Now - $PassedInfo.TimeSpan
+
+        if (-not (Test-Path $LogPath)) {
+            # If the directory isn't there, provide that
+            Write-Verbose "$LogPath doesn't exist"
+            NoFilesInLocation "Path doesn't exist"
             return
         }
+    }
+    process {
+        New-Item -ItemType Directory -Path $CopyToThisLocation -Force | Out-Null
+        Write-Verbose "Copy From Date: $copyFromDate"
 
-        #If we get here, we want to find the latest file that isn't a directory.
-        $files = $allFiles | Where-Object { $_.Mode -notlike "d*" } | Select-Object -First 1
+        if ($IncludeSubDirectory) {
+            $getChildItem = Get-ChildItem -Path $LogPath -Recurse
+            [array]$directories = Get-Item -Path $LogPath
+            $directories += @($getChildItem |
+                    Where-Object {
+                        $_.Mode -like "d*"
+                    })
 
-        #If we are still null, we want to let them know
-        if ($null -eq $files) {
-            $skipCopy = $true
-            NoFilesInLocation -CopyFromLocation $LogPath -CopyToLocation $CopyToThisLocation
+            # Map and find all the items per directory
+            foreach ($directory in $directories) {
+
+                Write-Verbose "Working on finding items for directory $($directory.FullName)"
+                if ($directory.FullName -eq $LogPath) {
+                    $newCopyToThisLocation = $CopyToThisLocation
+                } else {
+                    $newCopyToThisLocation = "$CopyToThisLocation\$($directory.Name)"
+                    New-Item -ItemType Directory -Path $newCopyToThisLocation -Force | Out-Null
+                }
+                # all the items that match this directory. Don't need to worry about directories because DirectoryName doesn't exist there.
+                $items = $getChildItem | Where-Object { $_.DirectoryName -eq $directory.FullName } | Sort-Object LastWriteTime -Descending
+                CopyItemsFromDirectory -AllItems $items -CopyToLocation $newCopyToThisLocation
+            }
+        } else {
+            $getChildItem = Get-ChildItem -Path $LogPath |
+                Sort-Object LastWriteTime -Descending |
+                Where-Object { $_.Mode -notlike "d*" }
+
+            CopyItemsFromDirectory -AllItems $getChildItem -CopyToLocation $CopyToThisLocation
         }
     }
-    Write-Verbose("Found {0} number of files at the location {1}" -f $Files.Count, $LogPath)
-    #ResetFiles to full path
-    $filesFullPath = @()
-    $files | ForEach-Object { $filesFullPath += $_.VersionInfo.FileName }
-
-    if (-not ($skipCopy)) {
-        Copy-BulkItems -CopyToLocation $CopyToThisLocation -ItemsToCopyLocation $filesFullPath
-        Invoke-ZipFolder -Folder $CopyToThisLocation
+    end {
+        Write-Verbose("Function Exit: $($MyInvocation.MyCommand)")
     }
-    Write-Verbose("Function Exit: Copy-LogsBasedOnTime")
 }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Save-DataInfoToFile.ps1
+. $PSScriptRoot\Save-RegistryHive.ps1
 . $PSScriptRoot\..\Get-ClusterNodeFileVersions.ps1
 #Save out the failover cluster information for the local node, besides the event logs.
 Function Save-FailoverClusterInformation {
@@ -60,16 +61,13 @@ Function Save-FailoverClusterInformation {
         Invoke-CatchBlockActions
     }
 
-    try {
-        $saveName = "$copyTo\ClusterHive.hiv"
-        reg save "HKEY_LOCAL_MACHINE\Cluster" $saveName | Out-Null
-        "To read the cluster hive. Run 'reg load HKLM\TempHive ClusterHive.hiv'. Then Open your regedit then go to HKLM:\TempHive to view the data." |
-            Out-File -FilePath "$copyTo\ClusterHive_HowToRead.txt"
-    } catch {
-        Write-Verbose "Failed to get the Cluster Hive"
-        Invoke-CatchBlockActions
+    $params = @{
+        RegistryPath    = "HKLM:Cluster"
+        SaveName        = "Cluster_Hive"
+        SaveToPath      = $copyTo
+        UseGetChildItem = $true
     }
-
+    Save-RegistryHive @params
     Invoke-ZipFolder -Folder $copyTo
     Write-Verbose "Function Exit: Save-FailoverClusterInformation"
 }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
@@ -1,0 +1,48 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Invoke-CatchBlockActions.ps1
+. $PSScriptRoot\Save-DataInfoToFile.ps1
+Function Save-RegistryHive {
+    [CmdletBinding()]
+    param(
+        [string]$RegistryPath,
+        [string]$SaveName,
+        [string]$SaveToPath,
+        [switch]$UseGetChildItem
+    )
+    Write-Verbose "Function Enter: $($MyInvocation.MyCommand)"
+
+    try {
+        if ($UseGetChildItem) {
+            $results = Get-ChildItem -Path $RegistryPath -Recurse -ErrorAction Stop
+        } else {
+            $results = Get-Item -Path $RegistryPath -ErrorAction Stop
+        }
+        Write-Verbose "Successfully got registry hive information for: $RegistryPath"
+        Save-DataInfoToFile -DataIn $results -SaveToLocation "$SaveToPath\$SaveName" -FormatList $false
+    } catch {
+        Write-Verbose "Failed to get registry hive for: $RegistryPath"
+        Invoke-CatchBlockActions
+    }
+
+    $updatedRegistryPath = $RegistryPath.Replace("HKLM:", "HKEY_LOCAL_MACHINE\")
+    $baseSaveName = Add-ServerNameToFileName "$SaveToPath\$SaveName"
+    try {
+        reg export $updatedRegistryPath "$baseSaveName.reg" | Out-Null
+
+        if ($LASTEXITCODE) {
+            Write-Verbose "Failed to export the registry hive for: $updatedRegistryPath"
+        }
+        reg save $updatedRegistryPath "$baseSaveName.hiv" | Out-Null
+
+        if ($LASTEXITCODE) {
+            Write-Verbose "Failed to save the registry hive for: $updatedRegistryPath"
+        }
+        "To read the registry hive. Run 'reg load HKLM\TempHive $SaveName.hiv'. Then Open your regedit then go to HKLM:\TempHive to view the data." |
+            Out-File -FilePath "$baseSaveName`_HowToRead.txt"
+    } catch {
+        Write-Verbose "failed to export/save the registry hive for: $updatedRegistryPath"
+        Invoke-CatchBlockActions
+    }
+}

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Save-DataInfoToFile.ps1
+. $PSScriptRoot\Save-RegistryHive.ps1
 . $PSScriptRoot\..\Add-ServerNameToFileName.ps1
 . $PSScriptRoot\..\Test-CommandExists.ps1
 Function Save-ServerInfoData {
@@ -16,31 +17,42 @@ Function Save-ServerInfoData {
         Start-Sleep 5;
     }
 
-    #Include TLS Registry Information #84
-    $tlsSettings = @()
-    try {
-        $tlsSettings += Get-ChildItem "HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols" -Recurse | Where-Object { $_.Name -like "*TLS*" } -ErrorAction stop
-    } catch {
-        Write-Verbose("Failed to get child items of 'HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols'")
-        Invoke-CatchBlockActions
+    $tlsRegistrySettingsName = "TLS_RegistrySettings"
+    $tlsProtocol = @{
+        RegistryPath    = "HKLM:SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
+        SaveName        = $tlsRegistrySettingsName
+        SaveToPath      = $copyTo
+        UseGetChildItem = $true
     }
-    try {
-        $regBaseV4 = "HKLM:SOFTWARE\{0}\.NETFramework\v4.0.30319"
-        $tlsSettings += Get-Item ($currentKey = $regBaseV4 -f "Microsoft") -ErrorAction stop
-        $tlsSettings += Get-Item ($currentKey = $regBaseV4 -f "Wow6432Node\Microsoft") -ErrorAction stop
-    } catch {
-        Write-Verbose("Failed to get child items of '{0}'" -f $currentKey)
-        Invoke-CatchBlockActions
+    Save-RegistryHive @tlsProtocol
+
+    $net4Protocol = @{
+        RegistryPath = "HKLM:SOFTWARE\Microsoft\.NETFramework\v4.0.30319"
+        SaveName     = "NET4_$tlsRegistrySettingsName"
+        SaveToPath   = $copyTo
     }
-    try {
-        $regBaseV2 = "HKLM:SOFTWARE\{0}\.NETFramework\v2.0.50727"
-        $tlsSettings += Get-Item ($currentKey = $regBaseV2 -f "Microsoft") -ErrorAction stop
-        $tlsSettings += Get-Item ($currentKey = $regBaseV2 -f "Wow6432Node\Microsoft") -ErrorAction stop
-    } catch {
-        Write-Verbose("Failed to get child items of '{0}'" -f $currentKey)
-        Invoke-CatchBlockActions
+    Save-RegistryHive @net4Protocol
+
+    $net4WowProtocol = @{
+        RegistryPath = "HKLM:SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319"
+        SaveName     = "NET4_Wow_$tlsRegistrySettingsName"
+        SaveToPath   = $copyTo
     }
-    Save-DataInfoToFile -DataIn $tlsSettings -SaveToLocation ("{0}\TLS_RegistrySettings" -f $copyTo) -FormatList $false
+    Save-RegistryHive @net4WowProtocol
+
+    $net2Protocol = @{
+        RegistryPath = "HKLM:SOFTWARE\Microsoft\.NETFramework\v2.0.50727"
+        SaveName     = "NET2_$tlsRegistrySettingsName"
+        SaveToPath   = $copyTo
+    }
+    Save-RegistryHive @net2Protocol
+
+    $net2WowProtocol = @{
+        RegistryPath = "HKLM:SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727"
+        SaveName     = "NET2_Wow_$tlsRegistrySettingsName"
+        SaveToPath   = $copyTo
+    }
+    Save-RegistryHive @net2WowProtocol
 
     #Running Processes #35
     Save-DataInfoToFile -dataIn (Get-Process) -SaveToLocation ("{0}\Running_Processes" -f $copyTo) -FormatList $false
@@ -76,15 +88,22 @@ Function Save-ServerInfoData {
     Save-DataInfoToFile -DataIn (TASKLIST /M) -SaveToLocation ("{0}\TaskList_Modules" -f $copyTo) -SaveXMLFile $false
 
     if (!$Script:localServerObject.Edge) {
-        $hiveKey = @()
-        try {
-            $hiveKey = Get-ChildItem HKLM:\SOFTWARE\Microsoft\Exchange\ -Recurse -ErrorAction Stop
-        } catch {
-            Write-Verbose("Failed to get child item on HKLM:\SOFTWARE\Microsoft\Exchange\")
-            Invoke-CatchBlockActions
+
+        $params = @{
+            RegistryPath    = "HKLM:\SOFTWARE\Microsoft\Exchange"
+            SaveName        = "Exchange_Registry_Hive"
+            SaveToPath      = $copyTo
+            UseGetChildItem = $true
         }
-        $hiveKey += Get-ChildItem HKLM:\SOFTWARE\Microsoft\ExchangeServer\ -Recurse
-        Save-DataInfoToFile -DataIn $hiveKey -SaveToLocation ("{0}\Exchange_Registry_Hive" -f $copyTo) -SaveTextFile $false
+        Save-RegistryHive @params
+
+        $params = @{
+            RegistryPath    = "HKLM:\SOFTWARE\Microsoft\ExchangeServer"
+            SaveName        = "ExchangeServer_Registry_Hive"
+            SaveToPath      = $copyTo
+            UseGetChildItem = $true
+        }
+        Save-RegistryHive @params
     }
 
     Save-DataInfoToFile -DataIn (gpresult /R /Z) -SaveToLocation ("{0}\GPResult" -f $copyTo) -SaveXMLFile $false

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -213,7 +213,7 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.MessageTrackingLogs -and
             (-not ($Script:localServerObject.Version -eq 15 -and
                 $Script:localServerObject.CASOnly))) {
-            Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.HubLoggingInfo.MessageTrackingLogPath "Message_Tracking_Logs"
+            Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.HubLoggingInfo.MessageTrackingLogPath "Message_Tracking_Logs" $false
         }
 
         if ($PassedInfo.HubProtocolLogs -and

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
@@ -24,6 +24,17 @@ Function NewLogCopyParameters {
     }
 }
 
+Function NewLogCopyBasedOffTimeParameters {
+    param(
+        [string]$LogPath,
+        [string]$CopyToThisLocation,
+        [bool]$IncludeSubDirectory
+    )
+    return (NewLogCopyParameters $LogPath $CopyToThisLocation) + @{
+        IncludeSubDirectory = $IncludeSubDirectory
+    }
+}
+
 Function GetTaskActionToString {
     [CmdletBinding()]
     [OutputType([string])]
@@ -49,11 +60,17 @@ Function Add-TaskAction {
 Function Add-LogCopyBasedOffTimeTaskAction {
     param(
         [string]$LogPath,
-        [string]$CopyToThisLocation
+        [string]$CopyToThisLocation,
+        [bool]$IncludeSubDirectory = $true
     )
+    $timeCopyParams = @{
+        LogPath             = $LogPath
+        CopyToThisLocation  = $CopyToThisLocation
+        IncludeSubDirectory = $IncludeSubDirectory
+    }
     $params = @{
         FunctionName = "Copy-LogsBasedOnTime"
-        Parameters   = (NewLogCopyParameters $LogPath $CopyToThisLocation)
+        Parameters   = (NewLogCopyBasedOffTimeParameters @timeCopyParams)
     }
     $Script:taskActionList.Add((NewTaskAction @params))
 }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
@@ -1,0 +1,83 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Function NewTaskAction {
+    [CmdletBinding()]
+    param(
+        [string]$FunctionName,
+        [object]$Parameters
+    )
+    return [PSCustomObject]@{
+        FunctionName = $FunctionName
+        Parameters   = $Parameters
+    }
+}
+
+Function NewLogCopyParameters {
+    param(
+        [string]$LogPath,
+        [string]$CopyToThisLocation
+    )
+    return @{
+        LogPath            = $LogPath
+        CopyToThisLocation = [System.IO.Path]::Combine($Script:RootCopyToDirectory, $CopyToThisLocation)
+    }
+}
+
+Function GetTaskActionToString {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [object]$TaskAction
+    )
+    $params = $TaskAction.Parameters
+    $line = "$($TaskAction.FunctionName)"
+
+    if ($null -ne $params) {
+        $line += " LogPath: '$($params.LogPath)' CopyToThisLocation: '$($params.CopyToThisLocation)'"
+    }
+    return $line
+}
+
+Function Add-TaskAction {
+    param(
+        [string]$FunctionName
+    )
+    $Script:taskActionList.Add((NewTaskAction $FunctionName))
+}
+
+Function Add-LogCopyBasedOffTimeTaskAction {
+    param(
+        [string]$LogPath,
+        [string]$CopyToThisLocation
+    )
+    $params = @{
+        FunctionName = "Copy-LogsBasedOnTime"
+        Parameters   = (NewLogCopyParameters $LogPath $CopyToThisLocation)
+    }
+    $Script:taskActionList.Add((NewTaskAction @params))
+}
+
+Function Add-LogCopyFullTaskAction {
+    param (
+        [string]$LogPath,
+        [string]$CopyToThisLocation
+    )
+    $params = @{
+        FunctionName = "Copy-FullLogFullPathRecurse"
+        Parameters   = (NewLogCopyParameters $LogPath $CopyToThisLocation)
+    }
+    $Script:taskActionList.Add((NewTaskAction @params))
+}
+
+Function Add-DefaultLogCopyTaskAction {
+    param(
+        [string]$LogPath,
+        [string]$CopyToThisLocation
+    )
+    if ($PassedInfo.CollectAllLogsBasedOnLogAge) {
+        Add-LogCopyBasedOffTimeTaskAction $LogPath $CopyToThisLocation
+    } else {
+        Add-LogCopyFullTaskAction $LogPath $CopyToThisLocation
+    }
+}


### PR DESCRIPTION
**Reason:**
Refactor some different code logic. 

- Removed using `Invoke-Expression` from being used. Now using `&` which is more secure. In order to do that, created some task objects to handle the logic. 
- Improved the code logic for `Copy-LogsBasedOnTime`. Make sure that we handle all the correct scenarios.
- Handle exporting the values from the registry all the same way. Created a function to call that handles everything the same way. This does the export a few different ways.

**Validation:**
Lab tested.

