### PR TITLE
SimplePerf: Use COMPUTERNAME instead of localhost

### DIFF
--- a/Performance/SimplePerf/SimplePerf.ps1
+++ b/Performance/SimplePerf/SimplePerf.ps1
@@ -238,7 +238,7 @@ begin {
             return
         }
 
-        $counterFullNames = $countersFiltered | ForEach-Object { ("\\localhost" + $_) }
+        $counterFullNames = $countersFiltered | ForEach-Object { ("\\$env:COMPUTERNAME" + $_) }
 
         if ($DisplayFilterResults) {
             Write-Host "$($env:COMPUTERNAME): The following counters matched the specified filters:"


### PR DESCRIPTION
Fixes #1075

Counter paths now reflect the computer name rather than localhost:

```powershell
[PS] C:\code\CSS-Exchange\dist>Get-ExchangeServer | .\SimplePerf.ps1 -Start -Scenario None -IncludeCounters "\Network Interface(*)" -Verbose
LAB1E15: Removing existing SimplePerf collector.
LAB1E15: Getting list of counters.
LAB1E15: Applying filters.
LAB1E15: The following counters matched the specified filters:
LAB1E15: \\LAB1E15\Network Interface(*)\*
LAB1E15: Creating SimplePerf collector, writing to C:\SimplePerf\220523081812.
The command completed successfully.
LAB1E15: Starting SimplePerf collector.
The command completed successfully.
LAB1E16: Removing existing SimplePerf collector.
LAB1E16: Getting list of counters.
LAB1E16: Applying filters.
LAB1E16: The following counters matched the specified filters:
LAB1E16: \\LAB1E16\Network Interface(*)\*
LAB1E16: Creating SimplePerf collector, writing to C:\SimplePerf\220523121821.
The command completed successfully.
LAB1E16: Starting SimplePerf collector.
The command completed successfully.
LAB1E19-1: Removing existing SimplePerf collector.
LAB1E19-1: Getting list of counters.
LAB1E19-1: Applying filters.
LAB1E19-1: The following counters matched the specified filters:
LAB1E19-1: \\LAB1E19-1\Network Interface\*
LAB1E19-1: Creating SimplePerf collector, writing to C:\SimplePerf\220523081831.
The command completed successfully.
LAB1E19-1: Starting SimplePerf collector.
The command completed successfully.
LAB1E19-2: Getting list of counters.
LAB1E19-2: Applying filters.
LAB1E19-2: The following counters matched the specified filters:
LAB1E19-2: \\LAB1E19-2\Network Interface\*
LAB1E19-2: Creating SimplePerf collector, writing to C:\SimplePerf\220523081840.
The command completed successfully.
```
