### PR TITLE
Update Get-EASMailboxLogs.md

### DIFF
--- a/docs/Admin/Get-EASMailboxLogs.md
+++ b/docs/Admin/Get-EASMailboxLogs.md
@@ -11,6 +11,7 @@ Get-EASMailboxLogs.ps1
   [-Mailbox <string[]>]
   [-OutputPath <string>]
   [-Interval <int>]
+  [-EnableMailboxLoggingVerboseMode <bool>]
 ```
 
 ## Examples
@@ -24,4 +25,9 @@ The following example collects logs for two mailbox every hour:
 The following example collects logs for a mailbox:
 ```
 .\Get-EASMailboxLogs.ps1 -Mailbox "jim" -OutputPath c:\EASLogs
+```
+
+The following example enables Verbose Logging on the current on premise server and collects logs for a mailbox:
+```
+.\Get-EASMailboxLogs.ps1 -Mailbox "jim" -OutputPath c:\EASLogs -EnableMailboxLoggingVerboseMode $true
 ```


### PR DESCRIPTION
Add EnableMailboxLoggingVerboseMode key and example.

**Issue:**
In some scenarios we need EAS verbose log to see all exchanged data. To enable verbose logging we need to modify corresponding web.config 

**Reason:**
Implement option to enable verbose logging on the current on premise Exchange server. 

