### PR TITLE
Get-ExchangeADPermissions doesn't work properly on Windows Server 2012

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -481,7 +481,7 @@ function Get-ExchangeInformation {
                 -CatchActionFunction ${Function:Invoke-CatchActions}
 
             Write-Verbose "Query Exchange AD permissions for CVE-2022-21978 testing"
-            $exchangeInformation.ExchangeAdPermissions = Get-ExchangeAdPermissions -ExchangeVersion $buildInformation.MajorVersion
+            $exchangeInformation.ExchangeAdPermissions = Get-ExchangeAdPermissions -ExchangeVersion $buildInformation.MajorVersion -OSVersion $OSMajorVersion
         }
 
         $exchangeInformation.ApplicationConfigFileStatus = Get-ExchangeApplicationConfigurationFileValidation -ConfigFileLocation ("{0}EdgeTransport.exe.config" -f $serverExchangeBinDirectory)


### PR DESCRIPTION
**Issue:**
We use the `Where()` method to check if an ACE exists or not. However, the `Where()` method was introduced with PowerShell version 4.0 (default version on Windows Server 2012 R2) and so is not available by default on Windows Server 2012.

**Fix:**
Fallback to `objectVersion (Default)` testing implemented for Windows Server 2012 OS.

**Validation:**
By customer who reported the issue

