### PR TITLE
Update Exchange Log Collector Parameters 

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -29,6 +29,7 @@ Param (
     [switch]$HubProtocolLogs,
     [switch]$IISLogs,
     [switch]$ImapLogs,
+    [switch]$MailboxAssistantsLogs,
     [switch]$MailboxConnectivityLogs,
     [switch]$MailboxDeliveryThrottlingLogs,
     [switch]$MailboxProtocolLogs,

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -50,7 +50,9 @@ Param (
     [switch]$SendConnectors,
     [Alias("ServerInfo")]
     [switch]$ServerInformation,
+    [switch]$TransportAgentLogs,
     [switch]$TransportConfig,
+    [switch]$TransportRoutingTableLogs,
     [switch]$WindowsSecurityLogs,
     [switch]$AcceptEULA,
     [switch]$AllPossibleLogs,

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -25,6 +25,8 @@ Function Get-TransportLoggingInformationPerServer {
                 ReceiveProtocolLogPath = $data.ReceiveProtocolLogPath.ToString()
                 SendProtocolLogPath    = $data.SendProtocolLogPath.ToString()
                 WlmLogPath             = $data.WlmLogPath.ToString()
+                RoutingTableLogPath    = $data.RoutingTableLogPath.ToString()
+                AgentLogPath           = $data.AgentLogPath.ToString()
             }
 
             if (![string]::IsNullOrEmpty($data.QueueLogPath)) {
@@ -39,11 +41,16 @@ Function Get-TransportLoggingInformationPerServer {
             if (($Version -eq 15 -and (-not ($MailboxOnly))) -or $Version -ge 16) {
                 $data = Get-FrontendTransportService -Identity $Server
 
+                if ($Version -ne 15) {
+                    $routingTableLogPath = $data.RoutingTableLogPath.ToString()
+                }
+
                 $FETransObject = [PSCustomObject]@{
                     ConnectivityLogPath    = $data.ConnectivityLogPath.ToString()
                     ReceiveProtocolLogPath = $data.ReceiveProtocolLogPath.ToString()
                     SendProtocolLogPath    = $data.SendProtocolLogPath.ToString()
                     AgentLogPath           = $data.AgentLogPath.ToString()
+                    RoutingTableLogPath    = $routingTableLogPath
                 }
                 $transportLoggingObject | Add-Member -MemberType NoteProperty -Name FELoggingInfo -Value $FETransObject
             }
@@ -51,12 +58,20 @@ Function Get-TransportLoggingInformationPerServer {
             if (($Version -eq 15 -and (-not ($CASOnly))) -or $Version -ge 16) {
                 #Mailbox Transport Layer
                 $data = Get-MailboxTransportService -Identity $Server
+
+                if ($Version -ne 15) {
+                    $routingTableLogPath = $data.RoutingTableLogPath.ToString()
+                }
+
                 $mbxObject = [PSCustomObject]@{
                     ConnectivityLogPath              = $data.ConnectivityLogPath.ToString()
                     ReceiveProtocolLogPath           = $data.ReceiveProtocolLogPath.ToString()
                     SendProtocolLogPath              = $data.SendProtocolLogPath.ToString()
                     PipelineTracingPath              = $data.PipelineTracingPath.ToString()
                     MailboxDeliveryThrottlingLogPath = $data.MailboxDeliveryThrottlingLogPath.ToString()
+                    MailboxDeliveryAgentLogPath      = $data.MailboxDeliveryAgentLogPath.ToString()
+                    MailboxSubmissionAgentLogPath    = $data.MailboxSubmissionAgentLogPath.ToString()
+                    RoutingTableLogPath              = $routingTableLogPath
                 }
                 $transportLoggingObject | Add-Member -MemberType NoteProperty -Name MBXLoggingInfo -Value $mbxObject
             }

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -52,6 +52,7 @@ Function Get-ArgumentList {
         IISLogs                        = $IISLogs
         ImapLogs                       = $ImapLogs
         TimeSpan                       = $LogAge
+        MailboxAssistantsLogs          = $MailboxAssistantsLogs
         MailboxConnectivityLogs        = $MailboxConnectivityLogs
         MailboxDeliveryThrottlingLogs  = $MailboxDeliveryThrottlingLogs
         MailboxProtocolLogs            = $MailboxProtocolLogs

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -74,7 +74,9 @@ Function Get-ArgumentList {
         ServerObjects                  = (Get-ServerObjects -ValidServers $Servers)
         ScriptDebug                    = $ScriptDebug
         StandardFreeSpaceInGBCheckSize = $Script:StandardFreeSpaceInGBCheckSize
+        TransportAgentLogs             = $TransportAgentLogs
         TransportConfig                = $TransportConfig
+        TransportRoutingTableLogs      = $TransportRoutingTableLogs
         WindowsSecurityLogs            = $WindowsSecurityLogs
     }
 }

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -28,6 +28,7 @@ Function Test-NoSwitchesProvided {
         $OABLogs -or
         $PowerShellLogs -or
         $WindowsSecurityLogs -or
+        $MailboxAssistantsLogs -or
         $ExchangeServerInformation -or
         $MitigationService
     ) {

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -43,7 +43,9 @@ Function Test-PossibleCommonScenarios {
         $Script:QueueInformation = $true
         $Script:SendConnectors = $true
         $Script:ReceiveConnectors = $true
+        $Script:TransportAgentLogs = $true
         $Script:TransportConfig = $true
+        $Script:TransportRoutingTableLogs = $true
         $Script:FrontEndConnectivityLogs = $true
         $Script:MailboxConnectivityLogs = $true
         $Script:FrontEndProtocolLogs = $true
@@ -117,6 +119,8 @@ Function Test-PossibleCommonScenarios {
         $MailboxConnectivityLogs -or
         $MailboxProtocolLogs -or
         $MailboxDeliveryThrottlingLogs -or
+        $TransportAgentLogs -or
+        $TransportRoutingTableLogs -or
         $DefaultTransportLogging) {
         $Script:AnyTransportSwitchesEnabled = $true
     }

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -34,6 +34,7 @@ Function Test-PossibleCommonScenarios {
         $Script:ConnectivityLogs = $true
         $Script:ProtocolLogs = $true
         $Script:MitigationService = $true
+        $Script:MailboxAssistantsLogs = $true
     }
 
     if ($DefaultTransportLogging) {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
@@ -63,18 +63,19 @@ Function Copy-LogsBasedOnTime {
 
         Write-Verbose "Function Enter: $($MyInvocation.MyCommand)"
         Write-Verbose "LogPath: '$LogPath' | CopyToThisLocation: '$CopyToThisLocation'"
+        New-Item -ItemType Directory -Path $CopyToThisLocation -Force | Out-Null
         $copyFromDate = [DateTime]::Now - $PassedInfo.TimeSpan
+        Write-Verbose "Copy From Date: $copyFromDate"
+    }
+    process {
 
+        # need to have the return in process
         if (-not (Test-Path $LogPath)) {
             # If the directory isn't there, provide that
             Write-Verbose "$LogPath doesn't exist"
             NoFilesInLocation "Path doesn't exist"
             return
         }
-    }
-    process {
-        New-Item -ItemType Directory -Path $CopyToThisLocation -Force | Out-Null
-        Write-Verbose "Copy From Date: $copyFromDate"
 
         if ($IncludeSubDirectory) {
             $getChildItem = Get-ChildItem -Path $LogPath -Recurse

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -264,6 +264,41 @@ Function Invoke-RemoteMain {
             Copy-BulkItems -CopyToLocation ($Script:RootCopyToDirectory + "\Transport_Configuration") -ItemsToCopyLocation $items
         }
 
+        if ($PassedInfo.TransportAgentLogs) {
+
+            if ($Script:localServerObject.CAS) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.FELoggingInfo.AgentLogPath "FE_Transport_Agent_Logs"
+            }
+
+            if ($Script:localServerObject.Hub -or
+                $Script:localServerObject.Edge) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.HubLoggingInfo.AgentLogPath "Hub_Transport_Agent_Logs"
+            }
+
+            if ($Script:localServerObject.Mailbox) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.MBXLoggingInfo.MailboxSubmissionAgentLogPath "Mbx_Submission_Transport_Agent_Logs"
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.MBXLoggingInfo.MailboxDeliveryAgentLogPath "Mbx_Delivery_Transport_Agent_Logs"
+            }
+        }
+
+        if ($PassedInfo.TransportRoutingTableLogs) {
+
+            if ($Script:localServerObject.Version -ne 15 -and
+                (-not ($Script:localServerObject.Edge))) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.FELoggingInfo.RoutingTableLogPath "FE_Transport_Routing_Table_Logs"
+            }
+
+            if ($Script:localServerObject.Hub -or
+                $Script:localServerObject.Edge) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.HubLoggingInfo.RoutingTableLogPath "Hub_Transport_Routing_Table_Logs"
+            }
+
+            if ($Script:localServerObject.Version -ne 15 -and
+                (-not ($Script:localServerObject.Edge))) {
+                Add-LogCopyBasedOffTimeTaskAction $Script:localServerObject.TransportInfo.MBXLoggingInfo.RoutingTableLogPath "Mbx_Transport_Routing_Table_Logs"
+            }
+        }
+
         #Exchange 2013+ only
         if ($Script:localServerObject.Version -ge 15 -and
             (-not($Script:localServerObject.Edge))) {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -181,6 +181,15 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.MitigationService) {
             Add-DefaultLogCopyTaskAction "$Script:localExinstall`Logging\MitigationService" "Mitigation_Service_Logs"
         }
+
+        if ($PassedInfo.MailboxAssistantsLogs) {
+            Add-DefaultLogCopyTaskAction "$Script:localExinstall`Logging\MailboxAssistantsLog" "Mailbox_Assistants_Logs"
+            Add-DefaultLogCopyTaskAction "$Script:localExinstall`Logging\MailboxAssistantsSlaReportLog" "Mailbox_Assistants_Sla_Report_Logs"
+
+            if ($Script:localServerObject.Version -eq 15) {
+                Add-DefaultLogCopyTaskAction "$Script:localExinstall`Logging\MailboxAssistantsDatabaseSlaLog" "Mailbox_Assistants_Database_Sla_Logs"
+            }
+        }
     }
 
     ############################################

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -106,7 +106,9 @@ RPCLogs | Enable to collect RPC Logs. Location: `V15\Logging\RPC Client Access`,
 SearchLogs | Enable to collect Search Logs. Location: `V15\Bin\Search\Ceres\Diagnostics\Logs`, `V15\Bin\Search\Ceres\Diagnostics\ETLTraces`, `V15\Logging\Search`. On 2019 only we also include `V15\Logging\BigFunnelMetricsCollectionAssistant`, `V15\Logging\BigFunnelQueryParityAssistant`, and `V15\Logging\BigFunnelRetryFeederTimeBasedAssistant`
 SendConnectors | Enable to collect the send connector information from the environment.
 ServerInformation | Enable to collect general server information.
+TransportAgentLogs | Enable to collect the Agnet Logs. Location: `(Get-TransportService $server).AgentLogPath`, `(Get-FrontendTransportService $server).AgentLogPath`, `(Get-MailboxTransportService $server).MailboxSubmissionAgentLogPath`, and `(Get-MailboxTransportService $server).MailboxDeliveryAgentLogPath`
 TransportConfig | Enable to collect the Transport Configuration files from the Server and `Get-TransportConfig` from the org. Files: `EdgeTransport.exe.config`, `MSExchangeFrontEndTransport.exe.config`, `MSExchangeDelivery.exe.config`, and `MSExchangeSubmission.exe.config`
+TransportRoutingTableLogs | Enable to collect the Routing Table Logs. Location: `(Get-TransportService $server).RoutingTableLogPath`, `(Get-FrontendTransportService $server).RoutingTableLogPath`, and `(Get-MailboxTransportService $server).RoutingTableLogPath`
 WindowsSecurityLogs | Enable to collect the Windows Security Logs. Default Location: `'C:\Windows\System32\Winevt\Logs\Security.evtx'`
 AcceptEULA | Enable to accept the conditions of the script and not get prompted.
 AllPossibleLogs | Enables the collection of all default logging collection on the Server.

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -87,6 +87,7 @@ HubConnectivityLogs | Enable to collect the Hub connectivity logging. Location: 
 HubProtocolLogs | Enable to collect the protocol logging. Location: `(Get-TransportService $server).ReceiveProtocolLogPath` and `(Get-TransportService $server).SendProtocolLogPath`
 IISLogs | Enable to collect IIS Logs and HTTPErr Logs from the Exchange Server. Default Location: `C:\inetpub\logs\LogFiles\W3SVC1`, `C:\inetpub\logs\LogFiles\W3SVC1`, and `C:\Windows\System32\LogFiles\HTTPERR`. Only able to collect on `LogAge`.
 ImapLogs | Enable to collect IMAP logging. Location: `(Get-ImapSettings -Server $server).LogFileLocation`
+MailboxAssistantsLogs | Enable to collect Mailbox Assistants logging. Location: `V15\Logging\MailboxAssistantsLog`, `V15\Logging\MailboxAssistantsSlaReportLog`, and `V15\Logging\MailboxAssistantsDatabaseSlaLog`
 MailboxConnectivityLogs | Enable to collect the connectivity logging on the mailbox server. Location: `(Get-MailboxTransportService $server).ConnectivityLogPath`
 MailboxDeliveryThrottlingLogs | Enable to collect the mailbox delivery throttling logs on the server. Location: `(Get-MailboxTransportService $server).MailboxDeliveryThrottlingLogPath`
 MailboxProtocolLogs | Enable to collect protocol logging on the mailbox server. Location: `(Get-MailboxTransportService $server).ReceiveProtocolLogPath` and `(Get-MailboxTransportService $server).SendProtocolLogPath`


### PR DESCRIPTION
**Reason:**
Added additional parameters and data collection options:

- MailboxAssistantsLogs
- TransportAgentLogs
- TrransportRoutingTableLogs

Fixed Bug with `Copy-LogsBasedOnTime`

**Validation:**
Lab tested
