### PR TITLE
Addressed ParameterBindingValidationException caused by IsUnlimited not being set

### DIFF
--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BigFunnelPropertyNameMapping.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-BigFunnelPropertyNameMapping.ps1
@@ -26,9 +26,9 @@ function Get-BigFunnelPropertyNameMapping {
         }
     }
     process {
+        $StoreQueryHandler = $StoreQueryHandler | ResetQueryInstances
         $StoreQueryHandler.IsUnlimited = $true
         $result = $StoreQueryHandler |
-            ResetQueryInstances |
             SetSelect -Value @(
                 "PropName",
                 "PropNumber") |


### PR DESCRIPTION
**Issue:**
Sometimes the script isn't getting the `Get-BigFunnelPropertyNameMapping` correctly. 

**Reason:**
A bug caused by running `ResetQueryInstances` after setting `IsUnlimited` to true. 

**Fix:**
Call `ResetQueryInstances` first. 

Resolved #1062 

**Validation:**
Customer tested
