### PR TITLE
Fixed bug where we fix OWA BE Vdir

### DIFF
--- a/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-VirtualDirectoryConfiguration.ps1
@@ -117,11 +117,11 @@ function Test-VirtualDirectoryConfiguration {
                     Where-Object { $_.Path -like "$($iisSite.Name)$($expectedVdir.Paths[0])*" }).Path
             $customMetadataPaths = ($appHostConfig.LastChild."system.applicationHost".customMetadata.key.GetEnumerator() |
                     Where-Object { $_.Path -like "*$($iisSite.Id)/ROOT$($expectedVdir.Paths[0])*" } ).Path
+            $owaRootPaths = @()
 
             if ($expectedVdir.DirectoryName -eq "owa (Exchange Back End)") {
                 $specialPaths = @("/Exchange", "/Exchweb", "/Public")
                 $tempLocationPaths = @()
-                $owaRootPaths = @()
 
                 foreach ($path in $specialPaths) {
                     $node = $appHostConfig.LastChild.Location.GetEnumerator() | Where-Object { $_.Path -like "$($iisSite.Name)$path" }


### PR DESCRIPTION
**Issue:**
If we find an issue with OWA, then move onto the next vdir and find a problem with that vdir, we then attempt to remove that child node again which fails.

**Fix:**
Set `$owaRootPaths` to an empty array for each loop not just when we are working on the `owa (Exchange Back End)`. 

**Validation:**
Lab tested

