### PR TITLE
Add Warning on MaxReceiveSize set to 0 Bytes on mailbox

### DIFF
--- a/Search/Troubleshoot-ModernSearch/Write/Write-BasicMailboxInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/Write/Write-BasicMailboxInformation.ps1
@@ -14,7 +14,14 @@ function Write-BasicMailboxInformation {
         Write-Host "Mailbox Database: $($MailboxInformation.Database)"
         Write-Host "Active Server: $($MailboxInformation.PrimaryServer)"
         Write-Host "Exchange Server Version: $($MailboxInformation.ExchangeServer.AdminDisplayVersion)"
+        Write-Host "Max Send Size: $($MailboxInformation.MailboxInfo.MaxSendSize.ToString())"
+        Write-Host "Max Receive Size: $($MailboxInformation.MailboxInfo.MaxReceiveSize.ToString())"
         Write-Host "----------------------------------------"
+
+        if ($MailboxInformation.MailboxInfo.MaxReceiveSize.ToString() -eq "0 B (0 bytes)") {
+            Write-Warning "The Max Receive Size is set to 0 Bytes, all messages greater than 1MB will be failed to indexed."
+        }
+
         Write-Host ""
         Write-Host "Big Funnel Count Information Based Off Get-MailboxStatistics"
         Write-DisplayObjectInformation -DisplayObject $MailboxInformation.MailboxStatistics -PropertyToDisplay @(


### PR DESCRIPTION
**Reason:**
When setting the `MaxReceiveSize` and `MaxSendSize` to 0 Bytes on mailbox is a common company policy, we need to call this out if we are trying to troubleshoot indexing issues on it.

**Validation:**
Lab tested

