### PR TITLE
Handle Common Issues with Get-WmiObject

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
@@ -36,6 +36,15 @@ Function Get-WmiObjectCriticalHandler {
     if ($null -eq $wmi) {
         # Check for common issues that have been seen. If common issue, the do a Write-Error, custom message, then exit to maintain readability.
 
+        if ($Error[0].Exception.ErrorCode -eq 0x800703FA) {
+            Write-Verbose "Registry key marked for deletion."
+            Write-Error $Error[0]
+            $message = "A registry key is marked for deletion that was attempted to read from for the cmdlet 'Get-WmiObject -Class $Class'.`r`n"
+            $message += "`tThis error goes away after some time and/or a reboot of the computer. At that time you should be able to run Health Checker again."
+            Write-Warning $message
+            exit
+        }
+
         # Grab the English version of hte message and/or the error code. Could get a different error code if service is not disabled.
         if ($Error[0].Exception.Message -like "The service cannot be started, either because it is disabled or because it has no enabled devices associated with it. *" -or
             $Error[0].Exception.ErrorCode -eq 0x80070422) {

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
@@ -34,6 +34,17 @@ Function Get-WmiObjectCriticalHandler {
     $wmi = Get-WmiObjectHandler @params
 
     if ($null -eq $wmi) {
+        # Check for common issues that have been seen. If common issue, the do a Write-Error, custom message, then exit to maintain readability.
+
+        # Grab the English version of hte message and/or the error code. Could get a different error code if service is not disabled.
+        if ($Error[0].Exception.Message -like "The service cannot be started, either because it is disabled or because it has no enabled devices associated with it. *" -or
+            $Error[0].Exception.ErrorCode -eq 0x80070422) {
+            Write-Verbose "winmgmt service is disabled or not working."
+            Write-Error $Error[0]
+            Write-Warning "The 'winmgmt' service appears to not be working correctly. Please make sure it is set to Automatic and in a running state. This script will fail unless this is working correctly."
+            exit
+        }
+
         throw "Failed to get critical information. Stopping the script. InnerException: $($Error[0])"
     }
 


### PR DESCRIPTION
**Reason:**
Within some critical classes for `Get-WmiObject` we throw an error stopping the script on purpose, however, some of those scenarios are common and can display what to do on the screen to help reduce emailing in on them.

Example: 

![image](https://user-images.githubusercontent.com/22776718/168642848-54ca3950-193c-4294-a4b3-de5b2bdecdea.png)



**Fix:**
Check the ErrorCode and/or the ErrorMessage inside the `Get-WmiObjectCriticalHandler` to display the error first, the custom message, then exit out of the script. 

Need to exit vs a throw to have "There appears to be some errors in the script." show last as it is in a `finally` block. 

**Validation:**
Lab tested.

Resolved #1034 
Resolved #948 