### PR TITLE
Proposal: Enforce lowercase keywords

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -15,6 +15,7 @@ Set-StrictMode -Version Latest
 . $PSScriptRoot\CodeFormatterChecks\CheckMarkdownFileHasNoBOM.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckScriptFileHasBOM.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckScriptFileHasComplianceHeader.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckKeywordCasing.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckScriptFormat.ps1
 
 if (-not (Load-Module -Name PSScriptAnalyzer -MinimumVersion "1.20")) {
@@ -39,6 +40,7 @@ foreach ($fileInfo in $filesToCheck) {
     $errorCount += (CheckMarkdownFileHasNoBOM $fileInfo $Save) ? 1 : 0
     $errorCount += (CheckScriptFileHasBOM $fileInfo $Save) ? 1 : 0
     $errorCount += (CheckScriptFileHasComplianceHeader $fileInfo $Save) ? 1 : 0
+    $errorCount += (CheckKeywordCasing $fileInfo $Save) ? 1 : 0
 
     # This one is tricky. It returns $true or $false like the others, but in the case
     # of an error, we also want to get the diff output. Piping to Out-Host from within

--- a/.build/CodeFormatterChecks/CheckKeywordCasing.ps1
+++ b/.build/CodeFormatterChecks/CheckKeywordCasing.ps1
@@ -1,0 +1,53 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckKeywordCasing {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    if ($FileInfo.Extension -eq ".ps1" -or $FileInfo.Extension -eq ".psm1") {
+        $content = Get-Content -Path $FileInfo.FullName -Raw
+        $errorsReturned = $null
+        $tokens = [System.Management.Automation.PSParser]::Tokenize($content, [ref]$errorsReturned)
+        if ($errorsReturned.Count -gt 0) {
+            Write-Warning "Failed to tokenize script: $($FileInfo.FullName)."
+            return $true
+        }
+
+        $keywordWrongCase = @()
+        foreach ($t in $tokens) {
+            if ($t.Type -eq "Keyword") {
+                if (-not $t.Content.Equals($t.Content.ToLower(), "Ordinal")) {
+                    $keywordWrongCase += $t
+
+                    if ($Save) {
+                        $content = $content.Remove($t.Start, $t.Length).Insert($t.Start, $t.Content.ToLower())
+                        Write-Host "Corrected case of keyword: $($t.Content) at position $($t.Start) in $($FileInfo.FullName)"
+                    } else {
+                        Write-Warning "Keyword $($t.Content) at position $($t.Start) in $($FileInfo.FullName) is not lowercase."
+                    }
+                }
+            }
+        }
+
+        if ($keywordWrongCase.Length -gt 0) {
+            if ($Save) {
+                Set-Content -Path $FileInfo.FullName -Value $content.TrimEnd() -Encoding utf8BOM
+                return $false
+            } else {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}

--- a/Admin/Get-SimpleAuditLogReport.ps1
+++ b/Admin/Get-SimpleAuditLogReport.ps1
@@ -55,14 +55,14 @@ Outputs to the screen
 
 #>
 
-Param (
+param (
     [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
     $SearchResults,
     [switch]$ResolveCaller
 )
 
 # Setup to process incomming results
-Begin {
+begin {
 
     # Set the counter to 1
     $i = 1
@@ -72,7 +72,7 @@ Begin {
 }
 
 # Process thru what ever is comming into the script
-Process {
+process {
 
     # Deal with each object in the input
     $searchresults | ForEach-Object {
@@ -87,7 +87,7 @@ Process {
             [string]$Recipient = (get-recipient $user -ErrorAction silentlycontinue).primarysmtpaddress
 
             # if we get a result then put that in the output otherwise do nothing
-            If (!([string]::IsNullOrEmpty($Recipient))) { $user = $Recipient }
+            if (!([string]::IsNullOrEmpty($Recipient))) { $user = $Recipient }
 
             # Since this is going to take longer to run provide status every 25 entries
             if ($i % 25 -eq 0) { Write-Host "Processed 25 Results" }

--- a/Admin/Test-AMSI.ps1
+++ b/Admin/Test-AMSI.ps1
@@ -17,7 +17,7 @@ param(
     [switch]$RestartIIS
 )
 
-Function Confirm-Administrator {
+function Confirm-Administrator {
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal( [Security.Principal.WindowsIdentity]::GetCurrent() )
     if ($currentPrincipal.IsInRole( [Security.Principal.WindowsBuiltInRole]::Administrator )) {
         return $true
@@ -85,7 +85,7 @@ function Test-AMSI {
             $CookieContainer.Cookies.Add($Cookie)
             Invoke-WebRequest https://$ExchangeServerFQDN/ecp/x.js -Method POST -Headers @{"Host" = "$ExchangeServerFQDN" } -WebSession $CookieContainer
         } catch [System.Net.WebException] {
-            If ($_.Exception.Message -notlike "*: (400)*") {
+            if ($_.Exception.Message -notlike "*: (400)*") {
                 $Message = ($_.Exception.Message).ToString().Trim()
                 Write-Output $msgNewLine
                 Write-Error $Message

--- a/Databases/VSSTester/ExchangeInformation/Get-CopyStatus.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-CopyStatus.ps1
@@ -18,7 +18,7 @@ function Get-CopyStatus {
                 exit
             }
         }
-    } Else {
+    } else {
         Write-Host "Not checking database copy status since the selected database is a Public Folder Database..."
     }
     " "

--- a/Databases/VSSTester/Logging/Get-WindowsEventLogs.ps1
+++ b/Databases/VSSTester/Logging/Get-WindowsEventLogs.ps1
@@ -4,7 +4,7 @@
 
 function Get-WindowsEventLogs {
 
-    Function Get-WindowEventsPerServer {
+    function Get-WindowEventsPerServer {
         param(
             [string]$CompunterName
         )

--- a/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
+++ b/Databases/VSSTester/Logging/Invoke-EnableExtraTracing.ps1
@@ -3,7 +3,7 @@
 
 function Invoke-EnableExTRATracing {
 
-    Function Invoke-ExtraTracingCreate {
+    function Invoke-ExtraTracingCreate {
         param(
             [string]$ComputerName,
             [string]$LogmanName

--- a/Databases/VSSTester/VSSTester.ps1
+++ b/Databases/VSSTester/VSSTester.ps1
@@ -39,7 +39,7 @@ param(
 . .\Logging\Invoke-EnableExtraTracing.ps1
 . .\Logging\Invoke-EnableVSSTracing.ps1
 
-Function Main {
+function Main {
     $updateInfo = Get-ScriptUpdateAvailable
     if ($updateInfo.UpdateFound) {
         Write-Warning "An update is available for this script. Current: $($updateInfo.CurrentVersion) Latest: $($updateInfo.LatestVersion)"
@@ -96,7 +96,7 @@ Function Main {
 
     $matchCondition = "^[1|2]$"
     Write-Debug "matchCondition: $matchCondition"
-    Do {
+    do {
         Write-Host "Selection: " -ForegroundColor Yellow -NoNewline;
         $Selection = Read-Host
         if ($Selection -notmatch $matchCondition) {
@@ -195,7 +195,7 @@ Function Main {
                 Write-Host
                 $continue = Read-Host "Please use the <Enter> key to exit..."
             }
-            While ($null -notmatch $continue)
+            while ($null -notmatch $continue)
             exit
         } catch { }
     }

--- a/Diagnostics/AVTester/Start-SleepWithProgress.ps1
+++ b/Diagnostics/AVTester/Start-SleepWithProgress.ps1
@@ -30,9 +30,9 @@ Creates a Progress bar with the message "Waiting on Process to complete"
 Counts down 60 seconds and updates the Progress bar during the proess.
 
 #>
-Function Start-SleepWithProgress {
+function Start-SleepWithProgress {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Start-Sleep does not use -WhatIf')]
-    Param(
+    param(
         [Parameter(Mandatory = $true)]
         [int]$SleepTime,
 
@@ -41,7 +41,7 @@ Function Start-SleepWithProgress {
     )
 
     # Loop Number of seconds you want to sleep
-    For ($i = 0; $i -le $SleepTime; $i++) {
+    for ($i = 0; $i -le $SleepTime; $i++) {
         $timeleft = ($SleepTime - $i);
 
         # Progress bar showing progress of the sleep

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -92,7 +92,7 @@ $BaseFolders.Add((Join-Path $env:SystemRoot '\Microsoft.NET\Framework64\v4.0.303
 $BaseFolders.Add((Join-Path $env:SystemRoot '\System32\Inetsrv').tolower())
 
 # Add all database folder paths
-Foreach ($Entry in (Get-MailboxDatabase -Server $Env:COMPUTERNAME)) {
+foreach ($Entry in (Get-MailboxDatabase -Server $Env:COMPUTERNAME)) {
     $BaseFolders.Add((Split-Path $Entry.EdbFilePath -Parent).tolower())
     $BaseFolders.Add(($Entry.LogFolderPath.pathname.tolower()))
 }
@@ -150,21 +150,21 @@ foreach ($Folder in $FolderList) {
     #Base64 of Eicar string
     [string] $EncodedEicar = 'WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo='
 
-    If (!(Test-Path -Path $FilePath)) {
+    if (!(Test-Path -Path $FilePath)) {
 
         # Try writing the encoded string to a the file
-        Try {
+        try {
             [byte[]] $EicarBytes = [System.Convert]::FromBase64String($EncodedEicar)
             [string] $Eicar = [System.Text.Encoding]::UTF8.GetString($EicarBytes)
             Set-Content -Value $Eicar -Encoding ascii -Path $FilePath -Force
         }
 
-        Catch {
+        catch {
             Write-Warning "$Folder Eicar.com file couldn't be created. Either permissions or AV prevented file creation."
         }
     }
 
-    Else {
+    else {
         Write-SimpleLogfile -string ("[WARNING] - Eicar.com already exists!: " + $FilePath) -name $LogFile -OutHost
     }
 }

--- a/Diagnostics/AVTester/Write-SimpleLogFile.ps1
+++ b/Diagnostics/AVTester/Write-SimpleLogFile.ps1
@@ -44,9 +44,9 @@ Write-SimpleLogFile -String "Start ProcessB" -Name mylogfile.log -OutHost
 Writes "[Date] - Start ProcessB" to $env:LocalAppData\mylogfile and to the Host
 
 #>
-Function Write-SimpleLogfile {
+function Write-SimpleLogfile {
     [cmdletbinding()]
-    Param
+    param
     (
         [Parameter(Mandatory = $true)]
         [string]$String,
@@ -60,16 +60,16 @@ Function Write-SimpleLogfile {
 
     )
 
-    Begin {
+    begin {
         # Get our log file path
         $LogFile = Join-Path $env:LOCALAPPDATA $Name
 
         if ($OpenLog) {
             Notepad.exe $LogFile
-            Exit
+            exit
         }
     }
-    Process {
+    process {
 
         # Get the current date
         [string]$date = Get-Date -Format G
@@ -83,5 +83,3 @@ Function Write-SimpleLogfile {
         else { Write-Verbose  $logstring }
     }
 }
-
-

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -3,7 +3,7 @@
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Value is used')]
 [CmdletBinding(DefaultParameterSetName = "LogAge")]
-Param (
+param (
     [string]$FilePath = "C:\MS_Logs_Collection",
     [array]$Servers = @($env:COMPUTERNAME),
     [switch]$ADDriverLogs,
@@ -83,7 +83,7 @@ if ($PSBoundParameters["Verbose"]) { $Script:ScriptDebug = $true }
 
 if ($PSCmdlet.ParameterSetName -eq "Worth") { $Script:LogAge = New-TimeSpan -Days $DaysWorth -Hours $HoursWorth }
 
-Function Invoke-RemoteFunctions {
+function Invoke-RemoteFunctions {
     param(
         [Parameter(Mandatory = $true)][object]$PassedInfo
     )
@@ -146,7 +146,7 @@ Function Invoke-RemoteFunctions {
 . $PSScriptRoot\Helpers\Test-PossibleCommonScenarios.ps1
 . $PSScriptRoot\Helpers\Test-RemoteExecutionOfServers.ps1
 
-Function Main {
+function Main {
 
     Start-Sleep 1
     Test-PossibleCommonScenarios

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-DAGInformation.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-DAGInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-DAGInformation {
+function Get-DAGInformation {
     param(
         [Parameter(Mandatory = $true)][string]$DAGName
     )

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\..\..\Shared\Get-ExchangeBuildVersionInformation.ps1
 #TODO: Create Pester Testing on this
 # Used to get the Exchange Version information and what roles are set on the server.
-Function Get-ExchangeBasicServerObject {
+function Get-ExchangeBasicServerObject {
     param(
         [Parameter(Mandatory = $true)][string]$ServerName,
         [Parameter(Mandatory = $false)][bool]$AddGetServerProperty = $false

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-ExchangeBasicServerObject.ps1
 . $PSScriptRoot\Get-TransportLoggingInformationPerServer.ps1
-Function Get-ServerObjects {
+function Get-ServerObjects {
     param(
         [Parameter(Mandatory = $true)][Array]$ValidServers
     )
@@ -56,5 +56,5 @@ Function Get-ServerObjects {
     #Set the valid servers
     $Script:ValidServers = $validServersList
     Write-Verbose("Function Exit: Get-ServerObjects")
-    Return $svrsObject
+    return $svrsObject
 }

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-TransportLoggingInformationPerServer {
+function Get-TransportLoggingInformationPerServer {
     param(
         [string]$Server,
         [int]$Version,

--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-VirtualDirectoriesLdap.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\..\..\Shared\ActiveDirectoryFunctions\Get-OrganizationContainer.ps1
 
-Function Get-VirtualDirectoriesLdap {
+function Get-VirtualDirectoriesLdap {
 
     $authTypeEnum = @"
     namespace AuthMethods

--- a/Diagnostics/ExchangeLogCollector/Helpers/Add-ScriptBlockInjection.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Add-ScriptBlockInjection.ps1
@@ -6,7 +6,7 @@
 # Injects Verbose and Debug Preferences and other passed variables into the script block
 # It will also inject any additional script blocks into the main script block.
 # This allows for an Invoke-Command to work as intended if multiple functions/script blocks are required.
-Function Add-ScriptBlockInjection {
+function Add-ScriptBlockInjection {
     [CmdletBinding()]
     [OutputType([string])]
     param(

--- a/Diagnostics/ExchangeLogCollector/Helpers/Enter-YesNoLoopAction.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Enter-YesNoLoopAction.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Enter-YesNoLoopAction {
+function Enter-YesNoLoopAction {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)][string]$Question,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\ExchangeServerInfo\Get-ServerObjects.ps1
-Function Get-ArgumentList {
+function Get-ArgumentList {
     param(
         [Parameter(Mandatory = $true)][array]$Servers
     )

--- a/Diagnostics/ExchangeLogCollector/Helpers/Import-ScriptConfigFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Import-ScriptConfigFile.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Import-ScriptConfigFile {
+function Import-ScriptConfigFile {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/ExchangeLogCollector/Helpers/Invoke-ServerRootZipAndCopy.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Invoke-ServerRootZipAndCopy.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\..\RemoteScriptBlock\Get-FreeSpace.ps1
 . $PSScriptRoot\..\RemoteScriptBlock\IO\Compress-Folder.ps1
 #This function is to handle all root zipping capabilities and copying of the data over.
-Function Invoke-ServerRootZipAndCopy {
+function Invoke-ServerRootZipAndCopy {
     param(
         [bool]$RemoteExecute = $true
     )
@@ -15,7 +15,7 @@ Function Invoke-ServerRootZipAndCopy {
             return $_.ServerName
         }
 
-    Function Write-CollectFilesFromLocation {
+    function Write-CollectFilesFromLocation {
         Write-Host ""
         Write-Host "Please collect the following files from these servers and upload them: "
         $LogPaths |

--- a/Diagnostics/ExchangeLogCollector/Helpers/PipelineFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/PipelineFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function New-PipelineObject {
+function New-PipelineObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Caller knows that this is an action')]
     [CmdletBinding()]
     param(
@@ -16,7 +16,7 @@ Function New-PipelineObject {
     }
 }
 
-Function Invoke-PipelineHandler {
+function Invoke-PipelineHandler {
     [CmdletBinding()]
     param(
         [object[]]$Object
@@ -34,7 +34,7 @@ Function Invoke-PipelineHandler {
     }
 }
 
-Function New-VerbosePipelineObject {
+function New-VerbosePipelineObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Caller knows that this is an action')]
     [CmdletBinding()]
     param(

--- a/Diagnostics/ExchangeLogCollector/Helpers/Start-JobManager.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Start-JobManager.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Start-JobManager {
+function Start-JobManager {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I prefer Start here')]
     [CmdletBinding()]
     param(
@@ -25,7 +25,7 @@ Function Start-JobManager {
             [object]ArgumentList #customized for your scriptblock
     #>
 
-    Function Wait-JobsCompleted {
+    function Wait-JobsCompleted {
         Write-Verbose "Calling Wait-JobsCompleted"
         [System.Diagnostics.Stopwatch]$timer = [System.Diagnostics.Stopwatch]::StartNew()
         # Data returned is a Hash Table that matches to the Server the Script Block ran against

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
@@ -7,7 +7,7 @@
 . $PSScriptRoot\Start-JobManager.ps1
 . $PSScriptRoot\..\RemoteScriptBlock\Get-FreeSpace.ps1
 . $PSScriptRoot\..\RemoteScriptBlock\IO\Invoke-CatchBlockActions.ps1
-Function Test-DiskSpace {
+function Test-DiskSpace {
     param(
         [Parameter(Mandatory = $true)][array]$Servers,
         [Parameter(Mandatory = $true)][string]$Path,
@@ -20,7 +20,7 @@ Function Test-DiskSpace {
         $Path = "{0}\" -f $Path
     }
 
-    Function Test-ServerDiskSpace {
+    function Test-ServerDiskSpace {
         param(
             [Parameter(Mandatory = $true)][string]$Server,
             [Parameter(Mandatory = $true)][int]$FreeSpace,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Enter-YesNoLoopAction.ps1
-Function Test-NoSwitchesProvided {
+function Test-NoSwitchesProvided {
     if ($EWSLogs -or
         $IISLogs -or
         $DailyPerformanceLogs -or

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Test-PossibleCommonScenarios {
+function Test-PossibleCommonScenarios {
 
     #all possible logs
     if ($AllPossibleLogs) {

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-RemoteExecutionOfServers.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-RemoteExecutionOfServers.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Enter-YesNoLoopAction.ps1
 . $PSScriptRoot\Test-DiskSpace.ps1
-Function Test-RemoteExecutionOfServers {
+function Test-RemoteExecutionOfServers {
     param(
         [Parameter(Mandatory = $true)][Array]$ServerList
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Add-ServerNameToFileName.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Add-ServerNameToFileName.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Add-ServerNameToFileName {
+function Add-ServerNameToFileName {
     param(
         [Parameter(Mandatory = $true)][string]$FilePath
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ClusterNodeFileVersions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ClusterNodeFileVersions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ClusterNodeFileVersions {
+function Get-ClusterNodeFileVersions {
     [CmdletBinding()]
     param(
         [string]$ClusterDirectory = "C:\Windows\Cluster"

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ExchangeInstallDirectory.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ExchangeInstallDirectory.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ExchangeInstallDirectory {
+function Get-ExchangeInstallDirectory {
     [CmdletBinding()]
     param()
 

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-FreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-FreeSpace.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-FreeSpace {
+function Get-FreeSpace {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Different types returned')]
     [CmdletBinding()]
     param(

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Test-CommandExists.ps1
-Function Get-IISLogDirectory {
+function Get-IISLogDirectory {
     Write-Verbose("Function Enter: Get-IISLogDirectory")
 
-    Function Get-IISDirectoryFromGetWebSite {
+    function Get-IISDirectoryFromGetWebSite {
         Write-Verbose("Get-WebSite command exists")
         return Get-WebSite |
             ForEach-Object {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ItemsSize.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-ItemsSize.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ItemsSize {
+function Get-ItemsSize {
     param(
         [Parameter(Mandatory = $true)][array]$FilePaths
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-StringDataForNotEnoughFreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-StringDataForNotEnoughFreeSpace.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-StringDataForNotEnoughFreeSpaceFile {
+function Get-StringDataForNotEnoughFreeSpaceFile {
     param(
         [Parameter(Mandatory = $true)][hashtable]$hasher
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Compress-Folder.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Compress-Folder.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Compress-Folder {
+function Compress-Folder {
     [CmdletBinding()]
     [OutputType([string])]
     param(

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-BulkItems.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-BulkItems.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\Get-StringDataForNotEnoughFreeSpace.ps1
 . $PSScriptRoot\..\Test-FreeSpace.ps1
-Function Copy-BulkItems {
+function Copy-BulkItems {
     param(
         [string]$CopyToLocation,
         [Array]$ItemsToCopyLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\Get-StringDataForNotEnoughFreeSpace.ps1
 . $PSScriptRoot\..\Test-FreeSpace.ps1
-Function Copy-FullLogFullPathRecurse {
+function Copy-FullLogFullPathRecurse {
     param(
         [Parameter(Mandatory = $true)][string]$LogPath,
         [Parameter(Mandatory = $true)][string]$CopyToThisLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-LogsBasedOnTime.ps1
@@ -9,14 +9,14 @@
     If there is a directory that doesn't contain logs within the TimeSpan,
     Collect the latest log or provide there is no logs in the directory
 #>
-Function Copy-LogsBasedOnTime {
+function Copy-LogsBasedOnTime {
     param(
         [Parameter(Mandatory = $true)][string]$LogPath,
         [Parameter(Mandatory = $true)][string]$CopyToThisLocation,
         [Parameter(Mandatory = $true)][bool]$IncludeSubDirectory
     )
     begin {
-        Function NoFilesInLocation {
+        function NoFilesInLocation {
             param(
                 [string]$Value = "No data in the location"
             )
@@ -36,7 +36,7 @@ Function Copy-LogsBasedOnTime {
             New-Item @params | Out-Null
         }
 
-        Function CopyItemsFromDirectory {
+        function CopyItemsFromDirectory {
             param(
                 [object]$AllItems,
                 [string]$CopyToLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Invoke-CatchBlockActions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Invoke-CatchBlockActions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-CatchBlockActions {
+function Invoke-CatchBlockActions {
     Write-Verbose "Error Exception: $($Error[0].Exception)"
     Write-Verbose "Error Stack: $($Error[0].ScriptStackTrace)"
     [array]$Script:ErrorsHandled += $Error[0]

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/LogmanFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/LogmanFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function CopyLogmanData {
+function CopyLogmanData {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -60,7 +60,7 @@ Function CopyLogmanData {
     }
 }
 
-Function GetLogmanObject {
+function GetLogmanObject {
     [CmdletBinding()]
     param(
         [string]$LogmanName
@@ -117,7 +117,7 @@ Function GetLogmanObject {
     }
 }
 
-Function GetLogmanData {
+function GetLogmanData {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -151,11 +151,11 @@ Function GetLogmanData {
     }
 }
 
-Function Save-LogmanExmonData {
+function Save-LogmanExmonData {
     GetLogmanData -LogmanName $PassedInfo.ExmonLogmanName
 }
 
-Function Save-LogmanExperfwizData {
+function Save-LogmanExperfwizData {
     $PassedInfo.ExperfwizLogmanName |
         ForEach-Object {
             GetLogmanData -LogmanName $_

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataInfoToFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataInfoToFile.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Save-DataToFile.ps1
 . $PSScriptRoot\..\Add-ServerNameToFileName.ps1
-Function Save-DataInfoToFile {
+function Save-DataInfoToFile {
     param(
         [Parameter(Mandatory = $false)][object]$DataIn,
         [Parameter(Mandatory = $true)][string]$SaveToLocation,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataToFile.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-DataToFile.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Save-DataToFile {
+function Save-DataToFile {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)][object]$DataIn,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-FailoverClusterInformation.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\Save-RegistryHive.ps1
 . $PSScriptRoot\..\Get-ClusterNodeFileVersions.ps1
 #Save out the failover cluster information for the local node, besides the event logs.
-Function Save-FailoverClusterInformation {
+function Save-FailoverClusterInformation {
     Write-Verbose("Function Enter: Save-FailoverClusterInformation")
     $copyTo = "$Script:RootCopyToDirectory\Cluster_Information"
     New-Item -ItemType Directory -Path $copyTo -Force | Out-Null

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Invoke-CatchBlockActions.ps1
 . $PSScriptRoot\Save-DataInfoToFile.ps1
-Function Save-RegistryHive {
+function Save-RegistryHive {
     [CmdletBinding()]
     param(
         [string]$RegistryPath,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\Save-RegistryHive.ps1
 . $PSScriptRoot\..\Add-ServerNameToFileName.ps1
 . $PSScriptRoot\..\Test-CommandExists.ps1
-Function Save-ServerInfoData {
+function Save-ServerInfoData {
     Write-Verbose("Function Enter: Save-ServerInfoData")
     $copyTo = $Script:RootCopyToDirectory + "\General_Server_Info"
     New-Item -ItemType Directory -Path $copyTo -Force | Out-Null

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-WindowsEventLogs.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-WindowsEventLogs.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Copy-BulkItems.ps1
 . $PSScriptRoot\Save-DataInfoToFile.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Save-WindowsEventLogs {
+function Save-WindowsEventLogs {
 
     Write-Verbose("Function Enter: Save-WindowsEventLogs")
     $baseSaveLocation = $Script:RootCopyToDirectory + "\Windows_Event_Logs"

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-Verbose.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Write-Verbose.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-Verbose {
+function Write-Verbose {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose from Shared functions')]
     [CmdletBinding()]
     param(
@@ -29,14 +29,14 @@ Function Write-Verbose {
     }
 }
 
-Function SetWriteVerboseAction ($DebugAction) {
+function SetWriteVerboseAction ($DebugAction) {
     $Script:WriteVerboseDebugAction = $DebugAction
 }
 
-Function SetWriteRemoteVerboseAction ($DebugAction) {
+function SetWriteRemoteVerboseAction ($DebugAction) {
     $Script:WriteRemoteVerboseDebugAction = $DebugAction
 }
 
-Function SetWriteVerboseManipulateMessageAction ($DebugAction) {
+function SetWriteVerboseManipulateMessageAction ($DebugAction) {
     $Script:WriteVerboseManipulateMessageAction = $DebugAction
 }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/WriteFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/WriteFunctions.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Small set of functions that are used to help override the Write-Host and Write-Verbose functions
-Function Get-ManipulateWriteHostValue {
+function Get-ManipulateWriteHostValue {
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -15,7 +15,7 @@ Function Get-ManipulateWriteHostValue {
     }
 }
 
-Function Get-ManipulateWriteVerboseValue {
+function Get-ManipulateWriteVerboseValue {
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -29,7 +29,7 @@ Function Get-ManipulateWriteVerboseValue {
 }
 
 #Calls the $Script:Logger object to write the data to file only.
-Function Write-DebugLog($message) {
+function Write-DebugLog($message) {
     if ($null -ne $message -and
         ![string]::IsNullOrEmpty($message) -and
         $null -ne $Script:Logger) {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -13,7 +13,7 @@
 . $PSScriptRoot\IO\Save-FailoverClusterInformation.ps1
 . $PSScriptRoot\IO\Save-ServerInfoData.ps1
 . $PSScriptRoot\IO\Save-WindowsEventLogs.ps1
-Function Invoke-RemoteMain {
+function Invoke-RemoteMain {
     [CmdletBinding()]
     param()
     Write-Verbose("Function Enter: Remote-Main")

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-ZipFolder.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-ZipFolder.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-ItemsSize.ps1
 . $PSScriptRoot\IO\Compress-Folder.ps1
-Function Invoke-ZipFolder {
+function Invoke-ZipFolder {
     param(
         [string]$Folder,
         [bool]$ZipItAll,

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/LogCopyTaskActionFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function NewTaskAction {
+function NewTaskAction {
     [CmdletBinding()]
     param(
         [string]$FunctionName,
@@ -13,7 +13,7 @@ Function NewTaskAction {
     }
 }
 
-Function NewLogCopyParameters {
+function NewLogCopyParameters {
     param(
         [string]$LogPath,
         [string]$CopyToThisLocation
@@ -24,7 +24,7 @@ Function NewLogCopyParameters {
     }
 }
 
-Function NewLogCopyBasedOffTimeParameters {
+function NewLogCopyBasedOffTimeParameters {
     param(
         [string]$LogPath,
         [string]$CopyToThisLocation,
@@ -35,7 +35,7 @@ Function NewLogCopyBasedOffTimeParameters {
     }
 }
 
-Function GetTaskActionToString {
+function GetTaskActionToString {
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -50,14 +50,14 @@ Function GetTaskActionToString {
     return $line
 }
 
-Function Add-TaskAction {
+function Add-TaskAction {
     param(
         [string]$FunctionName
     )
     $Script:taskActionList.Add((NewTaskAction $FunctionName))
 }
 
-Function Add-LogCopyBasedOffTimeTaskAction {
+function Add-LogCopyBasedOffTimeTaskAction {
     param(
         [string]$LogPath,
         [string]$CopyToThisLocation,
@@ -75,7 +75,7 @@ Function Add-LogCopyBasedOffTimeTaskAction {
     $Script:taskActionList.Add((NewTaskAction @params))
 }
 
-Function Add-LogCopyFullTaskAction {
+function Add-LogCopyFullTaskAction {
     param (
         [string]$LogPath,
         [string]$CopyToThisLocation
@@ -87,7 +87,7 @@ Function Add-LogCopyFullTaskAction {
     $Script:taskActionList.Add((NewTaskAction @params))
 }
 
-Function Add-DefaultLogCopyTaskAction {
+function Add-DefaultLogCopyTaskAction {
     param(
         [string]$LogPath,
         [string]$CopyToThisLocation

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Test-CommandExists {
+function Test-CommandExists {
     param(
         [string]$command
     )

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-FreeSpace.ps1
 . $PSScriptRoot\Get-ItemsSize.ps1
-Function Test-FreeSpace {
+function Test-FreeSpace {
     param(
         [Parameter(Mandatory = $false)][array]$FilePaths
     )

--- a/Diagnostics/ExchangeLogCollector/Write/Write-DataOnlyOnceOnMasterServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/Write/Write-DataOnlyOnceOnMasterServer.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\ExchangeServerInfo\Get-VirtualDirectoriesLdap.ps1
 . $PSScriptRoot\..\RemoteScriptBlock\IO\Save-DataInfoToFile.ps1
-Function Write-DataOnlyOnceOnMasterServer {
+function Write-DataOnlyOnceOnMasterServer {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseUsingScopeModifierInNewRunspaces', '', Justification = 'Can not use using for an env variable')]
     param()
     Write-Verbose("Enter Function: Write-DataOnlyOnceOnMasterServer")

--- a/Diagnostics/ExchangeLogCollector/Write/Write-LargeDataObjectsOnMachine.ps1
+++ b/Diagnostics/ExchangeLogCollector/Write/Write-LargeDataObjectsOnMachine.ps1
@@ -13,7 +13,7 @@
 #This function job is to write out the Data that is too large to pass into the main script block
 #This is for mostly Exchange Related objects.
 #To handle this, we export the data locally and copy the data over the correct server.
-Function Write-LargeDataObjectsOnMachine {
+function Write-LargeDataObjectsOnMachine {
 
     Write-Verbose("Function Enter Write-LargeDataObjectsOnMachine")
 
@@ -23,7 +23,7 @@ Function Write-LargeDataObjectsOnMachine {
         }
 
     #Collect the Exchange Data that resides on their own machine.
-    Function Invoke-ExchangeResideDataCollectionWrite {
+    function Invoke-ExchangeResideDataCollectionWrite {
         param(
             [Parameter(Mandatory = $true, Position = 1)]
             [string]$SaveToLocation,
@@ -145,7 +145,7 @@ Function Write-LargeDataObjectsOnMachine {
     #Exchange objects can be rather large preventing them to be passed within an Invoke-Command -ArgumentList
     #In order to get around this and to avoid going through a loop of doing an Invoke-Command per server per object,
     #Write the data out locally, copy that directory over to the remote location.
-    Function Write-ExchangeObjectDataLocal {
+    function Write-ExchangeObjectDataLocal {
         param(
             [object]$ServerData,
             [string]$Location
@@ -174,7 +174,7 @@ Function Write-LargeDataObjectsOnMachine {
         }
     }
 
-    Function Write-DatabaseAvailabilityGroupDataLocal {
+    function Write-DatabaseAvailabilityGroupDataLocal {
         param(
             [object]$DAGWriteInfo
         )

--- a/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Add-AnalyzedResultInformation {
+function Add-AnalyzedResultInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -30,7 +30,7 @@ Function Add-AnalyzedResultInformation {
     )
     begin {
         Write-Verbose "Calling $($MyInvocation.MyCommand): $name"
-        Function GetOutColumnsColorObject {
+        function GetOutColumnsColorObject {
             param(
                 [object[]]$OutColumns,
                 [scriptblock[]]$OutColumnsColorTests,

--- a/Diagnostics/HealthChecker/Analyzer/Get-DisplayResultsGroupingKey.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-DisplayResultsGroupingKey.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-DisplayResultsGroupingKey {
+function Get-DisplayResultsGroupingKey {
     param(
         [string]$Name,
         [bool]$DisplayGroupName = $true,

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngine.ps1
@@ -13,7 +13,7 @@
 . $PSScriptRoot\Invoke-AnalyzerWebAppPools.ps1
 . $PSScriptRoot\Security\Invoke-AnalyzerSecuritySettings.ps1
 . $PSScriptRoot\Security\Invoke-AnalyzerSecurityVulnerability.ps1
-Function Invoke-AnalyzerEngine {
+function Invoke-AnalyzerEngine {
     param(
         [HealthChecker.HealthCheckerExchangeServer]$HealthServerObject
     )

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
 . $PSScriptRoot\Invoke-AnalyzerKnownBuildIssues.ps1
-Function Invoke-AnalyzerExchangeInformation {
+function Invoke-AnalyzerExchangeInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
-Function Invoke-AnalyzerFrequentConfigurationIssues {
+function Invoke-AnalyzerFrequentConfigurationIssues {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
 . $PSScriptRoot\..\..\..\Shared\VisualCRedistributableVersionFunctions.ps1
-Function Invoke-AnalyzerHardwareInformation {
+function Invoke-AnalyzerHardwareInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
-Function Invoke-AnalyzerHybridInformation {
+function Invoke-AnalyzerHybridInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -242,7 +242,7 @@ Function Invoke-AnalyzerHybridInformation {
                     if (($connector.ConnectorType -eq "Send") -and
                         ($null -ne $connector.TlsAuthLevel)) {
                         # Check if send connector is configured to relay mails to the internet via M365
-                        Switch ($connector) {
+                        switch ($connector) {
                             { ($_.SmartHosts -like "*.mail.protection.outlook.com") } {
                                 $smartHostsPointToExo = $true
                             }
@@ -295,7 +295,7 @@ Function Invoke-AnalyzerHybridInformation {
                         }
                         Add-AnalyzedResultInformation @params
 
-                        Switch ($connector.TlsAuthLevel) {
+                        switch ($connector.TlsAuthLevel) {
                             "EncryptionOnly" {
                                 $tlsAuthLevelM365RelayWriteType = "Yellow";
                                 break
@@ -312,7 +312,7 @@ Function Invoke-AnalyzerHybridInformation {
                                 };
                                 break
                             }
-                            Default { $tlsAuthLevelM365RelayWriteType = "Red" }
+                            default { $tlsAuthLevelM365RelayWriteType = "Red" }
                         }
 
                         $params = $baseParams + @{
@@ -402,7 +402,7 @@ Function Invoke-AnalyzerHybridInformation {
                                 switch ($($connector.CertificateDetails.CertificateLifetimeInfo)[$thumbprint]) {
                                     { ($_ -ge 60) } { $certificateLifetimeWriteType = "Green"; break }
                                     { ($_ -ge 30) } { $certificateLifetimeWriteType = "Yellow"; break }
-                                    Default { $certificateLifetimeWriteType = "Red" }
+                                    default { $certificateLifetimeWriteType = "Red" }
                                 }
 
                                 $params = $baseParams + @{

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerKnownBuildIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerKnownBuildIssues.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\..\Helpers\Invoke-CatchActions.ps1
 
-Function Invoke-AnalyzerKnownBuildIssues {
+function Invoke-AnalyzerKnownBuildIssues {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -24,7 +24,7 @@ Function Invoke-AnalyzerKnownBuildIssues {
     }
 
     # Extract for Pester Testing - Start
-    Function GetVersionFromString {
+    function GetVersionFromString {
         param(
             [object]$VersionString
         )
@@ -36,7 +36,7 @@ Function Invoke-AnalyzerKnownBuildIssues {
         }
     }
 
-    Function GetKnownIssueInformation {
+    function GetKnownIssueInformation {
         param(
             [string]$Name,
             [string]$Url
@@ -48,7 +48,7 @@ Function Invoke-AnalyzerKnownBuildIssues {
         }
     }
 
-    Function GetKnownIssueBuildInformation {
+    function GetKnownIssueBuildInformation {
         param(
             [string]$BuildNumber,
             [string]$FixBuildNumber,
@@ -62,7 +62,7 @@ Function Invoke-AnalyzerKnownBuildIssues {
         }
     }
 
-    Function TestOnKnownBuildIssue {
+    function TestOnKnownBuildIssue {
         [CmdletBinding()]
         [OutputType("System.Boolean")]
         param(
@@ -100,7 +100,7 @@ Function Invoke-AnalyzerKnownBuildIssues {
 
     # Extract for Pester Testing - End
 
-    Function TestForKnownBuildIssues {
+    function TestForKnownBuildIssues {
         param(
             [version]$CurrentVersion,
             [object[]]$KnownBuildIssuesToFixes,

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
-Function Invoke-AnalyzerNicSettings {
+function Invoke-AnalyzerNicSettings {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
 . $PSScriptRoot\..\..\..\Shared\VisualCRedistributableVersionFunctions.ps1
-Function Invoke-AnalyzerOsInformation {
+function Invoke-AnalyzerOsInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerWebAppPools.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerWebAppPools.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\Get-DisplayResultsGroupingKey.ps1
-Function Invoke-AnalyzerWebAppPools {
+function Invoke-AnalyzerWebAppPools {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityAMSIConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityAMSIConfigState.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-AnalyzerSecurityAMSIConfigState {
+function Invoke-AnalyzerSecurityAMSIConfigState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2020-0796.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2020-0796.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-2020-0796 {
+function Invoke-AnalyzerSecurityCve-2020-0796 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2020-1147.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2020-1147.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-2020-1147 {
+function Invoke-AnalyzerSecurityCve-2020-1147 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-1730.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-1730.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-2021-1730 {
+function Invoke-AnalyzerSecurityCve-2021-1730 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-34470.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-34470.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-2021-34470 {
+function Invoke-AnalyzerSecurityCve-2021-34470 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-21978.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-21978.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-2022-21978 {
+function Invoke-AnalyzerSecurityCve-2022-21978 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-MarchSuSpecial.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-MarchSuSpecial.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCve-MarchSuSpecial {
+function Invoke-AnalyzerSecurityCve-MarchSuSpecial {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -23,13 +23,13 @@ Function Invoke-AnalyzerSecurityCve-MarchSuSpecial {
         ($SecurityObject.ExchangeInformation.BuildInformation.SupportedBuild -eq $false)) {
         if (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2013) -and
             ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU23)) {
-            Switch ($SecurityObject.CU) {
+            switch ($SecurityObject.CU) {
                 ([HealthChecker.ExchangeCULevel]::CU21) { $KBCveComb = @{KB4340731 = "CVE-2018-8302"; KB4459266 = "CVE-2018-8265", "CVE-2018-8448"; KB4471389 = "CVE-2019-0586", "CVE-2019-0588" } }
                 ([HealthChecker.ExchangeCULevel]::CU22) { $KBCveComb = @{KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018" } }
             }
         } elseif (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) -and
             ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU18)) {
-            Switch ($SecurityObject.CU) {
+            switch ($SecurityObject.CU) {
                 ([HealthChecker.ExchangeCULevel]::CU8) { $KBCveComb = @{KB4073392 = "CVE-2018-0924", "CVE-2018-0940", "CVE-2018-0941"; KB4092041 = "CVE-2018-8151", "CVE-2018-8152", "CVE-2018-8153", "CVE-2018-8154", "CVE-2018-8159" } }
                 ([HealthChecker.ExchangeCULevel]::CU9) { $KBCveComb = @{KB4092041 = "CVE-2018-8151", "CVE-2018-8152", "CVE-2018-8153", "CVE-2018-8154", "CVE-2018-8159"; KB4340731 = "CVE-2018-8374", "CVE-2018-8302" } }
                 ([HealthChecker.ExchangeCULevel]::CU10) { $KBCveComb = @{KB4340731 = "CVE-2018-8374", "CVE-2018-8302"; KB4459266 = "CVE-2018-8265", "CVE-2018-8448"; KB4468741 = "CVE-2018-8604"; KB4471389 = "CVE-2019-0586", "CVE-2019-0588" } }
@@ -43,7 +43,7 @@ Function Invoke-AnalyzerSecurityCve-MarchSuSpecial {
             }
         } elseif (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) -and
             ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU7)) {
-            Switch ($SecurityObject.CU) {
+            switch ($SecurityObject.CU) {
                 ([HealthChecker.ExchangeCULevel]::RTM) { $KBCveComb = @{KB4471389 = "CVE-2019-0586", "CVE-2019-0588"; KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018" } }
                 ([HealthChecker.ExchangeCULevel]::CU1) { $KBCveComb = @{KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018"; KB4509409 = "CVE-2019-1084", "CVE-2019-1137"; KB4515832 = "CVE-2019-1233", "CVE-2019-1266" } }
                 ([HealthChecker.ExchangeCULevel]::CU2) { $KBCveComb = @{KB4509409 = "CVE-2019-1084", "CVE-2019-1137"; KB4515832 = "CVE-2019-1233", "CVE-2019-1266"; KB4523171 = "CVE-2019-1373" } }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -8,7 +8,7 @@
 . $PSScriptRoot\Invoke-AnalyzerSecurityCve-2022-21978.ps1
 . $PSScriptRoot\Invoke-AnalyzerSecurityCve-MarchSuSpecial.ps1
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityCveCheck {
+function Invoke-AnalyzerSecurityCveCheck {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -21,7 +21,7 @@ Function Invoke-AnalyzerSecurityCveCheck {
         [object]$DisplayGroupingKey
     )
 
-    Function TestVulnerabilitiesByBuildNumbersForDisplay {
+    function TestVulnerabilitiesByBuildNumbersForDisplay {
         param(
             [Parameter(Mandatory = $true)][string]$ExchangeBuildRevision,
             [Parameter(Mandatory = $true)][array]$SecurityFixedBuilds,

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-AnalyzerSecurityExchangeCertificates {
+function Invoke-AnalyzerSecurityExchangeCertificates {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -77,7 +77,7 @@ Function Invoke-AnalyzerSecurityExchangeCertificates {
         $certStatusWriteType = [string]::Empty
 
         if ($null -ne $certificate.Status) {
-            Switch ($certificate.Status) {
+            switch ($certificate.Status) {
                 ("Unknown") { $certStatusWriteType = "Yellow" }
                 ("Valid") { $certStatusWriteType = "Grey" }
                 ("Revoked") { $certStatusWriteType = "Red" }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityMitigationService.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityMitigationService.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
-Function Invoke-AnalyzerSecurityMitigationService {
+function Invoke-AnalyzerSecurityMitigationService {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -6,7 +6,7 @@
 . $PSScriptRoot\Invoke-AnalyzerSecurityExchangeCertificates.ps1
 . $PSScriptRoot\Invoke-AnalyzerSecurityAMSIConfigState.ps1
 . $PSScriptRoot\Invoke-AnalyzerSecurityMitigationService.ps1
-Function Invoke-AnalyzerSecuritySettings {
+function Invoke-AnalyzerSecuritySettings {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -83,7 +83,7 @@ Function Invoke-AnalyzerSecuritySettings {
     }
     Add-AnalyzedResultInformation @params
 
-    Function GetBadTlsValueSetting {
+    function GetBadTlsValueSetting {
         [CmdletBinding()]
         param(
             [Parameter(ValueFromPipeline = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
 . $PSScriptRoot\..\Get-DisplayResultsGroupingKey.ps1
 . $PSScriptRoot\Invoke-AnalyzerSecurityCveCheck.ps1
-Function Invoke-AnalyzerSecurityVulnerability {
+function Invoke-AnalyzerSecurityVulnerability {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Diagnostics/HealthChecker/Analyzer/Tests/Invoke-AnalyzerKnownBuildIssues.Tests.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Tests/Invoke-AnalyzerKnownBuildIssues.Tests.ps1
@@ -9,9 +9,9 @@ BeforeAll {
     . $PSScriptRoot\..\..\..\..\Shared\PesterLoadFunctions.NotPublished.ps1
     $scriptContent = Get-PesterScriptContent -FilePath "$PSScriptRoot\..\Invoke-AnalyzerKnownBuildIssues.ps1"
     Invoke-Expression $scriptContent
-    Function Invoke-CatchActions { throw "Called Invoke-CatchActions" }
+    function Invoke-CatchActions { throw "Called Invoke-CatchActions" }
 
-    Function TestPesterResults {
+    function TestPesterResults {
         param(
             [hashtable]$TestGroup,
             [object]$KnownIssue

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-ExSetupDetails {
+function Get-ExSetupDetails {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $exSetupDetails = [string]::Empty
-    Function Get-ExSetupDetailsScriptBlock {
+    function Get-ExSetupDetailsScriptBlock {
         Get-Command ExSetup | ForEach-Object { $_.FileVersionInfo }
     }
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAMSIConfigurationState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAMSIConfigurationState.ps1
@@ -2,12 +2,12 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
-Function Get-ExchangeAMSIConfigurationState {
+function Get-ExchangeAMSIConfigurationState {
     [CmdletBinding()]
     param ()
 
     begin {
-        Function Get-AMSIStatusFlag {
+        function Get-AMSIStatusFlag {
             [CmdletBinding()]
             [OutputType([bool])]
             param (
@@ -17,10 +17,10 @@ Function Get-ExchangeAMSIConfigurationState {
 
             Write-Verbose "Calling: $($MyInvocation.MyCommand)"
             try {
-                Switch ($AMSIParameters.Split("=")[1]) {
+                switch ($AMSIParameters.Split("=")[1]) {
                     ("False") { return $false }
                     ("True") { return $true }
-                    Default { return $null }
+                    default { return $null }
                 }
             } catch {
                 Write-Verbose "Ran into an issue when calling Split method. Parameters passed: $AMSIParameters"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ActiveDirectoryAcl.ps1
 
-Function Get-ExchangeAdPermissions {
+function Get-ExchangeAdPermissions {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -15,7 +15,7 @@ Function Get-ExchangeAdPermissions {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
-    Function NewMatchingEntry {
+    function NewMatchingEntry {
         param(
             [ValidateSet("Domain", "AdminSDHolder")]
             [string]$TargetObject,
@@ -30,7 +30,7 @@ Function Get-ExchangeAdPermissions {
         }
     }
 
-    Function NewGroupEntry {
+    function NewGroupEntry {
         param(
             [string]$Name,
             [object[]]$MatchingEntries

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdSchemaClass.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdSchemaClass.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ExchangeAdSchemaClass {
+function Get-ExchangeAdSchemaClass {
     param(
         [Parameter(Mandatory = $true)][string]$SchemaClassName
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAppPoolsInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAppPoolsInformation.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-AppPool.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-ExchangeAppPoolsInformation {
+function Get-ExchangeAppPoolsInformation {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeApplicationConfigurationFileValidation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeApplicationConfigurationFileValidation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-ExchangeApplicationConfigurationFileValidation {
+function Get-ExchangeApplicationConfigurationFileValidation {
     param(
         [string[]]$ConfigFileLocation
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeConnectors.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeConnectors.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
-Function Get-ExchangeConnectors {
+function Get-ExchangeConnectors {
     [CmdletBinding()]
     [OutputType("System.Object[]")]
     param(

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDependentServices.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDependentServices.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
-Function Get-ExchangeDependentServices {
+function Get-ExchangeDependentServices {
     [CmdletBinding()]
     param(
         [string]$MachineName
@@ -23,7 +23,7 @@ Function Get-ExchangeDependentServices {
         $criticalServices = New-Object 'System.Collections.Generic.List[object]'
         $commonServices = New-Object 'System.Collections.Generic.List[object]'
         $getServicesList = New-Object 'System.Collections.Generic.List[object]'
-        Function TestServiceRunning {
+        function TestServiceRunning {
             param(
                 [object]$Service
             )
@@ -32,7 +32,7 @@ Function Get-ExchangeDependentServices {
             return $false
         }
 
-        Function NewServiceObject {
+        function NewServiceObject {
             param(
                 [object]$Service
             )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
 
-Function Get-ExchangeDomainConfigVersion {
+function Get-ExchangeDomainConfigVersion {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeEmergencyMitigationServiceState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeEmergencyMitigationServiceState.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-ExchangeEmergencyMitigationServiceState {
+function Get-ExchangeEmergencyMitigationServiceState {
     [CmdletBinding()]
     [OutputType("System.Object")]
     param(

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeIISConfigSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeIISConfigSettings.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
 
-Function Get-ExchangeIISConfigSettings {
+function Get-ExchangeIISConfigSettings {
     [CmdletBinding()]
     param(
         [string]$MachineName,
@@ -13,7 +13,7 @@ Function Get-ExchangeIISConfigSettings {
     begin {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         Write-Verbose "Passed ExchangeInstallPath: $ExchangeInstallPath"
-        Function GetExchangeIISConfigSettings {
+        function GetExchangeIISConfigSettings {
             param(
                 [string]$ExchangeInstallPath
             )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -20,7 +20,7 @@
 . $PSScriptRoot\Get-ExSetupDetails.ps1
 . $PSScriptRoot\Get-FIPFSScanEngineVersionState.ps1
 . $PSScriptRoot\Get-ServerRole.ps1
-Function Get-ExchangeInformation {
+function Get-ExchangeInformation {
     param(
         [HealthChecker.OSServerVersion]$OSMajorVersion
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Get-ExchangeRegistryValues {
+function Get-ExchangeRegistryValues {
     [CmdletBinding()]
     param(
         [string]$MachineName,

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
-Function Get-ExchangeServerCertificates {
+function Get-ExchangeServerCertificates {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
@@ -107,7 +107,7 @@ Function Get-ExchangeServerCertificates {
                             "1.2.840.10045.4.3.3" { $certSignatureHashAlgorithm = "sha384"; $certSignatureHashAlgorithmSecure = 2 }
                             "1.2.840.10045.4.3.4" { $certSignatureHashAlgorithm = "sha512"; $certSignatureHashAlgorithmSecure = 2 }
                             "1.2.840.10045.4.3" { $certSignatureHashAlgorithm = "sha256"; $certSignatureHashAlgorithmSecure = 2 }
-                            Default { $certSignatureHashAlgorithm = "Unknown"; $certSignatureHashAlgorithmSecure = 0 }
+                            default { $certSignatureHashAlgorithm = "Unknown"; $certSignatureHashAlgorithmSecure = 0 }
                         }
                     }
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceState.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
-Function Get-ExchangeServerMaintenanceState {
+function Get-ExchangeServerMaintenanceState {
     param(
         [Parameter(Mandatory = $false)][array]$ComponentsToSkip
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistrySubKey.ps1
-Function Get-ExchangeUpdates {
+function Get-ExchangeUpdates {
     param(
         [Parameter(Mandatory = $true)][HealthChecker.ExchangeMajorVersion]$ExchangeMajorVersion
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-FIPFSScanEngineVersionState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-FIPFSScanEngineVersionState.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\..\..\Helpers\Invoke-CatchActions.ps1
 
-Function Get-FIPFSScanEngineVersionState {
+function Get-FIPFSScanEngineVersionState {
     [CmdletBinding()]
     [OutputType("System.Object")]
     param (

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-HealthCheckerExchangeServer.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-HealthCheckerExchangeServer.ps1
@@ -6,7 +6,7 @@
 . $PSScriptRoot\..\ServerInformation\Get-OperatingSystemInformation.ps1
 . $PSScriptRoot\..\ServerInformation\Get-DotNetDllFileVersions.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-NETFrameworkVersion.ps1
-Function Get-HealthCheckerExchangeServer {
+function Get-HealthCheckerExchangeServer {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ServerRole.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ServerRole.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ServerRole {
+function Get-ServerRole {
     param(
         [Parameter(Mandatory = $true)][object]$ExchangeServerObj
     )

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeAMSIConfigurationState.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeAMSIConfigurationState.Tests.ps1
@@ -10,11 +10,11 @@ BeforeAll {
     $Script:Server = $env:COMPUTERNAME
     . $Script:parentPath\Get-ExchangeAMSIConfigurationState.ps1
 
-    Function Get-SettingOverride {
+    function Get-SettingOverride {
         param()
     }
 
-    Function Invoke-CatchActions {
+    function Invoke-CatchActions {
         param()
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectors.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectors.Tests.ps1
@@ -10,19 +10,19 @@ BeforeAll {
     . $Script:parentPath\Get-ExchangeConnectors.ps1
     . $Script:parentPath\Get-ExchangeServerCertificates.ps1
 
-    Function Invoke-CatchActions {
+    function Invoke-CatchActions {
         param()
     }
 
-    Function Get-ExchangeCertificate {
+    function Get-ExchangeCertificate {
         param()
     }
 
-    Function Get-ReceiveConnector {
+    function Get-ReceiveConnector {
         param()
     }
 
-    Function Get-SendConnector {
+    function Get-SendConnector {
         param()
     }
 }
@@ -248,7 +248,7 @@ Describe "Testing Get-ExchangeConnectors.ps1" {
         }
 
         It "Send Connector Configured As Expected For Relaying Via M365" {
-            Switch ($results) {
+            switch ($results) {
                 { ($_.SmartHosts -like "*.mail.protection.outlook.com") } {
                     $smartHostsPointToExo = $true;
                     $_.Name | Should -Be "My company to Office 365";

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeEmergencyMitigationServiceState.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeEmergencyMitigationServiceState.Tests.ps1
@@ -12,7 +12,7 @@ BeforeAll {
 
     # We need to overwrite the existing 'Get-Service' function because it doesn't support
     # the '-ComputerName' parameter on PowerShell 7
-    Function Get-Service {
+    function Get-Service {
         param(
             [Parameter(Mandatory = $false)]
             [string]

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeServerCertificates.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeServerCertificates.Tests.ps1
@@ -10,15 +10,15 @@ BeforeAll {
     $Script:Server = $env:COMPUTERNAME
     . $Script:parentPath\Get-ExchangeServerCertificates.ps1
 
-    Function Invoke-CatchActions {
+    function Invoke-CatchActions {
         param()
     }
 
-    Function Get-AuthConfig {
+    function Get-AuthConfig {
         param()
     }
 
-    Function Get-ExchangeCertificate {
+    function Get-ExchangeCertificate {
         param()
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-FIPFSScanEngineVersionState.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-FIPFSScanEngineVersionState.Tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
     $Script:Server = $env:COMPUTERNAME
     . $Script:parentPath\Get-FIPFSScanEngineVersionState.ps1
 
-    Function Invoke-CatchActions {
+    function Invoke-CatchActions {
         param()
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllNicInformation.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-CatchActionError.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-CatchActionErrorLoop.ps1
-Function Get-AllNicInformation {
+function Get-AllNicInformation {
     [CmdletBinding()]
     param(
         [string]$ComputerName = $env:COMPUTERNAME,
@@ -15,7 +15,7 @@ Function Get-AllNicInformation {
     begin {
 
         # Extract for Pester Testing - Start
-        Function Get-NicPnpCapabilitiesSetting {
+        function Get-NicPnpCapabilitiesSetting {
             [CmdletBinding()]
             param(
                 [ValidateNotNullOrEmpty()]
@@ -60,7 +60,7 @@ Function Get-AllNicInformation {
 
         # Extract for Pester Testing - End
 
-        Function Get-NetworkConfiguration {
+        function Get-NetworkConfiguration {
             [CmdletBinding()]
             param(
                 [string]$ComputerName
@@ -88,7 +88,7 @@ Function Get-AllNicInformation {
             }
         }
 
-        Function Get-NicInformation {
+        function Get-NicInformation {
             [CmdletBinding()]
             param(
                 [array]$NetworkConfiguration,
@@ -96,7 +96,7 @@ Function Get-AllNicInformation {
             )
             begin {
 
-                Function Get-IpvAddresses {
+                function Get-IpvAddresses {
                     return [PSCustomObject]@{
                         Address        = ([string]::Empty)
                         Subnet         = ([string]::Empty)

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllTlsSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllTlsSettings.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\Get-AllTlsSettingsFromRegistry.ps1
 
 # Gets all related TLS Settings, from registry or other factors
-Function Get-AllTlsSettings {
+function Get-AllTlsSettings {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllTlsSettingsFromRegistry.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-AllTlsSettingsFromRegistry.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Get-AllTlsSettingsFromRegistry {
+function Get-AllTlsSettingsFromRegistry {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,
@@ -10,7 +10,7 @@ Function Get-AllTlsSettingsFromRegistry {
     )
     begin {
 
-        Function Get-TLSMemberValue {
+        function Get-TLSMemberValue {
             param(
                 [Parameter(Mandatory = $true)]
                 [string]
@@ -31,7 +31,7 @@ Function Get-AllTlsSettingsFromRegistry {
             }
         }
 
-        Function Get-NETDefaultTLSValue {
+        function Get-NETDefaultTLSValue {
             param(
                 [Parameter(Mandatory = $false)]
                 [object]

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-CredentialGuardEnabled.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-CredentialGuardEnabled.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Get-CredentialGuardEnabled {
+function Get-CredentialGuardEnabled {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $registryValue = Get-RemoteRegistryValue -MachineName $Script:Server `

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-DotNetDllFileVersions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-DotNetDllFileVersions.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-DotNetDllFileVersions {
+function Get-DotNetDllFileVersions {
     [CmdletBinding()]
     [OutputType("System.Collections.Hashtable")]
     param(
@@ -13,7 +13,7 @@ Function Get-DotNetDllFileVersions {
     )
 
     begin {
-        Function Invoke-ScriptBlockGetItem {
+        function Invoke-ScriptBlockGetItem {
             param(
                 [string]$FilePath
             )

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HardwareInformation.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\Get-ServerType.ps1
 . $PSScriptRoot\Get-WmiObjectCriticalHandler.ps1
 . $PSScriptRoot\Get-WmiObjectHandler.ps1
-Function Get-HardwareInformation {
+function Get-HardwareInformation {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HttpProxySetting.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-HttpProxySetting.ps1
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-HttpProxySetting {
+function Get-HttpProxySetting {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
-    Function GetWinHttpSettings {
+    function GetWinHttpSettings {
         param(
             [Parameter(Mandatory = $true)][string]$RegistryLocation
         )

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-LmCompatibilityLevelInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-LmCompatibilityLevelInformation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Get-LmCompatibilityLevelInformation {
+function Get-LmCompatibilityLevelInformation {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
@@ -21,7 +21,7 @@ Function Get-LmCompatibilityLevelInformation {
     $ServerLmCompatObject.RegistryValue = $registryValue
     Write-Verbose "LmCompatibilityLevel Registry Value: $registryValue"
 
-    Switch ($ServerLmCompatObject.RegistryValue) {
+    switch ($ServerLmCompatObject.RegistryValue) {
         0 { $ServerLmCompatObject.Description = "Clients use LM and NTLM authentication, but they never use NTLMv2 session security. Domain controllers accept LM, NTLM, and NTLMv2 authentication." }
         1 { $ServerLmCompatObject.Description = "Clients use LM and NTLM authentication, and they use NTLMv2 session security if the server supports it. Domain controllers accept LM, NTLM, and NTLMv2 authentication." }
         2 { $ServerLmCompatObject.Description = "Clients use only NTLM authentication, and they use NTLMv2 session security if the server supports it. Domain controller accepts LM, NTLM, and NTLMv2 authentication." }
@@ -31,5 +31,5 @@ Function Get-LmCompatibilityLevelInformation {
     }
 
     Write-Verbose "Exiting: $($MyInvocation.MyCommand)"
-    Return $ServerLmCompatObject
+    return $ServerLmCompatObject
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -17,7 +17,7 @@
 . $PSScriptRoot\Get-WmiObjectCriticalHandler.ps1
 . $PSScriptRoot\Get-WmiObjectHandler.ps1
 . $PSScriptRoot\..\..\Helpers\PerformanceCountersFunctions.ps1
-Function Get-OperatingSystemInformation {
+function Get-OperatingSystemInformation {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PageFileInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PageFileInformation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-WmiObjectHandler.ps1
-Function Get-PageFileInformation {
+function Get-PageFileInformation {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $pageFiles = @(Get-WmiObjectHandler -ComputerName $Script:Server -Class "Win32_PageFileSetting" -CatchActionFunction ${Function:Invoke-CatchActions})

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ProcessorInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ProcessorInformation.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-WmiObjectCriticalHandler.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-ProcessorInformation {
+function Get-ProcessorInformation {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerOperatingSystemVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerOperatingSystemVersion.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-WmiObjectHandler.ps1
-Function Get-ServerOperatingSystemVersion {
+function Get-ServerOperatingSystemVersion {
     [CmdletBinding()]
     [OutputType("System.String")]
     param(

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerType.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerType.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ServerType {
+function Get-ServerType {
     [CmdletBinding()]
     [OutputType("System.String")]
     param(

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-Function Get-Smb1ServerSettings {
+function Get-Smb1ServerSettings {
     [CmdletBinding()]
     param(
         [string]$ServerName = $env:COMPUTERNAME,

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-TimeZoneInformationRegistrySettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-TimeZoneInformationRegistrySettings.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
-Function Get-TimeZoneInformationRegistrySettings {
+function Get-TimeZoneInformationRegistrySettings {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,
@@ -51,4 +51,3 @@ Function Get-TimeZoneInformationRegistrySettings {
         }
     }
 }
-

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectCriticalHandler.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-WmiObjectHandler.ps1
-Function Get-WmiObjectCriticalHandler {
+function Get-WmiObjectCriticalHandler {
     [CmdletBinding()]
     param(
         [string]

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectHandler.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-WmiObjectHandler.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-WmiObjectHandler {
+function Get-WmiObjectHandler {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'This is what this function is for')]
     [CmdletBinding()]
     param(

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
         $Script:net2Wow = "SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727"
         $Script:enabledKey = "Enabled"
 
-        Function SetVariables {
+        function SetVariables {
             $Script:result = Get-AllTlsSettingsFromRegistry
             $Script:tls10 = $result.TLS["1.0"]
             $Script:tls11 = $result.TLS["1.1"]
@@ -29,7 +29,7 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
             $Script:netv2 = $result.NET["NETv2"]
         }
 
-        Function TestObjectCompare {
+        function TestObjectCompare {
             param(
                 [object]$CompareObject,
                 [object]$TestObject

--- a/Diagnostics/HealthChecker/Features/Get-CasLoadBalancingReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-CasLoadBalancingReport.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Helpers\PerformanceCountersFunctions.ps1
-Function Get-CASLoadBalancingReport {
+function Get-CASLoadBalancingReport {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $CASServers = @()
@@ -25,10 +25,10 @@ Function Get-CASLoadBalancingReport {
 
     if ($CASServers.Count -eq 0) {
         Write-Red("Error: No CAS servers found using the specified search criteria.")
-        Exit
+        exit
     }
 
-    Function DisplayKeyMatching {
+    function DisplayKeyMatching {
         param(
             [string]$CounterValue,
             [string]$DisplayValue

--- a/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ComputerCoresObject {
+function Get-ComputerCoresObject {
     param(
         [Parameter(Mandatory = $true)][string]$Machine_Name
     )
@@ -39,7 +39,7 @@ Function Get-ComputerCoresObject {
     return $returnObj
 }
 
-Function Get-ExchangeDCCoreRatio {
+function Get-ExchangeDCCoreRatio {
 
     Invoke-ScriptLogFileLocation -FileName "HealthChecker-ExchangeDCCoreRatio"
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"

--- a/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
@@ -1,13 +1,13 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-HtmlServerReport {
+function Get-HtmlServerReport {
     param(
         [Parameter(Mandatory = $true)][array]$AnalyzedHtmlServerValues
     )
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
-    Function GetOutColumnHtmlTable {
+    function GetOutColumnHtmlTable {
         param(
             [object]$OutColumn
         )

--- a/Diagnostics/HealthChecker/Features/Get-MailboxDatabaseAndMailboxStatistics.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-MailboxDatabaseAndMailboxStatistics.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-MailboxDatabaseAndMailboxStatistics {
+function Get-MailboxDatabaseAndMailboxStatistics {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $AllDBs = Get-MailboxDatabaseCopyStatus -server $Script:Server -ErrorAction SilentlyContinue

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -150,7 +150,7 @@ if ($PSBoundParameters["Verbose"]) {
 . $PSScriptRoot\..\..\Shared\ScriptUpdateFunctions\Test-ScriptVersion.ps1
 . $PSScriptRoot\..\..\Shared\Write-Host.ps1
 
-Function Main {
+function Main {
 
     if (-not (Confirm-Administrator) -and
         (-not $AnalyzeDataOnly -and
@@ -313,4 +313,3 @@ try {
     }
     RevertProperForegroundColor
 }
-

--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -1,9 +1,9 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ErrorsThatOccurred {
+function Get-ErrorsThatOccurred {
 
-    Function WriteErrorInformation {
+    function WriteErrorInformation {
         [CmdletBinding()]
         param(
             [object]$CurrentError
@@ -24,7 +24,7 @@ Function Get-ErrorsThatOccurred {
 
     if ($Error.Count -gt 0) {
         Write-Grey(" "); Write-Grey(" ")
-        Function Write-Errors {
+        function Write-Errors {
             Write-Verbose "`r`n`r`nErrors that occurred that wasn't handled"
 
             $index = 0

--- a/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-HealthCheckFilesItemsFromLocation {
+function Get-HealthCheckFilesItemsFromLocation {
     $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthChecker-*-*.xml" }
 
     if ($null -eq $items) {

--- a/Diagnostics/HealthChecker/Helpers/Get-OnlyRecentUniqueServersXmls.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-OnlyRecentUniqueServersXmls.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-OnlyRecentUniqueServersXMLs {
+function Get-OnlyRecentUniqueServersXMLs {
     param(
         [Parameter(Mandatory = $true)][array]$FileItems
     )

--- a/Diagnostics/HealthChecker/Helpers/Import-MyData.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Import-MyData.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Import-MyData {
+function Import-MyData {
     param(
         [Parameter(Mandatory = $true)][array]$FilePaths
     )

--- a/Diagnostics/HealthChecker/Helpers/Invoke-CatchActions.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-CatchActions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-CatchActions {
+function Invoke-CatchActions {
     param(
         [object]$CopyThisError = $Error[0]
     )

--- a/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\..\Shared\Confirm-ExchangeShell.ps1
-Function Invoke-ScriptLogFileLocation {
+function Invoke-ScriptLogFileLocation {
     param(
         [Parameter(Mandatory = $true)][string]$FileName,
         [Parameter(Mandatory = $false)][bool]$IgnoreToolsIdentity = $false,

--- a/Diagnostics/HealthChecker/Helpers/PerformanceCountersFunctions.ps1
+++ b/Diagnostics/HealthChecker/Helpers/PerformanceCountersFunctions.ps1
@@ -6,7 +6,7 @@
 . $PSScriptRoot\Invoke-CatchActions.ps1
 
 # Use this after the counters have been localized.
-Function Get-CounterSamples {
+function Get-CounterSamples {
     param(
         [Parameter(Mandatory = $true)]
         [string[]]$MachineName,
@@ -27,7 +27,7 @@ Function Get-CounterSamples {
 }
 
 # Use this to localize the counters provided
-Function Get-LocalizedCounterSamples {
+function Get-LocalizedCounterSamples {
     param(
         [Parameter(Mandatory = $true)]
         [string[]]$MachineName,
@@ -58,7 +58,7 @@ Function Get-LocalizedCounterSamples {
     return (Get-CounterSamples -MachineName $MachineName -Counter $localizedCounters -CustomErrorAction $CustomErrorAction)
 }
 
-Function Get-LocalizedPerformanceCounterName {
+function Get-LocalizedPerformanceCounterName {
     [CmdletBinding()]
     [OutputType('System.String')]
     param(
@@ -152,7 +152,7 @@ Function Get-LocalizedPerformanceCounterName {
     }
 }
 
-Function Get-CounterFullNameToCounterObject {
+function Get-CounterFullNameToCounterObject {
     param(
         [Parameter(Mandatory = $true)]
         [string]$FullCounterName

--- a/Diagnostics/HealthChecker/Helpers/Test-RequiresServerFqdn.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Test-RequiresServerFqdn.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Test-RequiresServerFqdn {
+function Test-RequiresServerFqdn {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $tempServerName = ($Script:Server).Split(".")

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -22,7 +22,7 @@ Mock Get-WmiObjectHandler {
         "Win32_PageFileSetting" { return Import-Clixml "$Script:MockDataCollectionRoot\OS\Win32_PageFileSetting.xml" }
         "Win32_NetworkAdapterConfiguration" { return Import-Clixml "$Script:MockDataCollectionRoot\OS\Win32_NetworkAdapterConfiguration.xml" }
         "Win32_NetworkAdapter" { return Import-Clixml "$Script:MockDataCollectionRoot\OS\Win32_NetworkAdapter.xml" }
-        Default { throw "Failed to find class" }
+        default { throw "Failed to find class" }
     }
 }
 
@@ -49,7 +49,7 @@ Mock Get-RemoteRegistryValue {
         "Enabled" { return 0 }
         "DisableGranularReplication" { return 0 }
         "DisableAsyncNotification" { return 0 }
-        Default { throw "Failed to find GetValue: $GetValue" }
+        default { throw "Failed to find GetValue: $GetValue" }
     }
 }
 
@@ -152,42 +152,42 @@ Mock Get-ExchangeIISConfigSettings {
 Mock Invoke-CatchActions { }
 
 # Need to use function instead of Mock for Exchange cmdlets
-Function Get-ExchangeServer {
+function Get-ExchangeServer {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeServer.xml"
 }
 
-Function Get-ExchangeCertificate {
+function Get-ExchangeCertificate {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeCertificate.xml"
 }
 
-Function Get-AuthConfig {
+function Get-AuthConfig {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetAuthConfig.xml"
 }
 
-Function Get-ExSetupDetails {
+function Get-ExSetupDetails {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\ExSetup.xml"
 }
 
-Function Get-MailboxServer {
+function Get-MailboxServer {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetMailboxServer.xml"
 }
 
-Function Get-OwaVirtualDirectory {
+function Get-OwaVirtualDirectory {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOwaVirtualDirectory.xml"
 }
 
-Function Get-WebServicesVirtualDirectory {
+function Get-WebServicesVirtualDirectory {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetWebServicesVirtualDirectory.xml"
 }
 
-Function Get-OrganizationConfig {
+function Get-OrganizationConfig {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOrganizationConfig.xml"
 }
 
-Function Get-HybridConfiguration { return $null }
+function Get-HybridConfiguration { return $null }
 
 # Needs to be a function as PS core doesn't have -ComputerName parameter
-Function Get-Service {
+function Get-Service {
     [CmdletBinding()]
     param(
         [string]$ComputerName,
@@ -197,26 +197,26 @@ Function Get-Service {
     return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetService.xml"
 }
 
-Function Get-ServerComponentState {
+function Get-ServerComponentState {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetServerComponentState.xml"
 }
 
-Function Test-ServiceHealth {
+function Test-ServiceHealth {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\TestServiceHealth.xml"
 }
 
-Function Get-SettingOverride {
+function Get-SettingOverride {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetSettingOverride.xml"
 }
 
-Function Get-AcceptedDomain {
+function Get-AcceptedDomain {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetAcceptedDomain.xml"
 }
 
-Function Get-ReceiveConnector {
+function Get-ReceiveConnector {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetReceiveConnector.xml"
 }
 
-Function Get-SendConnector {
+function Get-SendConnector {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetSendConnector.xml"
 }

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTests.ImportCode.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTests.ImportCode.NotPublished.ps1
@@ -16,7 +16,7 @@ $scriptContent = Get-PesterScriptContent -FilePath @(
 
 Invoke-Expression $scriptContent
 
-Function SetActiveDisplayGrouping {
+function SetActiveDisplayGrouping {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 1)]
@@ -26,7 +26,7 @@ Function SetActiveDisplayGrouping {
     $Script:ActiveGrouping = $Script:results.DisplayResults[$key]
 }
 
-Function GetObject {
+function GetObject {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 1)]
@@ -36,7 +36,7 @@ Function GetObject {
     ($Script:ActiveGrouping | Where-Object { $_.TestingName -eq $Name }).TestingValue
 }
 
-Function GetWriteTypeObject {
+function GetWriteTypeObject {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 1)]
@@ -46,7 +46,7 @@ Function GetWriteTypeObject {
     ($Script:ActiveGrouping | Where-Object { $_.TestingName -eq $Name }).WriteType
 }
 
-Function TestObjectMatch {
+function TestObjectMatch {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 1)]
@@ -65,7 +65,7 @@ Function TestObjectMatch {
         Should -Be $WriteType
 }
 
-Function TestOutColumnObjectCompare {
+function TestOutColumnObjectCompare {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -88,7 +88,7 @@ Function TestOutColumnObjectCompare {
     }
 }
 
-Function NewOutColumnCompareValue {
+function NewOutColumnCompareValue {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 1)]

--- a/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
@@ -45,6 +45,6 @@ function Write-OutColumns($OutColumns) {
     }
 }
 
-Function Write-Break {
+function Write-Break {
     Write-Host ""
 }

--- a/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-ResultsToScreen {
+function Write-ResultsToScreen {
     param(
         [Hashtable]$ResultsToWrite
     )

--- a/Diagnostics/HealthChecker/Writers/Write-Verbose.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-Verbose.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-Verbose {
+function Write-Verbose {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose from Shared functions')]
     [CmdletBinding()]
     param(

--- a/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
+++ b/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
@@ -7,7 +7,7 @@
 #  Provide your feedback to ExToolsFeedback@microsoft.com
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Override for now')]
 [cmdletbinding()]
-Param([string]$pathforlogs, [switch]$Collect , [switch] $AllServers , [switch] $OnlyThisServer , [switch]$Help)
+param([string]$pathforlogs, [switch]$Collect , [switch] $AllServers , [switch] $OnlyThisServer , [switch]$Help)
 
 $Script:lastProbeerror = $null
 $Script:foundissue = $false
@@ -17,7 +17,7 @@ $Script:LoggingMonitoringpath = ""
 
 function TestFileorCmd {
     [cmdletbinding()]
-    Param( [String] $FileorCmd )
+    param( [String] $FileorCmd )
 
     if ($FileorCmd -like "File missing for this action*") {
         Write-Host -ForegroundColor red $FileorCmd;
@@ -27,7 +27,7 @@ function TestFileorCmd {
 
 function ParseProbeResult {
     [cmdletbinding()]
-    Param( [String] $FilterXpath , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
+    param( [String] $FilterXpath , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
 
     TestFileorCmd $ProbeResulteventcmd;
     ParseProbeResult2 -ProbeResulteventcompletecmd ($ProbeResulteventcmd + " -maxevents 200" ) `
@@ -46,7 +46,7 @@ function ParseProbeResult {
 
 function ParseProbeResult2 {
     [cmdletbinding()]
-    Param( [String] $ProbeResulteventcompletecmd , [String] $FilterXpath , [String] $waitstring , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
+    param( [String] $ProbeResulteventcompletecmd , [String] $FilterXpath , [String] $waitstring , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
 
     TestFileorCmd $ProbeResulteventcmd;
     $Probeeventscmd = '(' + $ProbeResulteventcompletecmd + ' -FilterXPath ("' + $FilterXpath + '") -ErrorAction SilentlyContinue | % {[XML]$_.toXml()}).event.userData.eventXml'
@@ -73,10 +73,10 @@ function ParseProbeResult2 {
     }
     if ($Probeevents) {
         foreach ($Probeevt in $Probeevents) {
-            If ($Probeevt.ResultType -eq 4) {
+            if ($Probeevt.ResultType -eq 4) {
                 $Script:lastProbeerror = $Probeevt
                 if ($Script:KnownIssueDetectionAlreadydone -eq $false) { KnownIssueDetection $MonitorToInvestigate $ResponderToInvestigate }
-                Break;
+                break;
             }
         }
         if ($Script:KnownIssueDetectionAlreadydone -eq $false) { KnownIssueDetection $MonitorToInvestigate $ResponderToInvestigate }
@@ -88,7 +88,7 @@ function ParseProbeResult2 {
 
 function InvestigateProbe {
     [cmdletbinding()]
-    Param([String]$ProbeToInvestigate , [String]$MonitorToInvestigate , [String]$ResponderToInvestigate , [String]$ResourceNameToInvestigate , [String]$ResponderTargetResource )
+    param([String]$ProbeToInvestigate , [String]$MonitorToInvestigate , [String]$ResponderToInvestigate , [String]$ResourceNameToInvestigate , [String]$ResponderTargetResource )
 
     TestFileorCmd $ProbeDefinitioneventcmd;
     if (-Not ($ResponderTargetResource) -and ($ProbeToInvestigate.split("/").Count -gt 1)) {
@@ -153,7 +153,7 @@ function InvestigateProbe {
             }
             Write-Host $relationdescription
         }
-        If ( $Probename -eq "EacBackEndLogonProbe") {
+        if ( $Probename -eq "EacBackEndLogonProbe") {
             if ($Script:KnownIssueDetectionAlreadydone -eq $false) { KnownIssueDetection $MonitorToInvestigate $ResponderToInvestigate }
 
             $EacBackEndLogonProbefolder = $Script:LoggingMonitoringpath + "\ECP\EacBackEndLogonProbe"
@@ -174,10 +174,10 @@ function InvestigateProbe {
     { Write-Host("`nFound no definitions for " + $ProbeToInvestigate + " probe") }
 }
 
-Function InvestigateMonitor {
+function InvestigateMonitor {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Override for now')]
     [cmdletbinding()]
-    Param( [String]$MonitorToInvestigate , [String]$ResourceNameToInvestigate , [String]$ResponderTargetResource , [String] $ResponderToInvestigate)
+    param( [String]$MonitorToInvestigate , [String]$ResourceNameToInvestigate , [String]$ResponderTargetResource , [String] $ResponderToInvestigate)
 
     if ($MonitorToInvestigate -like "MaintenanceFailureMonitor*") {
         $MaintenanceFailureMonitor = $MonitorToInvestigate.split(".")[1]
@@ -251,7 +251,7 @@ Function InvestigateMonitor {
 
 function InvestigateMaintenanceMonitor {
     [cmdletbinding()]
-    Param([String]$MaintenanceFailureMonitor , [String] $ResponderToInvestigate)
+    param([String]$MaintenanceFailureMonitor , [String] $ResponderToInvestigate)
 
     TestFileorCmd $MaintenanceDefinitioncmd;
     $MaintenanceDefinitioncmd = '(' + $MaintenanceDefinitioncmd + '| % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.ServiceName -like "' + $MaintenanceFailureMonitor + '*" }'
@@ -283,9 +283,9 @@ function InvestigateMaintenanceMonitor {
     }
 }
 
-Function OverrideIfNeeded {
+function OverrideIfNeeded {
     [cmdletbinding()]
-    Param( [String]$ResponderToInvestigate , [String]$ResponderServiceName)
+    param( [String]$ResponderToInvestigate , [String]$ResponderServiceName)
     if ( -not ( $ResponderServiceName)) {
         Write-Host -foreground red ("`nFound no ServiceName for " + $ResponderToInvestigate + " Responder. Thus can't provide the override command to disable this responder if needed.")
         return
@@ -353,9 +353,9 @@ Function OverrideIfNeeded {
     }
 }
 
-Function InvestigateResponder {
+function InvestigateResponder {
     [cmdletbinding()]
-    Param( [String]$ResponderToInvestigate , [String]$ResourceNameToInvestigate )
+    param( [String]$ResponderToInvestigate , [String]$ResourceNameToInvestigate )
 
     if ($ResponderToInvestigate -eq "ManagedAvailabilityStartup") {
         Write-Host "`nManagedAvailabilityStartup means HealthManager can't find the information about the Responder which triggered this reboot."
@@ -438,7 +438,7 @@ Function InvestigateResponder {
 
 function KnownIssueDetection {
     [cmdletbinding()]
-    Param( [String]$MonitorToInvestigate , [String]$ResponderToInvestigate)
+    param( [String]$MonitorToInvestigate , [String]$ResponderToInvestigate)
 
     if ($MonitorToInvestigate -or $ResponderToInvestigate) {
         Write-Host "`nKnown Issue Detection :"
@@ -457,7 +457,7 @@ function KnownIssueDetection {
 
 function CheckifthiscanbeaknownissueusingResponder {
     [cmdletbinding()]
-    Param( [String]$ResponderToInvestigate )
+    param( [String]$ResponderToInvestigate )
 
     $Script:checkforknownissue = $true
     if (($ResponderToInvestigate -eq "ActiveDirectoryConnectivityConfigDCServerReboot") -and ($Majorexchangeversion -eq 15) -and ($Minorexchangeversion -eq 0) -and ($Buildexchangeversion -lt 775)) {
@@ -487,7 +487,7 @@ function CheckifthiscanbeaknownissueusingResponder {
 
 function CheckifthiscanbeaknownissueusingMonitor {
     [cmdletbinding()]
-    Param( [String]$MonitorToInvestigate )
+    param( [String]$MonitorToInvestigate )
 
     $Script:checkforknownissue = $true
     if (($MonitorToInvestigate -like "*Mapi.Submit.Monitor") -and ($Majorexchangeversion -eq 15) -and ($Minorexchangeversion -eq 0)) {
@@ -588,7 +588,7 @@ function CheckifthiscanbeaknownissueusingMonitor {
 
 function InvestigateUnhealthyMonitor {
     [cmdletbinding()]
-    Param([String]$ServerHealthfile )
+    param([String]$ServerHealthfile )
 
     Write-Progress "Checking MonitorHealth"
     if ($pathforlogsspecified) {
@@ -659,7 +659,7 @@ function InvestigateUnhealthyMonitor {
 
 function CollectMaLogs {
     [cmdletbinding()]
-    Param([String] $InvocationPath )
+    param([String] $InvocationPath )
     try {
         $ExchangeServerinfo = Get-ExchangeServer -identity $env:computername -status | Format-List
     } catch [System.Management.Automation.CommandNotFoundException] {
@@ -698,7 +698,7 @@ function CollectMaLogs {
     $EventLogNames = wevtutil.exe el | Select-String "Microsoft-Exchange"
     $EventLogNames += "Application", "System"
 
-    ForEach ($EventLogName in $EventLogNames) {
+    foreach ($EventLogName in $EventLogNames) {
         $progresseventlogmessage = "Collecting " + $EventLogName + " eventlog"
         Write-Progress $progresseventlogmessage
         $wevtutilcmd = $EventLogName -replace "/", ""
@@ -778,7 +778,7 @@ if ( -not ($pathforlogs)) {
             try {
                 Write-Host -ForegroundColor Yellow "Log structure appears to come from ExchangeLogCollector"
                 $maanalysispath = $pathforlogs + "ManagedAvailabilityTroubleshooterAnalysis\"
-                If (!(Test-Path $maanalysispath)) {
+                if (!(Test-Path $maanalysispath)) {
                     New-Item -ItemType Directory -Force -Path $maanalysispath | Out-Null
                     Write-Progress "Unzip logs from ExchangeLogCollector to ManagedAvailabilityTroubleshooterAnalysis folder"
                     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -1207,7 +1207,7 @@ if ($Investigationchoose -eq 3) {
     Write-Progress "Checking SCOM Alerts"
     $alertevents = Invoke-Expression $ManagedAvailabilityMonitoringcmd
     $alerteventsprops = ($alertevents | ForEach-Object { [XML]$_.toXml() }).event.userData.eventXml
-    For ($i = 0; $i -lt $alerteventsprops.Count; $i++) {
+    for ($i = 0; $i -lt $alerteventsprops.Count; $i++) {
         $alerteventsprops[$i] | Add-Member TimeCreated $alertevents[$i].TimeCreated
         if ($CheckAlertsForMultipleMachines)
         { $alerteventsprops[$i] | Add-Member MachineName $alertevents[$i].MachineName }

--- a/Hybrid/Test-HMAEAS.ps1
+++ b/Hybrid/Test-HMAEAS.ps1
@@ -52,7 +52,7 @@ process {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $SMTPAddress = $SMTP.Split("@")
 
-    Function Read-AutoDv2EAS {
+    function Read-AutoDv2EAS {
         [CmdletBinding()]
         param (
             [Parameter()]
@@ -103,7 +103,7 @@ process {
         }
     }
 
-    Function Test-EASBearer {
+    function Test-EASBearer {
         process {
             try {
                 $requestURI = $easUrl
@@ -150,7 +150,7 @@ process {
         }
     }
 
-    Function Test-AutoDetect {
+    function Test-AutoDetect {
         process {
             try {
                 $RequestURI = "https://prod-autodetect.outlookmobile.com/detect?services=office365,outlook,google,icloud,yahoo&protocols=rest-cloud,rest-outlook,rest-office365,eas,imap,smtp"
@@ -190,7 +190,7 @@ process {
         }
     }
 
-    Function Read-EASOptions {
+    function Read-EASOptions {
         process {
             try {
                 Write-Host
@@ -215,7 +215,7 @@ process {
         }
     }
 
-    Function Read-EASSettings {
+    function Read-EASSettings {
         process {
             try {
                 Write-Host
@@ -245,7 +245,7 @@ process {
         }
     }
 
-    Function Get-AccessToken {
+    function Get-AccessToken {
         process {
             try {
                 Write-Host
@@ -294,7 +294,7 @@ process {
         }
     }
 
-    If ($TestEAS) {
+    if ($TestEAS) {
         Write-Host "Installing ADAL package. Please accept if prompted." -ForegroundColor Green
         Install-Package Microsoft.IdentityModel.Clients.ActiveDirectory -RequiredVersion 3.19.8 -Source 'https://www.nuget.org/api/v2' -SkipDependencies -Scope CurrentUser
         Write-Host "Loading ADAL package" -ForegroundColor Green

--- a/M365/src/DLT365Groupsupgrade.ps1
+++ b/M365/src/DLT365Groupsupgrade.ps1
@@ -6,7 +6,7 @@ $ExportPath = "$env:USERPROFILE\Desktop\PowershellDGUpgrade\DlToO365GroupUpgrade
 mkdir $ExportPath -Force | Out-Null
 Add-Content -Path $ExportPath\DlToO365GroupUpgradeCheckslogging.csv  -Value '"Function","Description","Status"'
 $Script:Conditionsfailed = 0
-Function log {
+function log {
     param(
         [Parameter(Mandatory = $true)]
         [string]$CurrentStatus,
@@ -25,7 +25,7 @@ Function log {
     $PSobject | Add-Member -NotePropertyName "Status" -NotePropertyValue $CurrentStatus
     $PSobject | Export-Csv $ExportPath\DlToO365GroupUpgradeCheckslogging.csv -NoTypeInformation -Append
 }
-Function Connect2EXO {
+function Connect2EXO {
     try {
         #Validate EXO V2 is installed
         if ((Get-Module | Where-Object { $_.Name -like "ExchangeOnlineManagement" }).count -eq 1) {
@@ -62,7 +62,7 @@ Function Connect2EXO {
     }
 }
 #Check if Distribution Group can't be upgraded because Member*Restriction is set to "Closed"
-Function Debugmemberrestriction {
+function Debugmemberrestriction {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -79,7 +79,7 @@ Function Debugmemberrestriction {
     }
 }
 #Check if Distribution Group can't be upgraded because it is DirSynced
-Function Debugdirsync {
+function Debugdirsync {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -92,7 +92,7 @@ Function Debugdirsync {
     }
 }
 #Check if Distribution Group can't be upgraded because EmailAddressPolicyViolated
-Function Debugmatchingeap {
+function Debugmatchingeap {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -115,7 +115,7 @@ Function Debugmatchingeap {
     }
 }
 #Check if Distribution Group can't be upgraded because DlHasParentGroups
-Function Debuggroupnesting {
+function Debuggroupnesting {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -173,7 +173,7 @@ Function Debuggroupnesting {
     }
 }
 #Check if Distribution Group can't be upgraded because DlHasNonSupportedMemberTypes with RecipientTypeDetails other than UserMailbox, SharedMailbox, TeamMailbox, MailUser
-Function Debugmembersrecipienttypes {
+function Debugmembersrecipienttypes {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -214,7 +214,7 @@ Function Debugmembersrecipienttypes {
     }
 }
 #Check if Distribution Group can't be upgraded because it has more than 100 owners or it has no owner
-Function Debugownerscount {
+function Debugownerscount {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -229,7 +229,7 @@ Function Debugownerscount {
     }
 }
 #Check if Distribution Group can't be upgraded because the distribution list owner(s) is non-supported with RecipientTypeDetails other than UserMailbox, MailUser
-Function Debugownersstatus {
+function Debugownersstatus {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -272,7 +272,7 @@ Function Debugownersstatus {
     }
 }
 #Check if Distribution Group can't be upgraded because the distribution list is part of Sender Restriction in another DL
-Function Debugsenderrestriction {
+function Debugsenderrestriction {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -306,7 +306,7 @@ Function Debugsenderrestriction {
     }
 }
 #Check if Distribution Group can't be upgraded because Distribution lists which were converted to RoomLists or isn't a security group nor Dynamic DG
-Function Debuggrouprecipienttype {
+function Debuggrouprecipienttype {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -320,7 +320,7 @@ Function Debuggrouprecipienttype {
     }
 }
 #Check if Distribution Group can't be upgraded because the distribution list is configured to be a forwarding address for Shared Mailbox
-Function Debugforwardingforsharedmbxs {
+function Debugforwardingforsharedmbxs {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -361,7 +361,7 @@ Function Debugforwardingforsharedmbxs {
     }
 }
 #Check for duplicate Alias,PrimarySmtpAddress,Name,DisplayName on EXO objects
-Function Debugduplicateobjects {
+function Debugduplicateobjects {
     param(
         [Parameter(Mandatory = $true)]
         [PScustomobject]$Distgroup
@@ -435,7 +435,7 @@ try {
     $CurrentStatus = "Failure"
     log -CurrentStatus $CurrentStatus -Function "Retrieving Distribution Group from EXO Directory" -CurrentDescription $CurrentDescription
     Write-Host "You entered an incorrect smtp, the script is quitting!`n" -ForegroundColor Red
-    Break
+    break
 }
 
 #Intro with group name

--- a/Performance/ExPerfAnalyzer.ps1
+++ b/Performance/ExPerfAnalyzer.ps1
@@ -3,7 +3,7 @@
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Vars are in use')]
 [CmdletBinding()]
-Param(
+param(
     #[Parameter(Mandatory=$true,ParameterSetName="FileDirectory")][string]$PerfmonFileDirectory,
     [Parameter(Mandatory = $false, ParameterSetName = "FileDirectory")]
     [Parameter(ParameterSetName = "SingleFile")][int64]$MaxSamples = [Int64]::MaxValue,
@@ -615,7 +615,7 @@ $xmlCountersToAnalyze = [xml]@"
 
 #"\\*\LogicalDisk(*)\Avg. Disk sec/Read","\\*\LogicalDisk(*)\Avg. Disk sec/Write","\\*\LogicalDisk(*)\Avg. Disk sec/Transfer","\\*\LogicalDisk(*)\Disk Transfers/sec","\\*\LogicalDisk(*)\Disk Bytes/sec","\\*\LogicalDisk(*)\Avg. Disk Queue Length","\\*\LogicalDisk(*)\% Idle Time","\\*\Processor(_Total)\% Processor Time","\\*\System\Processor Queue Length","\\*\System\Context Switches/sec","\\*\Memory\Available MBytes","\\*\Netlogon(*)\*","\\*\Processor Information(*)\% of Maximum Frequency"
 #"\LogicalDisk(*)\Avg. Disk sec/Read","\LogicalDisk(*)\Avg. Disk sec/Write","\LogicalDisk(*)\Avg. Disk sec/Transfer","\LogicalDisk(*)\Disk Transfers/sec","\LogicalDisk(*)\Disk Bytes/sec","\LogicalDisk(*)\Avg. Disk Queue Length","\LogicalDisk(*)\% Idle Time","\Processor(_Total)\% Processor Time","\System\Processor Queue Length","\System\Context Switches/sec","\Memory\Available MBytes","\Netlogon(*)\*","\Processor Information(*)\% of Maximum Frequency"
-Function Get-PerformanceDataFromFileLocal {
+function Get-PerformanceDataFromFileLocal {
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.List[PerformanceHealth.PerfFileDataInfo]])]
     param(
@@ -661,7 +661,7 @@ Function Get-PerformanceDataFromFileLocal {
     return $aPerfFileDataInfo
 }
 
-Function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuickAnalyze {
+function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuickAnalyze {
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.List[System.Object]])]
     param(
@@ -675,7 +675,7 @@ Function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuic
     Write-Verbose("Grouped Raw Data in {0} seconds" -f $measure_gData.TotalSeconds)
     Write-Verbose("There are {0} different paths detected" -f $gData.Count)
 
-    Function Get-FullCounterNameObject {
+    function Get-FullCounterNameObject {
         param(
             [Parameter(Mandatory = $true)][object]$PerformanceCounterSample
         )
@@ -701,7 +701,7 @@ Function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuic
         return $obj
     }
 
-    Function Build-ServerPerformanceObject_CounterData {
+    function Build-ServerPerformanceObject_CounterData {
         param(
             [Parameter(Mandatory = $true)][object]$CounterNameObject
         )
@@ -725,7 +725,7 @@ Function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuic
         return $counterDataPerfObject
     }
 
-    Function Build-ServerPerformanceObject_Server {
+    function Build-ServerPerformanceObject_Server {
         param(
             [Parameter(Mandatory = $true)][object]$CounterNameObject
         )
@@ -818,7 +818,7 @@ Function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuic
     return $MasterObject
 }
 
-Function Write-QuickSummaryDetails {
+function Write-QuickSummaryDetails {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)][Object]$ServerObject
@@ -829,7 +829,7 @@ Function Write-QuickSummaryDetails {
     $strLength_detail = 48
     $strLength_columnWidth = 12
 
-    Function Add-Line {
+    function Add-Line {
         param(
             [Parameter(Mandatory = $true)][string]$New_line
         )
@@ -958,7 +958,7 @@ Function Write-QuickSummaryDetails {
     &$outFile
 }
 
-Function Get-CountersFromXml {
+function Get-CountersFromXml {
     param(
         [Parameter(Mandatory = $true)][xml]$xmlCounters,
         [Parameter(Mandatory = $false)][bool]$IncludeWildForServers = $false
@@ -977,12 +977,12 @@ Function Get-CountersFromXml {
     return $aCounters
 }
 
-Function Main {
+function Main {
 
     $script:processStartTime = [System.DateTime]::Now
 
     #determine the logic we want out of the script
-    Switch ($PSCmdlet.ParameterSetName) {
+    switch ($PSCmdlet.ParameterSetName) {
         "FileDirectory" {
             Write-Verbose("File Directory Option detected")
             if (-not (Test-Path $PerfmonFileDirectory)) {

--- a/Performance/ExPerfWiz/ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/ExPerfWiz.ps1
@@ -344,17 +344,17 @@ $xml131619 = @"
 if (Confirm-Administrator) {}
 else { Write-Error "Please run as Administrator" -ErrorAction Stop }
 
-Function global:Convert-OnOffBool {
+function global:Convert-OnOffBool {
     [cmdletbinding()]
     [OutputType([bool])]
-    Param(
+    param(
         [Parameter(Mandatory = $true)]
         [string]$tocompare
     )
 
     switch ($tocompare) {
         On { return $true }
-        Default { return $false }
+        default { return $false }
     }
 }
 
@@ -379,5 +379,5 @@ $response = $host.UI.PromptForChoice($title, $message, $options, 0)
 # Perform action based on answer
 switch ($response) {
     0 { New-ExPerfwiz -FolderPath C:\EXPerfWiz } # Yes
-    1 { Break } # No
+    1 { break } # No
 }

--- a/Performance/ExPerfWiz/Get-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/Get-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Get-ExPerfWiz {
+function global:Get-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -60,7 +60,7 @@ Function global:Get-ExPerfWiz {
         # Returns all found collector sets
         $logmanAll = logman query -s $server
 
-        If (!([string]::isnullorempty(($logmanAll | Select-String "Error:")))) {
+        if (!([string]::isnullorempty(($logmanAll | Select-String "Error:")))) {
             throw $logmanAll[-1]
         }
 
@@ -68,7 +68,7 @@ Function global:Get-ExPerfWiz {
         $i = -3
         [array]$perfLogNames = $null
 
-        While (!($logmanAll[$i] | Select-String "---")) {
+        while (!($logmanAll[$i] | Select-String "---")) {
 
             # pull the first 40 characters then trim and trailing spaces
             [array]$perfLogNames += $logmanAll[$i].substring(0, 40).trimend()
@@ -86,7 +86,7 @@ Function global:Get-ExPerfWiz {
         $logman = logman query $collectorname -s $Server
 
         # Quick error check
-        If (!([string]::isnullorempty(($logman | Select-String "Error:")))) {
+        if (!([string]::isnullorempty(($logman | Select-String "Error:")))) {
             throw $logman[-1]
         }
 
@@ -131,7 +131,7 @@ Function global:Get-ExPerfWiz {
                 'Circular' { $circular = (Convert-OnOffBool($linesplit[1])) }
                 'Overwrite' { $overwrite = (Convert-OnOffBool($linesplit[1])) }
                 'Sample Interval' { $sampleInterval = (($linesplit[1].split(" "))[0]) }
-                Default {}
+                default {}
             }
         }
 
@@ -163,5 +163,3 @@ Function global:Get-ExPerfWiz {
         $logmanObject
     }
 }
-
-

--- a/Performance/ExPerfWiz/New-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/New-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:New-ExPerfWiz {
+function global:New-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -107,7 +107,7 @@ Function global:New-ExPerfWiz {
 
     ### Creates a new experfwiz collector
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    Param(
+    param(
         [switch]
         $Circular,
 
@@ -145,14 +145,14 @@ Function global:New-ExPerfWiz {
 
     )
 
-    Begin {
+    begin {
         # Check for new version of Experfwiz
     }
 
-    Process {
+    process {
 
         # If no template provided then we use the default one
-        If ([string]::IsNullOrEmpty($Template)) {
+        if ([string]::IsNullOrEmpty($Template)) {
             Write-SimpleLogFile "Using default template" -Name "ExPerfWiz.log"
 
             # Put the default xml into template
@@ -160,10 +160,10 @@ Function global:New-ExPerfWiz {
         }
 
         # Test the template path and log it as good or throw an error
-        If (Test-Path $Template) {
+        if (Test-Path $Template) {
             Write-SimpleLogFile -string ("Using Template:" + $Template) -Name "ExPerfWiz.log"
-        } Else {
-            Throw "Cannot find template xml file provided.  Please provide a valid Perfmon template file. $Template"
+        } else {
+            throw "Cannot find template xml file provided.  Please provide a valid Perfmon template file. $Template"
         }
 
         ### Manipulate Template ###
@@ -221,7 +221,7 @@ Function global:New-ExPerfWiz {
         }
 
         # If -threads is specified we need to add it to the counter set
-        If ($Threads) {
+        if ($Threads) {
 
             Write-SimpleLogFile -string "Adding threads to counter set" -Name "ExPerfWiz.log"
 
@@ -255,7 +255,7 @@ Function global:New-ExPerfWiz {
                 Write-SimpleLogFile "Duplicate Found" -Name "ExPerfWiz.log"
                 #Remove-ExPerfwiz -Name $Name -Server $server -Confirm:$false
             }
-            Default {
+            default {
                 Write-SimpleLogFile "No Comflicts Found" -Name "ExPerfWiz.log"
             }
         }
@@ -267,7 +267,7 @@ Function global:New-ExPerfWiz {
         if ($null -eq ($logman | Select-String "Error:")) {
             Write-SimpleLogFile "Collector Successfully Created" -Name "ExPerfWiz.log"
         } else {
-            Throw $logman
+            throw $logman
         }
 
         ## Implement Start time
@@ -281,7 +281,7 @@ Function global:New-ExPerfWiz {
         }
 
         # Need to start the counter set if asked to do so
-        If ($StartOnCreate) {
+        if ($StartOnCreate) {
             Start-ExPerfwiz -Server $Server -Name $Name
         } else {}
 
@@ -289,4 +289,3 @@ Function global:New-ExPerfWiz {
         Get-ExPerfwiz -Name $Name -Server $Server
     }
 }
-

--- a/Performance/ExPerfWiz/Remove-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/Remove-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Remove-ExPerfWiz {
+function global:Remove-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -46,7 +46,7 @@ Function global:Remove-ExPerfWiz {
         $Server = $env:ComputerName
     )
 
-    Process {
+    process {
 
         Write-SimpleLogFile -string ("Removing Experfwiz for: " + $server) -Name "ExPerfWiz.log"
 
@@ -56,13 +56,12 @@ Function global:Remove-ExPerfWiz {
         }
 
         # Check if we have an error and throw and error if needed.
-        If ([string]::isnullorempty(($logman | Select-String "Error:"))) {
+        if ([string]::isnullorempty(($logman | Select-String "Error:"))) {
             Write-SimpleLogFile "ExPerfwiz removed" -Name "ExPerfWiz.log"
         } else {
             Write-SimpleLogFile "[ERROR] - Unable to remove Collector" -Name "ExPerfWiz.log"
             Write-SimpleLogFile $logman -Name "ExPerfWiz.log"
-            Throw $logman
+            throw $logman
         }
     }
 }
-

--- a/Performance/ExPerfWiz/Set-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/Set-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Set-ExPerfWiz {
+function global:Set-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -95,7 +95,7 @@ Function global:Set-ExPerfWiz {
     }
 
 
-    Process {
+    process {
 
         Write-SimpleLogFile -string "Updating experfwiz $name on $server" -Name "ExPerfWiz.log"
 
@@ -105,18 +105,17 @@ Function global:Set-ExPerfWiz {
         }
 
         # Check if we generated and error on update
-        If ($null -eq ($logman | Select-String "Error:")) {
+        if ($null -eq ($logman | Select-String "Error:")) {
             Write-SimpleLogFile "Update Successful" -Name "ExPerfWiz.log"
         } else {
             Write-SimpleLogFile -string "[ERROR] - Problem updating perfwiz:" -Name "ExPerfWiz.log"
             Write-SimpleLogFile -string $logman -Name "ExPerfWiz.log"
-            Throw $logman
+            throw $logman
         }
     }
-    End {
+    end {
         # Return the new object and values
         if ($quiet) {}
         else { Get-ExPerfwiz -Name $name -Server $server }
     }
 }
-

--- a/Performance/ExPerfWiz/Start-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/Start-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Start-ExPerfWiz {
+function global:Start-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -44,7 +44,7 @@ Function global:Start-ExPerfWiz {
         $Server = $env:ComputerName
     )
 
-    Process {
+    process {
         Write-SimpleLogFile -string ("Starting ExPerfwiz: " + $Server) -Name "ExPerfWiz.log"
 
         # Check if we have an error and throw and error if needed.
@@ -69,18 +69,17 @@ Function global:Start-ExPerfWiz {
         } while ($repeat -and ($i -lt 3))
 
         # If we have an error then we need to throw else continue
-        If ($logman | Select-String "Error:") {
+        if ($logman | Select-String "Error:") {
             # Don't throw an error if the collector is already started
             if ($logman | Select-String "administrator has refused the request") {
                 Write-SimpleLogFile "Collector already Started" -Name "ExPerfWiz.log"
             } else {
                 Write-SimpleLogFile "[ERROR] - Unable to Start Collector" -Name "ExPerfWiz.log"
                 Write-SimpleLogFile $logman -Name "ExPerfWiz.log"
-                Throw $logman
+                throw $logman
             }
         } else {
             Write-SimpleLogFile "ExPerfwiz Started" -Name "ExPerfWiz.log"
         }
     }
 }
-

--- a/Performance/ExPerfWiz/Step-ExPerfWizSize.ps1
+++ b/Performance/ExPerfWiz/Step-ExPerfWizSize.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Step-ExPerfWizSize {
+function global:Step-ExPerfWizSize {
     <#
 
     .SYNOPSIS
@@ -57,11 +57,6 @@ Function global:Step-ExPerfWizSize {
     if ($logman | Select-String "Error:") {
         Write-SimpleLogFile -string "[ERROR] - Problem stepping perfwize size:" -Name "ExPerfWiz.log"
         Write-SimpleLogFile -string $logman -Name "ExPerfWiz.log"
-        Throw $logman
+        throw $logman
     } else {}
 }
-
-
-
-
-

--- a/Performance/ExPerfWiz/Stop-ExPerfWiz.ps1
+++ b/Performance/ExPerfWiz/Stop-ExPerfWiz.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function global:Stop-ExPerfWiz {
+function global:Stop-ExPerfWiz {
     <#
 
     .SYNOPSIS
@@ -44,7 +44,7 @@ Function global:Stop-ExPerfWiz {
         $Server = $env:ComputerName
     )
 
-    Process {
+    process {
         Write-SimpleLogFile -string ("Stopping ExPerfwiz: " + $server + "\" + $Name) -Name "ExPerfWiz.log"
 
         # Remove the experfwiz counter set
@@ -53,18 +53,17 @@ Function global:Stop-ExPerfWiz {
         }
 
         # Check if we have an error and throw and error if needed.
-        If ($logman | Select-String "Error:") {
+        if ($logman | Select-String "Error:") {
             # if we are not running already then just move on
             if ($logman | Select-String "is not running") {
                 Write-SimpleLogFile "Collector Not Running" -Name "ExPerfWiz.log"
             } else {
                 Write-SimpleLogFile "[ERROR] - Unable to Stop Collector" -Name "ExPerfWiz.log"
                 Write-SimpleLogFile $logman -Name "ExPerfWiz.log"
-                Throw $logman
+                throw $logman
             }
         } else {
             Write-SimpleLogFile "ExPerfwiz Stopped" -Name "ExPerfWiz.log"
         }
     }
 }
-

--- a/Performance/ExPerfWiz/Write-SimpleLogFile.ps1
+++ b/Performance/ExPerfWiz/Write-SimpleLogFile.ps1
@@ -44,9 +44,9 @@ Write-SimpleLogFile -String "Start ProcessB" -Name mylogfile.log -OutHost
 Writes "[Date] - Start ProcessB" to $env:LocalAppData\mylogfile and to the Host
 
 #>
-Function global:Write-SimpleLogfile {
+function global:Write-SimpleLogfile {
     [cmdletbinding()]
-    Param
+    param
     (
         [Parameter(Mandatory = $true)]
         [string]$String,
@@ -60,16 +60,16 @@ Function global:Write-SimpleLogfile {
 
     )
 
-    Begin {
+    begin {
         # Get our log file path
         $LogFile = Join-Path $env:LOCALAPPDATA $Name
 
         if ($OpenLog) {
             Notepad.exe $LogFile
-            Exit
+            exit
         }
     }
-    Process {
+    process {
 
         # Get the current date
         [string]$date = Get-Date -Format G
@@ -83,5 +83,3 @@ Function global:Write-SimpleLogfile {
         else { Write-Verbose  $logstring }
     }
 }
-
-

--- a/Retention/Get-MRMDetails.ps1
+++ b/Retention/Get-MRMDetails.ps1
@@ -36,7 +36,7 @@
 # even if Microsoft has been advised of the possibility of such damages
 ##############################################################################################
 
-Param (
+param (
     [Parameter(Mandatory = $true, HelpMessage = 'You must specify the name of a mailbox user')][string] $Mailbox
 )
 
@@ -301,7 +301,7 @@ function funcConvertPrStartTime {
 }
 
 function funcUltArchive {
-    Param(
+    param(
         [string]$mbx
     )
     $m = get-mailbox $mbx
@@ -336,7 +336,7 @@ function funcUltArchive {
 # MAIN
 #===================================================================
 
-If ($SDE -eq $True) {
+if ($SDE -eq $True) {
     funcConvertPrStartTime
 }
 

--- a/Search/Troubleshoot-ModernSearch.ps1
+++ b/Search/Troubleshoot-ModernSearch.ps1
@@ -112,7 +112,7 @@ try {
     throw "Failed to load ManagedStoreDiagnosticFunctions.ps1 Inner Exception: $($Error[0].Exception) Stack Trace: $($Error[0].ScriptStackTrace)"
 }
 
-Function Main {
+function Main {
     @("Identity: '$MailboxIdentity'",
         "ItemSubject: '$ItemSubject'",
         "FolderName: '$FolderName'",

--- a/Search/Troubleshoot-ModernSearch/Exchange/Get-ActiveDatabasesOnServer.ps1
+++ b/Search/Troubleshoot-ModernSearch/Exchange/Get-ActiveDatabasesOnServer.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 #Dependencies are based off EMS cmdlets.
-Function Get-ActiveDatabasesOnServer {
+function Get-ActiveDatabasesOnServer {
     [CmdletBinding()]
     param(
         [ValidateNotNullOrEmpty()]

--- a/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxInformation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 #Dependencies are based off EMS cmdlets.
-Function Get-MailboxInformation {
+function Get-MailboxInformation {
     [CmdletBinding()]
     param(
         [string]

--- a/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxStatisticsOnDatabase.ps1
+++ b/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxStatisticsOnDatabase.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-MailboxStatisticsOnDatabase {
+function Get-MailboxStatisticsOnDatabase {
     [CmdletBinding()]
     param(
         [string[]]$MailboxDatabase

--- a/Search/Troubleshoot-ModernSearch/Exchange/Get-SearchProcessState.ps1
+++ b/Search/Troubleshoot-ModernSearch/Exchange/Get-SearchProcessState.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-SearchProcessState {
+function Get-SearchProcessState {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Cmdlet required')]
     [CmdletBinding()]
     param(
@@ -9,7 +9,7 @@ Function Get-SearchProcessState {
     )
     begin {
 
-        Function Get-DefaultSettings {
+        function Get-DefaultSettings {
             return [PSCustomObject]@{
                 PID               = 0
                 ThirdPartyModules = (New-Object 'System.Collections.Generic.List[object]')

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BasicMailboxQueryContext.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BasicMailboxQueryContext.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-BigFunnelPropertyNameMapping.ps1
-Function Get-BasicMailboxQueryContext {
+function Get-BasicMailboxQueryContext {
     [CmdletBinding()]
     param(
         [object]$StoreQueryHandler

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BigFunnelPropertyNameMapping.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BigFunnelPropertyNameMapping.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-BigFunnelPropertyNameMapping {
+function Get-BigFunnelPropertyNameMapping {
     [CmdletBinding()]
     param(
         [object]$StoreQueryHandler,

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-CategoryOffStatistics.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-CategoryOffStatistics.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-CategoryOffStatistics {
+function Get-CategoryOffStatistics {
     [CmdletBinding()]
     param(
         [object]$MailboxStatistics

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-FolderInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-FolderInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-FolderInformation {
+function Get-FolderInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexStateOfMessage.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexStateOfMessage.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-IndexStateOfMessage {
+function Get-IndexStateOfMessage {
     [CmdletBinding()]
     [OutputType([System.String])]
     param(
@@ -48,4 +48,3 @@ Function Get-IndexStateOfMessage {
         return $status
     }
 }
-

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexingErrorMessage.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexingErrorMessage.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-IndexingErrorMessage {
+function Get-IndexingErrorMessage {
     [CmdletBinding()]
     param(
         [object]$Message

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MailboxIndexMessageStatistics.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MailboxIndexMessageStatistics.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-IndexingErrorMessage.ps1
 . $PSScriptRoot\Get-MessageInformationObject.ps1
-Function Get-MailboxIndexMessageStatistics {
+function Get-MailboxIndexMessageStatistics {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MessageIndexState.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MessageIndexState.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-FolderInformation.ps1
 . $PSScriptRoot\Get-MessageInformationObject.ps1
-Function Get-MessageIndexState {
+function Get-MessageIndexState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -131,4 +131,3 @@ Function Get-MessageIndexState {
         return $messageList
     }
 }
-

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MessageInformationObject.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-MessageInformationObject.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-IndexStateOfMessage.ps1
-Function Get-MessageInformationObject {
+function Get-MessageInformationObject {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-QueryItemResult.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-QueryItemResult.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-QueryItemResult {
+function Get-QueryItemResult {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/StoreQueryFunctions.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/StoreQueryFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function ResetQueryInstances {
+function ResetQueryInstances {
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -17,7 +17,7 @@ Function ResetQueryInstances {
     }
 }
 
-Function SetSelect {
+function SetSelect {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -35,7 +35,7 @@ Function SetSelect {
     }
 }
 
-Function AddToSelect {
+function AddToSelect {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -52,7 +52,7 @@ Function AddToSelect {
     }
 }
 
-Function SetFrom {
+function SetFrom {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -67,7 +67,7 @@ Function SetFrom {
     }
 }
 
-Function SetWhere {
+function SetWhere {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -82,7 +82,7 @@ Function SetWhere {
     }
 }
 
-Function AddToWhere {
+function AddToWhere {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
@@ -97,7 +97,7 @@ Function AddToWhere {
     }
 }
 
-Function InvokeGetStoreQuery {
+function InvokeGetStoreQuery {
     [CmdletBinding()]
     [OutputType("System.Object[]")]
     param(
@@ -136,7 +136,7 @@ Function InvokeGetStoreQuery {
     }
 }
 
-Function Get-StoreQueryObject {
+function Get-StoreQueryObject {
     [CmdletBinding()]
     param(
         [object]$MailboxInformation

--- a/Search/Troubleshoot-ModernSearch/Write/Write-BasicMailboxInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-BasicMailboxInformation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Write-ScriptOutput.ps1
-Function Write-BasicMailboxInformation {
+function Write-BasicMailboxInformation {
     [CmdletBinding()]
     param(
         [object]$MailboxInformation

--- a/Search/Troubleshoot-ModernSearch/Write/Write-CheckSearchProcessState.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-CheckSearchProcessState.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\Exchange\Get-SearchProcessState.ps1
 . $PSScriptRoot\Write-DisplayObjectInformation.ps1
 . $PSScriptRoot\Write-ScriptOutput.ps1
-Function Write-CheckSearchProcessState {
+function Write-CheckSearchProcessState {
     [CmdletBinding()]
     param(
         [string]$ActiveServer

--- a/Search/Troubleshoot-ModernSearch/Write/Write-DisplayObjectInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-DisplayObjectInformation.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Write-ScriptOutput.ps1
-Function Write-DisplayObjectInformation {
+function Write-DisplayObjectInformation {
     [CmdletBinding()]
     param(
         [object]$DisplayObject,

--- a/Search/Troubleshoot-ModernSearch/Write/Write-Error.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-Error.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Write-LogInformation.ps1
-Function Write-Error {
+function Write-Error {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Error')]
     [CmdletBinding()]
     param(

--- a/Search/Troubleshoot-ModernSearch/Write/Write-LogInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-LogInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-LogInformation {
+function Write-LogInformation {
     param(
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         [object[]]$Object,

--- a/Search/Troubleshoot-ModernSearch/Write/Write-MailboxIndexMessageStatistics.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-MailboxIndexMessageStatistics.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\StoreQuery\Get-MailboxIndexMessageStatistics.ps1
 . $PSScriptRoot\Write-ScriptOutput.ps1
 . $PSScriptRoot\Write-DisplayObjectInformation.ps1
-Function Write-MailboxIndexMessageStatistics {
+function Write-MailboxIndexMessageStatistics {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Search/Troubleshoot-ModernSearch/Write/Write-MailboxStatisticsOnServer.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-MailboxStatisticsOnServer.ps1
@@ -6,7 +6,7 @@
 . $PSScriptRoot\..\Exchange\Get-MailboxStatisticsOnDatabase.ps1
 . $PSScriptRoot\..\Exchange\Get-SearchProcessState.ps1
 . $PSScriptRoot\Write-ScriptOutput.ps1
-Function Write-MailboxStatisticsOnServer {
+function Write-MailboxStatisticsOnServer {
     [CmdletBinding()]
     param(
         [string[]]$Server,

--- a/Search/Troubleshoot-ModernSearch/Write/Write-ScriptOutput.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-ScriptOutput.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Write-LogInformation.ps1
-Function Write-ScriptOutput {
+function Write-ScriptOutput {
     param(
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         [object[]]$Object,

--- a/Search/Troubleshoot-ModernSearch/Write/Write-Verbose.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-Verbose.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-Verbose {
+function Write-Verbose {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose from Shared functions')]
     [CmdletBinding()]
     param(

--- a/Search/Troubleshoot-ModernSearch/Write/Write-Warning.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-Warning.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Write-LogInformation.ps1
-Function Write-Warning {
+function Write-Warning {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Warning')]
     [CmdletBinding()]
     param(

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -647,7 +647,7 @@ function Set-LogActivity {
         $FullRegMessage = "1 $RegMessage"
         $Level = "Info"
     }
-    If ($Level -eq "Info") {
+    if ($Level -eq "Info") {
         Write-Verbose -Message $Message -Verbose
     } elseif ($Level -eq "Notice") {
         Write-Host -ForegroundColor Cyan -BackgroundColor black "NOTICE: $Message"
@@ -883,7 +883,7 @@ try {
 
                 try {
                     & $eomtLatestFilepath @PSBoundParameters
-                    Exit
+                    exit
                 } catch {
                     $Message = "Run failed for latest EOMT version $latestEOMTVersion downloaded to $eomtLatestFilepath, please re-run $eomtLatestFilepath manually. $DisableAutoupdateIfNeeded. Exception: $($_.Exception)"
                     $RegMessage = "Run failed for latest EOMT version $latestEOMTVersion"

--- a/Security/src/Test-ProxyLogon.ps1
+++ b/Security/src/Test-ProxyLogon.ps1
@@ -126,7 +126,7 @@ begin {
                     $sw = New-Object System.Diagnostics.Stopwatch
                     $sw.Start()
 
-                    For ( $i = 0; $i -lt $files.Count; ++$i ) {
+                    for ( $i = 0; $i -lt $files.Count; ++$i ) {
                         if ($sw.ElapsedMilliseconds -gt 1000) {
                             Write-Progress -Activity $Activity -Status "$i / $($files.Count)" -PercentComplete ($i * 100 / $files.Count) -Id $progressId
                             $sw.Restart()
@@ -215,7 +215,7 @@ begin {
                         resetVDirFiles          = [System.Collections.ArrayList]@()
                         setVDirMaliciousUrlLogs = [System.Collections.ArrayList]@()
                     }
-                    For ( $i = 0; $i -lt $files.Count; ++$i ) {
+                    for ( $i = 0; $i -lt $files.Count; ++$i ) {
 
                         if ((Get-ChildItem $files[$i] -ErrorAction SilentlyContinue | Select-String -Pattern "ServerInfo~").Count -gt 0) {
 
@@ -254,7 +254,7 @@ begin {
 
                     Get-ChildItem -Path $env:ProgramData -Recurse -ErrorAction SilentlyContinue |
                         ForEach-Object {
-                            If ( $_.Extension -in $zipFilter ) {
+                            if ( $_.Extension -in $zipFilter ) {
                                 [PSCustomObject]@{
                                     ComputerName = $env:COMPUTERNAME
                                     Type         = 'SuspiciousArchive'

--- a/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
+++ b/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
@@ -10,7 +10,7 @@ param(
 )
 
 
-Function Get-EvaluatedSettingOrRule {
+function Get-EvaluatedSettingOrRule {
     param(
         [string]$SettingName,
         [string]$SettingOrRule = "Setting"
@@ -18,7 +18,7 @@ Function Get-EvaluatedSettingOrRule {
     return Select-String ("Evaluated \[{0}:{1}\].+\[Value:" -f $SettingOrRule, $SettingName) $SetupLog | Select-Object -Last 1
 }
 
-Function Add-SettingOrRuleToCollect {
+function Add-SettingOrRuleToCollect {
     param(
         [string]$Name,
         [string]$SettingOrRule = "Setting"
@@ -117,7 +117,7 @@ while ($i -lt $allContent.Count) {
     $logContent.Add($allContent[$i++])
 }
 
-Function ScrubValuesAndReplace {
+function ScrubValuesAndReplace {
     param(
         [string]$Match,
         [string]$Replace

--- a/Setup/CopyMissingDlls/CopyMissingDlls.ps1
+++ b/Setup/CopyMissingDlls/CopyMissingDlls.ps1
@@ -41,7 +41,7 @@ if ($isoItemRoot.VersionInfo.ProductMinorPart -eq 0) {
     throw "Can't tell what version you are on"
 }
 
-Function Receive-Output {
+function Receive-Output {
     process {
         Write-Host $_
         $_ | Out-File -FilePath $scriptLogging -Append

--- a/Setup/CopyMissingDlls/DllMappings/DllMaper.NotPublished.ps1
+++ b/Setup/CopyMissingDlls/DllMappings/DllMaper.NotPublished.ps1
@@ -10,7 +10,7 @@ param(
 
 $Overrides = @{"C:\Program Files\Microsoft\Exchange Server\V15\Bin".ToLower() = "D:\Setup\ServerRoles\Common".ToLower() }
 
-Function Get-MatchingObject {
+function Get-MatchingObject {
     param(
         [object]$InstallChildObject,
         [object]$IsoChildObject
@@ -23,7 +23,7 @@ Function Get-MatchingObject {
     }
 }
 
-Function Find-BestObject {
+function Find-BestObject {
     param(
         [object]$InstallChildObject,
         [array]$IsoFoundChildObjects
@@ -75,7 +75,7 @@ Function Find-BestObject {
         }
 
     #only 1 in the install path
-    Function Get-BestFromMultiIsoFound {
+    function Get-BestFromMultiIsoFound {
 
         $testingDirectory = $InstallChildObject.Directory.ToString().ToLower()
 

--- a/Setup/FixInstallerCache/FixInstallerCache.ps1
+++ b/Setup/FixInstallerCache/FixInstallerCache.ps1
@@ -15,7 +15,7 @@ param(
 . $PSScriptRoot\..\Shared\Get-InstallerPackages.ps1
 . $PSScriptRoot\WriteFunctions.ps1
 
-Function MainIsoCopy {
+function MainIsoCopy {
     $installedVersion = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\AdminTools -ErrorAction SilentlyContinue).PostSetupVersion
     $filterDisplayNames = @("Microsoft Lync Server", "Exchange", "Microsoft Server Speech", "Microsoft Unified Communications")
 
@@ -77,7 +77,7 @@ Function MainIsoCopy {
     "Fixed $fixedFiles out of $currentMissingPackages" | Write-Host
 }
 
-Function MainMachineCopy {
+function MainMachineCopy {
 
     $msiInstallerPackages = Get-InstallerPackages -FilterDisplayName $filterDisplayNames
     [System.Collections.Generic.List[PSObject]]$missingPackages = $msiInstallerPackages | Where-Object { $_.ValidMsi -eq $false }
@@ -129,7 +129,7 @@ Function MainMachineCopy {
     "Fixed $fixedFiles out of $currentMissingPackages" | Write-Host
 }
 
-Function Main {
+function Main {
 
     if ($PsCmdlet.ParameterSetName -eq "CopyFromCu") {
         Write-Host "Starting Fix Installer Cache from CU ISO."

--- a/Setup/FixInstallerCache/WriteFunctions.ps1
+++ b/Setup/FixInstallerCache/WriteFunctions.ps1
@@ -1,13 +1,13 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function WriteLog {
+function WriteLog {
     process {
         $_ | Out-File -FilePath ".\InstallerCacheLogger.log" -Append
     }
 }
 
-Function Write-Host {
+function Write-Host {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Host')]
     [CmdletBinding()]
     param(

--- a/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-TestResult.ps1
 
-Function Test-ComputersContainerExists {
+function Test-ComputersContainerExists {
     try {
         $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
         foreach ($domain in $forest.Domains) {

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainMultiActiveSyncVirtualDirectories.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-OrganizationContainer.ps1
 
-Function Test-DomainMultiActiveSyncVirtualDirectories {
+function Test-DomainMultiActiveSyncVirtualDirectories {
     $params = @{
         TestName = "Multiple Active Sync Vdirs Detected"
     }

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeContainer.ps1
 
-Function Test-DomainOtherWellKnownObjects {
+function Test-DomainOtherWellKnownObjects {
     $exchangeContainer = Get-ExchangeContainer
     $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=*)", @("otherWellKnownObjects", "distinguishedName"))
     $result = $searcher.FindOne()

--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -3,10 +3,10 @@
 
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\UserContext\Test-UserGroupMemberOf.ps1
-Function Test-ExchangeADSetupLevel {
+function Test-ExchangeADSetupLevel {
 
     # Extract for Pester Testing - Start
-    Function TestPrepareAD {
+    function TestPrepareAD {
         param(
             [string]$ExchangeVersion
         )
@@ -63,7 +63,7 @@ Function Test-ExchangeADSetupLevel {
         Test-UserGroupMemberOf -PrepareAdRequired $true -PrepareSchemaRequired ($latestExchangeVersion.$ExchangeVersion.UpperRange -ne $currentSchemaValue)
     }
 
-    Function TestMismatchLevel {
+    function TestMismatchLevel {
         param(
             [string]$ExchangeVersion,
             [object]$ADSetupLevel
@@ -79,7 +79,7 @@ Function Test-ExchangeADSetupLevel {
         TestPrepareAD -ExchangeVersion $ExchangeVersion
     }
 
-    Function TestReadyLevel {
+    function TestReadyLevel {
         param(
             [string]$ExchangeVersion,
             [string]$CULevel
@@ -102,7 +102,7 @@ Function Test-ExchangeADSetupLevel {
         }
     }
 
-    Function GetVersionObject {
+    function GetVersionObject {
         param(
             [object]$SearchResults,
             [string]$VersionValueName = "ObjectVersion"
@@ -113,7 +113,7 @@ Function Test-ExchangeADSetupLevel {
         }
     }
 
-    Function GetExchangeADSetupLevel {
+    function GetExchangeADSetupLevel {
         $rootDSE = [ADSI]("LDAP://RootDSE")
         $directorySearcher = New-Object System.DirectoryServices.DirectorySearcher
         $directorySearcher.SearchScope = "Subtree"

--- a/Setup/SetupAssist/Checks/Domain/Test-ValidHomeMdb.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ValidHomeMdb.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Search-AllActiveDirectoryDomains.ps1
 
-Function Test-ValidHomeMDB {
+function Test-ValidHomeMDB {
     $testName = "Valid Home MDB"
     $arbitration = 0x800000
     $discovery = 0x20000000

--- a/Setup/SetupAssist/Checks/LocalServer/Test-ExecutionPolicy.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-ExecutionPolicy.ps1
@@ -3,7 +3,7 @@
 
 
 . $PSScriptRoot\..\New-TestResult.ps1
-Function Test-ExecutionPolicy {
+function Test-ExecutionPolicy {
 
     $executionPolicy = Get-ExecutionPolicy
 

--- a/Setup/SetupAssist/Checks/LocalServer/Test-PendingReboot.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-PendingReboot.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-ServerRebootPending.ps1
-Function Test-PendingReboot {
+function Test-PendingReboot {
     $rebootPending = Get-ServerRebootPending
     $params = @{
         TestName      = "Pending Reboot"

--- a/Setup/SetupAssist/Checks/New-TestResult.ps1
+++ b/Setup/SetupAssist/Checks/New-TestResult.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function New-TestResult {
+function New-TestResult {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Does not change state')]
     [CmdletBinding()]
     param(

--- a/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\..\..\..\Shared\Confirm-Administrator.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-WellKnownGroupSid.ps1
 . $PSScriptRoot\..\New-TestResult.ps1
-Function Test-UserGroupMemberOf {
+function Test-UserGroupMemberOf {
     [CmdletBinding()]
     param(
         [bool]$PrepareAdRequired,

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -33,13 +33,13 @@ param(
 
 $BuildVersion = ""
 
-Function WriteCatchInfo {
+function WriteCatchInfo {
     Write-Host "$($Error[0].Exception)"
     Write-Host "$($Error[0].ScriptStackTrace)"
     $Script:ErrorOccurred = $true
 }
 
-Function RunAllTests {
+function RunAllTests {
     $tests = @("Test-ExchangeADSetupLevel",
         "Test-ExecutionPolicy",
         "Test-ExchangeServices",
@@ -66,7 +66,7 @@ Function RunAllTests {
     }
 }
 
-Function Main {
+function Main {
 
     $results = RunAllTests
     $results | Export-Csv "$PSScriptRoot\SetupAssistResults-$((Get-Date).ToString("yyyyMMddhhmm")).csv" -NoTypeInformation

--- a/Setup/SetupAssist/WriteFunctions.ps1
+++ b/Setup/SetupAssist/WriteFunctions.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\..\Shared\Out-Columns.ps1
-Function Write-Verbose {
+function Write-Verbose {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Verbose')]
     [CmdletBinding()]
     param(
@@ -16,7 +16,7 @@ Function Write-Verbose {
     }
 }
 
-Function Write-Warning {
+function Write-Warning {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'In order to log Write-Waring')]
     [CmdletBinding()]
     param(
@@ -30,11 +30,11 @@ Function Write-Warning {
     }
 }
 
-Function Write-DebugLog($Message) {
+function Write-DebugLog($Message) {
     $Script:Logger = $Script:Logger | Write-LoggerInstance $Message
 }
 
-Function Write-OutColumns {
+function Write-OutColumns {
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ArbitrationMailbox.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ArbitrationMailbox.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\Test-SetupAssist.ps1
-Function Test-ArbitrationMailbox {
+function Test-ArbitrationMailbox {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-DisabledService.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-DisabledService.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-DisabledService {
+function Test-DisabledService {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-EndpointMapper.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-EndpointMapper.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-EndpointMapper {
+function Test-EndpointMapper {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ExceptionADOperationFailedAlreadyExist.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ExceptionADOperationFailedAlreadyExist.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-ExceptionADOperationFailedAlreadyExist {
+function Test-ExceptionADOperationFailedAlreadyExist {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-FailedSearchFoundation.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-FailedSearchFoundation.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-FailedSearchFoundation {
+function Test-FailedSearchFoundation {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-InstallFromBin.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-InstallFromBin.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-InstallFromBin {
+function Test-InstallFromBin {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MSExchangeSecurityGroupsContainerDeleted.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MSExchangeSecurityGroupsContainerDeleted.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-MSExchangeSecurityGroupsContainerDeleted {
+function Test-MSExchangeSecurityGroupsContainerDeleted {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MissingDirectory.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MissingDirectory.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-MissingDirectory {
+function Test-MissingDirectory {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MissingHomeMdb.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MissingHomeMdb.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\Test-SetupAssist.ps1
-Function Test-MissingHomeMdb {
+function Test-MissingHomeMdb {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MountDatabaseFailure.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-MountDatabaseFailure.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-MountDatabaseFailure {
+function Test-MountDatabaseFailure {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-VirtualDirectoryFailure.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-VirtualDirectoryFailure.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\Test-SetupAssist.ps1
-Function Test-VirtualDirectoryFailure {
+function Test-VirtualDirectoryFailure {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorReference/Test-FipsUpgradeConfiguration.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorReference/Test-FipsUpgradeConfiguration.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-FipsUpgradeConfiguration {
+function Test-FipsUpgradeConfiguration {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorReference/Test-InitializePermissionsOfDomain.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorReference/Test-InitializePermissionsOfDomain.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-InitializePermissionsOfDomain {
+function Test-InitializePermissionsOfDomain {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/ErrorReference/Test-MultiActiveSyncVirtualDirectories.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorReference/Test-MultiActiveSyncVirtualDirectories.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-MultiActiveSyncVirtualDirectories {
+function Test-MultiActiveSyncVirtualDirectories {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-DelegatedInstallerHasProperRights.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-DelegatedInstallerHasProperRights.ps1
@@ -8,7 +8,7 @@
 # group. The options are either add the delegated installer to that group, or
 # remove them from whatever group is giving them too many rights (usually Domain Admins).
 . $PSScriptRoot\..\New-WriteObject.ps1
-Function Test-DelegatedInstallerHasProperRights {
+function Test-DelegatedInstallerHasProperRights {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-ExpiredCertificate.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-ExpiredCertificate.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
-Function Test-ExpiredCertificate {
+function Test-ExpiredCertificate {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-InvalidWKObjectTargetException.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-InvalidWKObjectTargetException.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-InvalidWKObjectTargetException {
+function Test-InvalidWKObjectTargetException {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-IsHybridObjectFoundOnPremises.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-IsHybridObjectFoundOnPremises.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\New-WriteObject.ps1
-Function Test-IsHybridObjectFoundOnPremises {
+function Test-IsHybridObjectFoundOnPremises {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
@@ -15,7 +15,7 @@
 . $PSScriptRoot\..\ErrorReference\Test-FipsUpgradeConfiguration.ps1
 . $PSScriptRoot\..\ErrorReference\Test-InitializePermissionsOfDomain.ps1
 . $PSScriptRoot\..\ErrorReference\Test-MultiActiveSyncVirtualDirectories.ps1
-Function Test-KnownIssuesByErrors {
+function Test-KnownIssuesByErrors {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]
@@ -24,7 +24,7 @@ Function Test-KnownIssuesByErrors {
     )
     begin {
         #Use this to call similar tests and break when we find a result that we like
-        Function InvokeTest {
+        function InvokeTest {
             [CmdletBinding()]
             param(
                 [object]$PipeObject,

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownLdifErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownLdifErrors.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-KnownLdifErrors {
+function Test-KnownLdifErrors {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownMsiIssuesCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownMsiIssuesCheck.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
-Function Test-KnownMsiIssuesCheck {
+function Test-KnownMsiIssuesCheck {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-OtherWellKnownObjects.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-OtherWellKnownObjects.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\Test-SetupAssist.ps1
-Function Test-OtherWellKnownObjects {
+function Test-OtherWellKnownObjects {
     param(
         [Parameter(ValueFromPipeline = $true)]
         [object]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\New-WriteObject.ps1
-Function Test-PrerequisiteCheck {
+function Test-PrerequisiteCheck {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/FindContext/Write-LastErrorInformation.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Write-LastErrorInformation.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-ErrorContext.ps1
 . $PSScriptRoot\..\New-WriteObject.ps1
 . $PSScriptRoot\..\Test-SetupAssist.ps1
-Function Write-LastErrorInformation {
+function Write-LastErrorInformation {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $true)]

--- a/Setup/SetupLogReviewer/Checks/New-ActionPlan.ps1
+++ b/Setup/SetupLogReviewer/Checks/New-ActionPlan.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\New-WriteObject.ps1
-Function New-ActionPlan {
+function New-ActionPlan {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Does not change state')]
     [CmdletBinding()]
     param(

--- a/Setup/SetupLogReviewer/Checks/New-ErrorContext.ps1
+++ b/Setup/SetupLogReviewer/Checks/New-ErrorContext.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\New-WriteObject.ps1
-Function New-ErrorContext {
+function New-ErrorContext {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Does not change state')]
     [CmdletBinding()]
     param(

--- a/Setup/SetupLogReviewer/Checks/New-WriteObject.ps1
+++ b/Setup/SetupLogReviewer/Checks/New-WriteObject.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function New-WriteObject {
+function New-WriteObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Does not change state')]
     [CmdletBinding()]
     param(

--- a/Setup/SetupLogReviewer/Checks/Test-SetupAssist.ps1
+++ b/Setup/SetupLogReviewer/Checks/Test-SetupAssist.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Test-SetupAssist {
+function Test-SetupAssist {
     $name = [System.IO.Path]::GetFileName($MyInvocation.ScriptName)
     return $name -eq "SetupAssist.ps1"
 }

--- a/Setup/SetupLogReviewer/Checks/Write-Result.ps1
+++ b/Setup/SetupLogReviewer/Checks/Write-Result.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-Result {
+function Write-Result {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]

--- a/Setup/Shared/Get-FileInformation.ps1
+++ b/Setup/Shared/Get-FileInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-FileInformation {
+function Get-FileInformation {
     [CmdletBinding()]
     param(
         [IO.FileInfo]$File,

--- a/Setup/Shared/Get-InstallerPackages.ps1
+++ b/Setup/Shared/Get-InstallerPackages.ps1
@@ -4,7 +4,7 @@
 #By doing it this way and looking at the registry, we get msp files as well. (Security Updates)
 #Vs doing Get-CimInstance -ClassName Win32_Product
 . $PSScriptRoot\Get-FileInformation.ps1
-Function Get-InstallerPackages {
+function Get-InstallerPackages {
     [CmdletBinding()]
     param(
         [string[]]$FilterDisplayName
@@ -88,7 +88,7 @@ Function Get-InstallerPackages {
     }
 }
 
-Function Get-GuidProductCodeFromString {
+function Get-GuidProductCodeFromString {
     param(
         [string]$GuidString
     )

--- a/Setup/Shared/SetupLogReviewerFunctions.ps1
+++ b/Setup/Shared/SetupLogReviewerFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function SelectStringLastRunOfExchangeSetup {
+function SelectStringLastRunOfExchangeSetup {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true )]
@@ -22,7 +22,7 @@ Function SelectStringLastRunOfExchangeSetup {
     }
 }
 
-Function GetEvaluatedSettingOrRule {
+function GetEvaluatedSettingOrRule {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true )]
@@ -43,7 +43,7 @@ Function GetEvaluatedSettingOrRule {
     }
 }
 
-Function TestEvaluatedSettingOrRule {
+function TestEvaluatedSettingOrRule {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true )]
@@ -73,7 +73,7 @@ Function TestEvaluatedSettingOrRule {
     }
 }
 
-Function GetFirstErrorWithContextToLine {
+function GetFirstErrorWithContextToLine {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true )]
@@ -119,13 +119,13 @@ Function GetFirstErrorWithContextToLine {
     }
 }
 
-Function Get-SetupLogReviewer {
+function Get-SetupLogReviewer {
     [CmdletBinding()]
     param(
         [string]$SetupLog
     )
 
-    Function GetDateTimeFromLine {
+    function GetDateTimeFromLine {
         param(
             [string]$line
         )

--- a/Setup/Shared/SetupLogReviewerLogic.ps1
+++ b/Setup/Shared/SetupLogReviewerLogic.ps1
@@ -13,7 +13,7 @@
 . $PSScriptRoot\..\SetupLogReviewer\Checks\FindContext\Test-PrerequisiteCheck.ps1
 . $PSScriptRoot\..\SetupLogReviewer\Checks\FindContext\Write-LastErrorInformation.ps1
 . $PSScriptRoot\..\SetupLogReviewer\Checks\Write-Result.ps1
-Function Invoke-SetupLogReviewer {
+function Invoke-SetupLogReviewer {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true,
@@ -21,7 +21,7 @@ Function Invoke-SetupLogReviewer {
         [System.IO.FileInfo]$SetupLog,
         [switch]$DelegatedSetup
     )
-    Function InvokeTests {
+    function InvokeTests {
         [CmdletBinding()]
         param(
             [object]$SetupLogReviewer,

--- a/Setup/Tests/SetupAssist.Tests.ps1
+++ b/Setup/Tests/SetupAssist.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Testing SetupAssist" {
             Mock TestPrepareAD {}
             Mock Test-UserGroupMemberOf {}
 
-            Function SetGetExchangeADSetupLevel {
+            function SetGetExchangeADSetupLevel {
                 param(
                     [int]$OrgValue,
                     [int]$SchemaValue,

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Testing SetupLogReviewer" {
             Mock Write-Host {}
             Mock Write-Warning {}
             Mock Write-Host {}
-            Function Test-GeneralAdditionalContext {
+            function Test-GeneralAdditionalContext {
                 param(
                     [bool]$SkipSchema = $false
                 )

--- a/Shared/Confirm-Administrator.ps1
+++ b/Shared/Confirm-Administrator.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Confirm-Administrator {
+function Confirm-Administrator {
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal( [Security.Principal.WindowsIdentity]::GetCurrent() )
 
     return $currentPrincipal.IsInRole( [Security.Principal.WindowsBuiltInRole]::Administrator )

--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\Invoke-CatchActionError.ps1
 . $PSScriptRoot\Invoke-CatchActionErrorLoop.ps1
 
-Function Confirm-ExchangeShell {
+function Confirm-ExchangeShell {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -22,7 +22,7 @@ Function Confirm-ExchangeShell {
     )
 
     begin {
-        Function Test-GetExchangeServerCmdletError {
+        function Test-GetExchangeServerCmdletError {
             param(
                 [Parameter(Mandatory = $true)]
                 [object]$ThisError

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-ExchangeBuildVersionInformation {
+function Get-ExchangeBuildVersionInformation {
     [CmdletBinding()]
     param(
         [object]$AdminDisplayVersion

--- a/Shared/Get-NETFrameworkVersion.ps1
+++ b/Shared/Get-NETFrameworkVersion.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-RemoteRegistryValue.ps1
 
-Function Get-NETFrameworkVersion {
+function Get-NETFrameworkVersion {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,

--- a/Shared/Get-RemoteRegistrySubKey.ps1
+++ b/Shared/Get-RemoteRegistrySubKey.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-RemoteRegistrySubKey {
+function Get-RemoteRegistrySubKey {
     [CmdletBinding()]
     param(
         [string]$RegistryHive = "LocalMachine",

--- a/Shared/Get-RemoteRegistryValue.ps1
+++ b/Shared/Get-RemoteRegistryValue.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Get-RemoteRegistrySubKey.ps1
 
-Function Get-RemoteRegistryValue {
+function Get-RemoteRegistryValue {
     [CmdletBinding()]
     param(
         [string]$RegistryHive = "LocalMachine",

--- a/Shared/Get-ServerRebootPending.ps1
+++ b/Shared/Get-ServerRebootPending.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Invoke-ScriptBlockHandler.ps1
 
-Function Get-ServerRebootPending {
+function Get-ServerRebootPending {
     [CmdletBinding()]
     param(
         [string]$ServerName = $env:COMPUTERNAME,
@@ -11,7 +11,7 @@ Function Get-ServerRebootPending {
     )
     begin {
 
-        Function Get-PendingFileReboot {
+        function Get-PendingFileReboot {
             try {
                 if ((Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\" -Name PendingFileRenameOperations -ErrorAction Stop)) {
                     return $true
@@ -22,7 +22,7 @@ Function Get-ServerRebootPending {
             }
         }
 
-        Function Get-PendingCCMReboot {
+        function Get-PendingCCMReboot {
             try {
                 return (Invoke-CimMethod -Namespace 'Root\ccm\clientSDK' -ClassName 'CCM_ClientUtilities' -Name 'DetermineIfRebootPending' -ErrorAction Stop)
             } catch {
@@ -30,7 +30,7 @@ Function Get-ServerRebootPending {
             }
         }
 
-        Function Get-PathTestingReboot {
+        function Get-PathTestingReboot {
             param(
                 [string]$TestingPath
             )

--- a/Shared/Invoke-CatchActionError.ps1
+++ b/Shared/Invoke-CatchActionError.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-CatchActionError {
+function Invoke-CatchActionError {
     [CmdletBinding()]
     param(
         [scriptblock]$CatchActionFunction

--- a/Shared/Invoke-CatchActionErrorLoop.ps1
+++ b/Shared/Invoke-CatchActionErrorLoop.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Invoke-CatchActionErrorLoop {
+function Invoke-CatchActionErrorLoop {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]

--- a/Shared/Invoke-ScriptBlockHandler.ps1
+++ b/Shared/Invoke-ScriptBlockHandler.ps1
@@ -5,7 +5,7 @@
 
 # Common method used to handle Invoke-Command within a script.
 # Avoids using Invoke-Command when running locally on a server.
-Function Invoke-ScriptBlockHandler {
+function Invoke-ScriptBlockHandler {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Shared/LoggerFunctions.ps1
+++ b/Shared/LoggerFunctions.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Get-NewLoggerInstance {
+function Get-NewLoggerInstance {
     [CmdletBinding()]
     param(
         [string]$LogDirectory = (Get-Location).Path,
@@ -45,7 +45,7 @@ Function Get-NewLoggerInstance {
     } | Write-LoggerInstance -Object "Starting Logger Instance $(Get-Date)"
 }
 
-Function Write-LoggerInstance {
+function Write-LoggerInstance {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -94,7 +94,7 @@ Function Write-LoggerInstance {
     }
 }
 
-Function Invoke-LoggerInstanceCleanup {
+function Invoke-LoggerInstanceCleanup {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]

--- a/Shared/PesterLoadFunctions.NotPublished.ps1
+++ b/Shared/PesterLoadFunctions.NotPublished.ps1
@@ -3,7 +3,7 @@
 
 # Common code to get the string value to run Invoke-Expression against.
 # Need to return the string value as we can't run Invoke-Expression from inside this function as it won't expose it to the caller
-Function Get-PesterScriptContent {
+function Get-PesterScriptContent {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Pester testing file')]
     [CmdletBinding()]
     [OutputType("System.String")]

--- a/Shared/Tests/Get-NETFrameworkVersion.Tests.ps1
+++ b/Shared/Tests/Get-NETFrameworkVersion.Tests.ps1
@@ -117,7 +117,7 @@ Describe "Testing $scriptName" {
 
         It "Testing a catch script block" {
 
-            Function Write-CustomScriptBlock {
+            function Write-CustomScriptBlock {
                 Write-Host "Write-CustomScriptBlock"
             }
 

--- a/Shared/Tests/Get-ServerPendingReboot.Tests.ps1
+++ b/Shared/Tests/Get-ServerPendingReboot.Tests.ps1
@@ -7,7 +7,7 @@ BeforeAll {
 
     . "$parent\$scriptName"
 
-    Function Get-SCCMRebootObject {
+    function Get-SCCMRebootObject {
         $t = New-Object PSCustomObject
         $t | Add-Member -MemberType NoteProperty -Name "RebootPending" -Value $false
         $t | Add-Member -MemberType NoteProperty -Name "IsHardRebootPending" -Value $false

--- a/Shared/Tests/Invoke-ScriptBlockHandler.Tests.ps1
+++ b/Shared/Tests/Invoke-ScriptBlockHandler.Tests.ps1
@@ -10,7 +10,7 @@ BeforeAll {
 
     . "$parent\$scriptName"
 
-    Function Get-WinHttpSettings {
+    function Get-WinHttpSettings {
         param(
             [Parameter(Mandatory = $true)][string]$RegistryLocation
         )
@@ -27,7 +27,7 @@ BeforeAll {
         return $(if ($Proxy -eq [string]::Empty) { "<None>" } else { $Proxy })
     }
 
-    Function Get-PendingSCCMReboot {
+    function Get-PendingSCCMReboot {
 
         begin {
             $returnValue = $false
@@ -55,7 +55,7 @@ BeforeAll {
         }
     }
 
-    Function Test-VerboseOutput {
+    function Test-VerboseOutput {
         param(
             [bool]$Without = $true,
             [bool]$Local = $true
@@ -178,7 +178,7 @@ Describe "Testing $scriptName" {
     Context "Testing catch action script block" {
 
         It "Testing throw" {
-            Function Test-PesterCatchAction {
+            function Test-PesterCatchAction {
                 Write-Host "Test-PesterCatchAction"
             }
             Mock Invoke-Command { throw "Failed Pester Testing" }

--- a/Shared/VisualCRedistributableVersionFunctions.ps1
+++ b/Shared/VisualCRedistributableVersionFunctions.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\Invoke-ScriptBlockHandler.ps1
 
-Function Get-VisualCRedistributableInstalledVersion {
+function Get-VisualCRedistributableInstalledVersion {
     [CmdletBinding()]
     param(
         [string]$ComputerName = $env:COMPUTERNAME,
@@ -38,7 +38,7 @@ Function Get-VisualCRedistributableInstalledVersion {
     }
 }
 
-Function Get-VisualCRedistributableInfo {
+function Get-VisualCRedistributableInfo {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -62,7 +62,7 @@ Function Get-VisualCRedistributableInfo {
     }
 }
 
-Function Test-VisualCRedistributableInstalled {
+function Test-VisualCRedistributableInstalled {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0)]
@@ -80,7 +80,7 @@ Function Test-VisualCRedistributableInstalled {
     return ($null -ne ($Installed | Where-Object { $_.DisplayName -like $desired.DisplayName }))
 }
 
-Function Test-VisualCRedistributableUpToDate {
+function Test-VisualCRedistributableUpToDate {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0)]

--- a/Shared/Write-Host.ps1
+++ b/Shared/Write-Host.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Function Write-Host {
+function Write-Host {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'Proper handling of write host with colors')]
     [CmdletBinding()]
     param(
@@ -48,7 +48,7 @@ Function Write-Host {
     }
 }
 
-Function SetProperForegroundColor {
+function SetProperForegroundColor {
     $Script:OriginalConsoleForegroundColor = $host.UI.RawUI.ForegroundColor
 
     if ($Host.UI.RawUI.ForegroundColor -eq $Host.PrivateData.WarningForegroundColor) {
@@ -68,14 +68,14 @@ Function SetProperForegroundColor {
     }
 }
 
-Function RevertProperForegroundColor {
+function RevertProperForegroundColor {
     $Host.UI.RawUI.ForegroundColor = $Script:OriginalConsoleForegroundColor
 }
 
-Function SetWriteHostAction ($DebugAction) {
+function SetWriteHostAction ($DebugAction) {
     $Script:WriteHostDebugAction = $DebugAction
 }
 
-Function SetWriteHostManipulateObjectAction ($ManipulateObject) {
+function SetWriteHostManipulateObjectAction ($ManipulateObject) {
     $Script:WriteHostManipulateObjectAction = $ManipulateObject
 }

--- a/Transport/Compute-TopExoRecipientsFromMessageTrace.ps1
+++ b/Transport/Compute-TopExoRecipientsFromMessageTrace.ps1
@@ -68,13 +68,13 @@ $GetDeliveredMessageTraceEvents =
     [int]$page=1
     [DateTime]$timeout = (Get-Date).AddMinutes($TimeoutAfter)
 
-    Do {
+    do {
         Write-Host "Processing Page $($page)"
         $pageList = New-Object -TypeName "System.Collections.ArrayList"
         $pageList = Get-MessageTrace -StartDate $StartDate -EndDate $EndDate -Page $page -PageSize 5000 -Status Delivered
         $eventList += $pageList
         $page++
-    }While ($pageList.count -eq 5000 -and (Get-Date) -lt $timeout)
+    }while ($pageList.count -eq 5000 -and (Get-Date) -lt $timeout)
     return $eventList
 }
 
@@ -95,4 +95,3 @@ $props = [ordered]@{
 }
 $results = New-Object -TypeName PSObject -Property $props;
 return $results
-


### PR DESCRIPTION
**Issue:**

We have no consistent formatting of keywords. In some scripts, keywords change cases every few lines.

PoshCode says [keywords should be lowercase](https://github.com/PoshCode/PowerShellPracticeAndStyle/blob/master/Style-Guide/Code-Layout-and-Formatting.md).

PSScriptAnalyzer is most likely headed for a keywords-must-be-lowercase rule. There are multiple issues open, but no one has done the work yet. You can start following the trail of issues at PowerShell/PSScriptAnalyzer#767.

**Fix:**

Until PSScriptAnalyzer adds this check, add our own check.
