### PR TITLE
Include Get-StoreQueryMailboxInformation in StoreQueryFunctions

### DIFF
--- a/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Exchange/Get-MailboxInformation.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-#Dependencies are based off EMS cmdlets.
+. $PSScriptRoot\..\..\..\Shared\StoreQueryFunctions.ps1
 function Get-MailboxInformation {
     [CmdletBinding()]
     param(
@@ -15,63 +15,14 @@ function Get-MailboxInformation {
         $IsPublicFolder
     )
 
-    begin {
-        $diagnosticContext = New-Object 'System.Collections.Generic.List[string]'
-        $breadCrumb = 0
-    }
+    try {
 
-    process {
+        $storeQueryMailboxInfo = Get-StoreQueryMailboxInformation -Identity $Identity -IsArchive $IsArchive -IsPublicFolder $IsPublicFolder
 
-        try {
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-            $mailboxInfo = Get-Mailbox -Identity $Identity -PublicFolder:$IsPublicFolder -Archive:$IsArchive -ErrorAction Stop
-
-            if ($IsArchive) {
-                $mbxGuid = $mailboxInfo.ArchiveGuid.ToString()
-                $databaseName = $mailboxInfo.ArchiveDatabase.ToString()
-            } else {
-                $mbxGuid = $mailboxInfo.ExchangeGuid.ToString()
-                $databaseName = $mailboxInfo.Database.ToString()
-            }
-
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-            $mailboxStats = Get-MailboxStatistics -Identity $Identity -Archive:$IsArchive
-
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-            $dbCopyStatus = Get-MailboxDatabaseCopyStatus $databaseName\* |
-                Where-Object {
-                    $_.Status -like "*Mounted*"
-                }
-            $primaryServer = $dbCopyStatus.Name.Substring($dbCopyStatus.Name.IndexOf("\") + 1)
-
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-            $primaryServerInfo = Get-ExchangeServer -Identity $primaryServer
-
-            if ($primaryServerInfo.AdminDisplayVersion.ToString() -notlike "Version 15.2*") {
-                throw "User isn't on an Exchange 2019 server"
-            }
-
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-            $dbStatus = Get-MailboxDatabase -Identity $databaseName -Status
-
-            $diagnosticContext.Add("Get-MailboxInformation $($breadCrumb; $breadCrumb++)")
-        } catch {
-            throw "Failed to find '$Identity' information. InnerException: $($Error[0].Exception)"
+        if ($storeQueryMailboxInfo.ExchangeServer.AdminDisplayVersion.ToString() -notlike "Version 15.2*") {
+            throw "User isn't on an Exchange 2019 server"
         }
-    }
-    end {
-        return [PSCustomObject]@{
-            Identity           = $Identity
-            MailboxGuid        = $mbxGuid
-            PrimaryServer      = $primaryServer
-            DBWorkerID         = $dbStatus.WorkerProcessId
-            Database           = $databaseName
-            ExchangeServer     = $primaryServerInfo
-            DatabaseStatus     = $dbStatus
-            DatabaseCopyStatus = $dbCopyStatus
-            MailboxInfo        = $mailboxInfo
-            MailboxStatistics  = $mailboxStats
-            DiagnosticContext  = $diagnosticContext
-        }
+    } catch {
+        throw "Failed to find '$Identity' information. InnerException: $($Error[0].Exception)"
     }
 }

--- a/Shared/StoreQueryFunctions.ps1
+++ b/Shared/StoreQueryFunctions.ps1
@@ -152,6 +152,68 @@ function Test-LoadGetStoreQuery {
     return $false
 }
 
+# the function used to get the mailbox information required for Get-StoreQueryObject
+function Get-StoreQueryMailboxInformation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Identity,
+
+        [bool]
+        $IsArchive,
+
+        [bool]
+        $IsPublicFolder
+    )
+    process {
+        try {
+            Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+            Write-Verbose "Attempting to run Get-Mailbox"
+            $mailboxInfo = Get-Mailbox -Identity $Identity -PublicFolder:$IsPublicFolder -Archive:$IsArchive -ErrorAction Stop
+
+            if ($IsArchive) {
+                $mbxGuid = $mailboxInfo.ArchiveGuid.ToString()
+                $databaseName = $mailboxInfo.ArchiveDatabase.ToString()
+            } else {
+                $mbxGuid = $mailboxInfo.ExchangeGuid.ToString()
+                $databaseName = $mailboxInfo.Database.ToString()
+            }
+
+            Write-Verbose "Attempting to run Get-MailboxStatistics"
+            $mailboxStatistics = Get-MailboxStatistics -Identity $Identity -Archive:$IsArchive
+
+            Write-Verbose "Attempting to run Get-MailboxDatabaseCopyStatus"
+            $dbCopyStatus = Get-MailboxDatabaseCopyStatus $databaseName\* |
+                Where-Object { $_.Status -like "*Mounted*" }
+            $primaryServer = $dbCopyStatus.MailboxServer
+
+            Write-Verbose "Running Get-ExchangeServer for primary server: $primaryServer"
+            $primaryServerInfo = Get-ExchangeServer -Identity $primaryServer
+
+            Write-Verbose "Running Get-MailboxDatabase"
+            $databaseStatus = Get-MailboxDatabase -Identity $databaseName -Status
+        } catch {
+            Write-ErrorInformation $_ "Write-Host"
+            throw "Failed to find '$Identity' information."
+        }
+    }
+    end {
+        return [PSCustomObject]@{
+            Identity           = $Identity
+            MailboxGuid        = $mbxGuid
+            PrimaryServer      = $primaryServer
+            DBWorkerID         = $dbCopyStatus.WorkerProcessId
+            Database           = $databaseName
+            ExchangeServer     = $primaryServerInfo
+            DatabaseStatus     = $databaseStatus
+            DatabaseCopyStatus = $dbCopyStatus
+            MailboxInfo        = $mailboxInfo
+            MailboxStatistics  = $mailboxStatistics
+        }
+    }
+}
+
 function Get-StoreQueryObject {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
**Reason:**
Because the `Get-StoreQueryObject` was created around `Get-MailboxInformation` from the Troubleshoot-ModernSearch script, moved that into the StoreQueryFunctions


