### PR TITLE
Health Checker Updates for Test-ScriptUpdate

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -228,7 +228,7 @@ function Main {
 
     if ($ScriptUpdateOnly) {
         Invoke-ScriptLogFileLocation -FileName "HealthChecker-ScriptUpdateOnly"
-        switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/HC-VersionsUrl") {
+        switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/HC-VersionsUrl" -Confirm:$false) {
             ($true) { Write-Green("Script was successfully updated.") }
             ($false) { Write-Yellow("No update of the script performed.") }
             default { Write-Red("Unable to perform ScriptUpdateOnly operation.") }

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -84,7 +84,7 @@
     https://docs.microsoft.com/en-us/exchange/plan-and-deploy/virtualization?view=exchserver-2019#requirements-for-hardware-virtualization
 #>
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Variables are being used')]
-[CmdletBinding(DefaultParameterSetName = "HealthChecker")]
+[CmdletBinding(DefaultParameterSetName = "HealthChecker", SupportsShouldProcess)]
 param(
     [Parameter(Mandatory = $false, ParameterSetName = "HealthChecker")]
     [Parameter(Mandatory = $false, ParameterSetName = "MailboxReport")]


### PR DESCRIPTION
**Issue:**
The latest breakout of `Test-ScriptVersion` caused the switch `-ScriptUpdateOnly` to require a confirmation to update. This breaks Health Checker automation as described in #1098. 

**Reason:**
If using `-ScriptUpdateOnly` we want to force the update to occur without question, if one is available. 

**Fix:**
When doing `-ScriptUpdateOnly`, pass `-Confirm:$false` to `Test-ScriptVersion`.

Also supported `SupportsShouldProcess` on `HealthChecker.ps1` to allow customers to pass `-Confirm:$false` on the main part of the script if they would like.

Resolved #1098 

**Validation:**
Lab tested

