### PR TITLE
Handle No Setup Run on Server

### DIFF
--- a/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
@@ -8,18 +8,33 @@ Function Test-DomainMultiActiveSyncVirtualDirectories {
     $params = @{
         TestName = "Multiple Active Sync Vdirs Detected"
     }
-    $orgContainer = Get-OrganizationContainer
-    $orgDN = $orgContainer.Properties["distinguishedName"]
-    $containerPath = [ADSI]("LDAP://CN=$env:ComputerName,CN=Servers,CN=Exchange administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,$orgDN")
-    $searcher = New-Object System.DirectoryServices.DirectorySearcher($containerPath, "(objectClass=msExchMobileVirtualDirectory)", @("distinguishedName"))
-    $result = $searcher.FindAll()
-    $fe = $result | Where-Object { $_.Properties["distinguishedName"] -notlike "*(Exchange Back End)*" }
 
-    if ($fe.Count -gt 1) {
-        $fe | ForEach-Object {
-            New-TestResult @params -Result "Failed" -Details $_.Properties["distinguishedName"] -ReferenceInfo ("Remove the secondary virtual directory that is custom on the server")
+    try {
+        $orgContainer = Get-OrganizationContainer
+        $orgDN = $orgContainer.Properties["distinguishedName"]
+        $containerPath = [ADSI]("LDAP://CN=$env:ComputerName,CN=Servers,CN=Exchange administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,$orgDN")
+        $searcher = New-Object System.DirectoryServices.DirectorySearcher($containerPath, "(objectClass=msExchMobileVirtualDirectory)", @("distinguishedName"))
+        $result = $searcher.FindAll()
+        $fe = $result | Where-Object { $_.Properties["distinguishedName"] -notlike "*(Exchange Back End)*" }
+
+        if ($fe.Count -gt 1) {
+            $fe | ForEach-Object {
+                New-TestResult @params -Result "Failed" -Details $_.Properties["distinguishedName"] -ReferenceInfo ("Remove the secondary virtual directory that is custom on the server")
+            }
+        } else {
+            New-TestResult @params -Result "Passed"
         }
-    } else {
-        New-TestResult @params -Result "Passed"
+    } catch {
+
+        $innerException = $_.Exception.InnerException
+        if ($null -ne $innerException) {
+            if ($innerException.ErrorCode -eq 0x80072030) {
+                New-TestResult @params -Result "Passed" -Details "No Active Sync Virtual Directories Detected."
+            } else {
+                New-TestResult @params -Result "Warning" -Details "Unknown Failure for test. Inner Exception: $innerException"
+            }
+        } else {
+            New-TestResult @params -Result "Warning" -Details "Unknown Failure for test. Exception: $_"
+        }
     }
 }

--- a/Setup/SetupAssist/Checks/LocalServer/Test-ExchangeServices.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-ExchangeServices.ps1
@@ -47,19 +47,24 @@ function Test-ExchangeServices {
         }
     }
 
+    $path = "C:\ExchangeSetupLogs"
     $params = @{
         TestName      = "Services Cache Files"
         ReferenceInfo = "Delete the file and start Exchange Services"
     }
 
-    [array]$serviceCacheFiles = Get-ChildItem "C:\ExchangeSetupLogs" |
-        Where-Object { $_.Name -like "Service*.xml" }
+    if ((Test-Path $path)) {
+        [array]$serviceCacheFiles = Get-ChildItem "C:\ExchangeSetupLogs" |
+            Where-Object { $_.Name -like "Service*.xml" }
 
-    if ($serviceCacheFiles.Count -gt 0) {
-        $serviceCacheFiles |
-            ForEach-Object {
-                New-TestResult @params -Result "Failed" -Details $_.FullName
-            }
+        if ($serviceCacheFiles.Count -gt 0) {
+            $serviceCacheFiles |
+                ForEach-Object {
+                    New-TestResult @params -Result "Failed" -Details $_.FullName
+                }
+        } else {
+            New-TestResult @params -Result "Passed"
+        }
     } else {
         New-TestResult @params -Result "Passed"
     }


### PR DESCRIPTION
**Issue:**
`SetupAssist` would have some errors occur if `setup.exe` was never attempted on the server. 


**Fix:**
Gracefully handle the issues that were occurring if `setup.exe` was never attempted on the server. 

Resolved #871 
Resolved #827

**Validation:**
Lab tested
