### PR TITLE
Don't execute Get-ExchangeADPermissions on Edge

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-21978.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-21978.ps1
@@ -29,7 +29,8 @@ Function Invoke-AnalyzerSecurityCve-2022-21978 {
     if ((($SecurityObject.MajorVersion -le [HealthChecker.ExchangeMajorVersion]::Exchange2016) -and
             ($SecurityObject.CU -le [HealthChecker.ExchangeCULevel]::CU23)) -or
         (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) -and
-            ($SecurityObject.CU -le [HealthChecker.ExchangeCULevel]::CU12))) {
+            ($SecurityObject.CU -le [HealthChecker.ExchangeCULevel]::CU12)) -and
+        ($SecurityObject.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge)) {
         Write-Verbose "Testing CVE: CVE-2022-21978"
 
         if ($null -ne $SecurityObject.ExchangeInformation.ExchangeAdPermissions) {

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -479,6 +479,9 @@ Function Get-ExchangeInformation {
             $exchangeInformation.IISConfigurationSettings = Get-ExchangeIISConfigSettings -MachineName $Script:Server `
                 -ExchangeInstallPath $serverExchangeInstallDirectory `
                 -CatchActionFunction ${Function:Invoke-CatchActions}
+
+            Write-Verbose "Query Exchange AD permissions for CVE-2022-21978 testing"
+            $exchangeInformation.ExchangeAdPermissions = Get-ExchangeAdPermissions
         }
 
         $exchangeInformation.ApplicationConfigFileStatus = Get-ExchangeApplicationConfigurationFileValidation -ConfigFileLocation ("{0}EdgeTransport.exe.config" -f $serverExchangeBinDirectory)
@@ -491,9 +494,6 @@ Function Get-ExchangeInformation {
             Write-Verbose "March 2021 SU: KB5000871 was not detected on the system"
             $buildInformation.March2021SUInstalled = $false
         }
-
-        Write-Verbose "Query Exchange AD permissions for CVE-2022-21978 testing"
-        $exchangeInformation.ExchangeAdPermissions = Get-ExchangeAdPermissions
 
         Write-Verbose "Query schema class information for CVE-2021-34470 testing"
         try {


### PR DESCRIPTION
**Description:**
No need to run `Get-ExchangeADPermissions` on Edge Transport servers. Excluded the check for this role.


