### PR TITLE
Fix bug with Exchange Log Collector CAS Detection

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
@@ -55,7 +55,7 @@ function Get-ExchangeBasicServerObject {
         Mailbox        = $mailbox
         MailboxOnly    = $exchServerRole -eq "Mailbox"
         Hub            = $exchVersion -ge 15 -and (-not ($exchServerRole -eq "ClientAccess"))
-        CAS            = $exchServerRole -like "*ClientAccess*"
+        CAS            = $exchVersion -ge 16 -or $exchServerRole -like "*ClientAccess*"
         CASOnly        = $exchServerRole -eq "ClientAccess"
         Edge           = $exchServerRole -eq "Edge"
         Version        = $exchVersion


### PR DESCRIPTION
**Issue:**
Fixed bug where on 2016/2019 proxy logs were not getting collected. 

**Reason:**
Script didn't detect that this was a CAS role that contains the proxy logs.

**Fix:**
Corrected the bug, by having any 16+ versions of Exchange to be a CAS role as well. 

**Validation:**
Lab Tested

