### PR TITLE
Use otherWellKnownObjects to find Exchange groups

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -79,7 +79,7 @@ function Get-ExchangeAdPermissions {
 
         foreach ($group in $groupLists) {
             Write-Verbose "Trying to find: $($group.Name)"
-            $wkObject = $otherWellKnownObjects | Where-Object WellKnownName -EQ $group.Name
+            $wkObject = $otherWellKnownObjects | Where-Object { $_.WellKnownName -eq $group.Name }
             if ($null -ne $wkObject) {
                 Write-Verbose "Found DN in otherWellKnownObjects: $($wkObject.DistinguishedName)"
                 $entry = [ADSI]("LDAP://$($wkObject.DistinguishedName)")

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -4,6 +4,7 @@
 . $PSScriptRoot\Get-ExchangeDomainConfigVersion.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ErrorMonitorFunctions.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ActiveDirectoryAcl.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeOtherWellKnownObjects.ps1
 
 function Get-ExchangeAdPermissions {
     [CmdletBinding()]
@@ -74,16 +75,15 @@ function Get-ExchangeAdPermissions {
         Write-Verbose "Getting the domain information"
         $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
         Write-Verbose ("Detected: $($forest.Domains.Count) domain(s)")
-        $rootDomain = $forest.RootDomain.GetDirectoryEntry()
+        $otherWellKnownObjects = Get-ExchangeOtherWellKnownObjects
 
         foreach ($group in $groupLists) {
             Write-Verbose "Trying to find: $($group.Name)"
-            $searcher = New-Object System.DirectoryServices.DirectorySearcher($rootDomain, "(samAccountName=$($group.Name))")
-            $results = $searcher.FindOne()
-
-            if ($null -ne $results) {
-                $results = $results.GetDirectoryEntry()
-                $group.Sid = (New-Object System.Security.Principal.SecurityIdentifier($results.objectSid.Value, 0)).Value
+            $wkObject = $otherWellKnownObjects | Where-Object WellKnownName -EQ $group.Name
+            if ($null -ne $wkObject) {
+                Write-Verbose "Found DN in otherWellKnownObjects: $($wkObject.DistinguishedName)"
+                $entry = [ADSI]("LDAP://$($wkObject.DistinguishedName)")
+                $group.Sid = (New-Object System.Security.Principal.SecurityIdentifier($entry.objectSid.Value, 0)).Value
                 Write-Verbose "Found Results Set Sid: $($group.Sid)"
             }
         }

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainOtherWellKnownObjects.ps1
@@ -3,19 +3,19 @@
 
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeContainer.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeOtherWellKnownObjects.ps1
 
 function Test-DomainOtherWellKnownObjects {
     $exchangeContainer = Get-ExchangeContainer
-    $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=*)", @("otherWellKnownObjects", "distinguishedName"))
-    $result = $searcher.FindOne()
+    $otherWellKnownObjects = Get-ExchangeOtherWellKnownObjects
 
     $importFilePath = "$PSScriptRoot\ExchangeContainerImport.txt"
     $outputLines = New-Object 'System.Collections.Generic.List[string]'
-    $outputLines.Add("dn: $($result.Properties["distinguishedName"][0].ToString())")
+    $outputLines.Add("dn: $($exchangeContainer.Properties["distinguishedName"][0].ToString())")
     $outputLines.Add("changeType: modify")
     $outputLines.Add("replace: otherWellKnownObjects")
     $badItemsFound = $false
-    foreach ($value in $result.Properties["otherWellKnownObjects"]) {
+    foreach ($value in $otherWellKnownObjects.RawValue) {
 
         $params = @{
             TestName = "Other Well Known Objects"

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
@@ -1,0 +1,53 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Get-ExchangeContainer.ps1
+
+function Get-ExchangeOtherWellKnownObjects {
+    [CmdletBinding()]
+    param ()
+
+    $otherWellKnownObjectIds = @{
+        "C2F9A9F9D6A1B74A9E068728F8F842EA" = "Organization Management"
+        "DB72C41D49580A4DB304FE6981E56297" = "Recipient Management"
+        "1A9E39D35ABE5747B979FFC0C6E5EA26" = "View-Only Organization Management"
+        "45FA417B3574DC4E929BC4B059699792" = "Public Folder Management"
+        "E80CDFB75697934981C898B4DBC5A0C6" = "UM Management"
+        "B3DDC6BE2A3BE84B97EB2DCE9477E389" = "Help Desk"
+        "BEA432C94E1D254EAF99B40573360D5B" = "Records Management"
+        "C67FDE2E8339674490FBAFDCA3DFDC95" = "Discovery Management"
+        "4DB8E7754EB6C1439565612E69A80A4F" = "Server Management"
+        "D1281926D1F55B44866D1D6B5BD87A09" = "Delegated Setup"
+        "03B709F451F3BF4388E33495369B6771" = "Hygiene Management"
+        "B30A449BA9B420458C4BB22F33C52766" = "Compliance Management"
+        "A7D2016C83F003458132789EEB127B84" = "Exchange Servers"
+        "EA876A58DB6DD04C9006939818F800EB" = "Exchange Trusted Subsystem"
+        "02522ECF9985984A9232056FC704CC8B" = "Managed Availability Servers"
+        "4C17D0117EBE6642AFAEE03BC66D381F" = "Exchange Windows Permissions"
+        "9C5B963F67F14A4B936CB8EFB19C4784" = "ExchangeLegacyInterop"
+        "776B176BD3CB2A4DA7829EA963693013" = "Security Reader"
+        "03D7F0316EF4B3498AC434B6E16F09D9" = "Security Administrator"
+        "A2A4102E6F676141A2C4AB50F3C102D5" = "PublicFolderMailboxes"
+    }
+
+    $exchangeContainer = Get-ExchangeContainer
+    $searcher = New-Object System.DirectoryServices.DirectorySearcher($exchangeContainer, "(objectClass=*)", @("otherWellKnownObjects", "distinguishedName"))
+    $result = $searcher.FindOne()
+    foreach ($val in $result.Properties["otherWellKnownObjects"]) {
+        $matchResults = $val | Select-String "^B:32:([^:]+):(.*)$"
+        if ($matchResults.Matches.Groups.Count -ne 3) {
+            # What should we do with a corrupted entry?
+            continue
+        }
+
+        $wkGuid = $matchResults.Matches.Groups[1].Value
+        $wkName = $otherWellKnownObjectIds[$wkGuid]
+
+        [PSCustomObject]@{
+            WellKnownName     = $wkName
+            WellKnownGuid     = $wkGuid
+            DistinguishedName = $matchResults.Matches.Groups[2].Value
+            RawValue          = $val
+        }
+    }
+}

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
@@ -36,7 +36,14 @@ function Get-ExchangeOtherWellKnownObjects {
     foreach ($val in $result.Properties["otherWellKnownObjects"]) {
         $matchResults = $val | Select-String "^B:32:([^:]+):(.*)$"
         if ($matchResults.Matches.Groups.Count -ne 3) {
-            # What should we do with a corrupted entry?
+            # Only output the raw value of a corrupted entry
+            [PSCustomObject]@{
+                WellKnownName     = $null
+                WellKnownGuid     = $null
+                DistinguishedName = $null
+                RawValue          = $val
+            }
+
             continue
         }
 


### PR DESCRIPTION
**Issue:**
HealthChecker finds well known groups by samAccountName, but this doesn't work if a duplicate group caused the samAccountName to be something like "Exchange Servers1" instead of "Exchange Servers".

**Fix:**
Use otherWellKnownGroups property to find the well known groups. This is how Exchange does it.

**Validation:**
Tested both SetupAssist and HealthChecker in my lab with these changes. Example HealthChecker verbose output:

```
Trying to find: Exchange Servers
Found DN in otherWellKnownObjects: CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=contoso,DC=local
Found Results Set Sid: S-1-5-21-2387909468-3200044226-3854461676-1121
Trying to find: Exchange Windows Permissions
Found DN in otherWellKnownObjects: CN=Exchange Windows Permissions,OU=Microsoft Exchange Security Groups,DC=contoso,DC=local
Found Results Set Sid: S-1-5-21-2387909468-3200044226-3854461676-1124
```

Note: In Get-ExchangeOtherWellKnownGroups, I defined all the ones I see in my lab. However, we actually only need the two that HealthChecker currently looks up. We could remove these others until we need them, or leave them in.