### PR TITLE
Adding SetUnifiedContentPath script

### DIFF
--- a/Admin/SetUnifiedContentPath/Get-UnifiedContentInformation.ps1
+++ b/Admin/SetUnifiedContentPath/Get-UnifiedContentInformation.ps1
@@ -1,0 +1,86 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\..\Shared\Write-ErrorInformation.ps1
+function Get-UnifiedContentInformation {
+    [CmdletBinding()]
+    param()
+    process {
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        $cleanupFolderValue = [string]::Empty
+        $antiMalwareFilePath = [string]::Empty
+        $success = $false
+        $validSetting = $false
+        $foundAntiMalwareFile = $false
+
+        try {
+            $installDirectory = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction Stop).MsiInstallPath
+        } catch {
+            Write-VerboseErrorInformation
+            Write-Verbose "Failed to determine Exchange Install path"
+            return
+        }
+
+        try {
+            $appConfig = [System.Configuration.ConfigurationManager]::OpenExeConfiguration("$installDirectory`Bin\EdgeTransport.exe")
+            $temporaryStoragePath = "$($appConfig.AppSettings.Settings["TemporaryStoragePath"].Value)\UnifiedContent"
+        } catch {
+            Write-VerboseErrorInformation
+            Write-Verbose "Failed to determine TemporaryStoragePath"
+            return
+        }
+
+        $defaultUnifiedContentPath = "$installDirectory`TransportRoles\data\Temp\UnifiedContent"
+        $antiMalwareFilePath = "$installDirectory`Bin\Monitoring\Config\AntiMalware.xml"
+        $foundAntiMalwareFile = Test-Path $antiMalwareFilePath
+
+        if (-not ($foundAntiMalwareFile)) {
+            Write-Verbose "Failed to find the AntiMalware.xml file"
+            return
+        }
+
+        try {
+            $loadAntiMalwareFile = New-Object System.Xml.XmlDocument
+            $loadAntiMalwareFile.PreserveWhitespace = $true
+            $loadAntiMalwareFile.Load($antiMalwareFilePath)
+            $cleanupFolderValue = $loadAntiMalwareFile.Definition.MaintenanceDefinition.ExtensionAttributes.CleanupFolderResponderFolderPaths
+        } catch {
+            Write-VerboseErrorInformation
+            Write-Verbose "Failed to determine value of CleanupFolderResponderFolderPaths"
+        }
+
+        $paths = @("D:\ExchangeTemp\TransportCts\UnifiedContent", "C:\Windows\Temp\UnifiedContent", $defaultUnifiedContentPath)
+        $splitCleanupFolderValue = $cleanupFolderValue.Split(";")
+
+        if ($defaultUnifiedContentPath -ne $temporaryStoragePath) {
+            Write-Verbose "Default TemporaryStoragePath doesn't not equal what is loaded. Add both locations."
+            $paths += $temporaryStoragePath
+        }
+
+        $failed = $false
+        $expectedCleanupFolderValue = [string]::Empty
+
+        foreach ($expectedPath in $paths) {
+            $expectedCleanupFolderValue += "$expectedPath;"
+            if (-not ($splitCleanupFolderValue.ToLower().Contains($expectedPath.ToLower()))) {
+                Write-Verbose "Failed to find expected path $expectedPath"
+                $failed = $true
+            } else {
+                Write-Verbose "Found expected path $expectedPath"
+            }
+        }
+
+        $validSetting = $failed -eq $false
+        $success = $true
+    } end {
+        return [PSCustomObject]@{
+            Success                    = $success
+            FoundAntiMalwareFile       = $foundAntiMalwareFile
+            ValidSetting               = $validSetting
+            LoadAntiMalwareFile        = $loadAntiMalwareFile
+            AntiMalwareFilePath        = $antiMalwareFilePath
+            CleanupFolderValue         = $cleanupFolderValue
+            ExpectedCleanupFolderValue = $expectedCleanupFolderValue.TrimEnd(";")
+        }
+    }
+}

--- a/Admin/SetUnifiedContentPath/Get-UnifiedContentInformation.ps1
+++ b/Admin/SetUnifiedContentPath/Get-UnifiedContentInformation.ps1
@@ -53,7 +53,8 @@ function Get-UnifiedContentInformation {
         $splitCleanupFolderValue = $cleanupFolderValue.Split(";")
 
         if ($defaultUnifiedContentPath -ne $temporaryStoragePath) {
-            Write-Verbose "Default TemporaryStoragePath doesn't not equal what is loaded. Add both locations."
+            Write-Verbose "TemporaryStoragePath does not equal default installed Temporary Unified Content Path based off of install location."
+            Write-Verbose "Adding both locations to make sure the Unified Content is removed by maintenance."
             $paths += $temporaryStoragePath
         }
 

--- a/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
+++ b/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
@@ -46,7 +46,7 @@ end {
             exit
         }
 
-        $exchangeSession = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+        $exchangeSession = Confirm-ExchangeShell -Identity $computerNames[0]
 
         if (-not ($exchangeSession.ShellLoaded)) {
             Write-Warning "Failed to load Exchange Management Shell."

--- a/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
+++ b/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
@@ -1,0 +1,93 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Set the Unified Content Cleanup path when exchange isn't installed in the default location
+.DESCRIPTION
+    The AntiMalware.xml is hard coded to look at the default locations without regards to where Exchange is installed at or the transport database is located.
+    Because of this, the probe that goes through and cleans up the Unified Content in the Transport's temp storage location isn't aware of any other locations.
+    This script will go through and correct the value to where Exchange is truly installed at or where the Transport's temp storage is located at.
+.EXAMPLE
+    PS C:\> .\SetUnifiedContentPath.ps1
+    Will detect and determine if the AntiMalware.xml file contains the correct expected CleanupFolderResponderFolderPaths within it.
+    Otherwise, it will set it for you and create a AntiMalware.xml.bak file.
+.EXAMPLE
+    PS C:\> Get-ExchangeServer | .\SetUnifiedContentPath.ps1
+    Will run the SetUnifiedContentPath.ps1 against all the Exchange Servers
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string[]]
+    $ComputerName = $env:COMPUTERNAME
+)
+
+begin {
+    . $PSScriptRoot\Get-UnifiedContentInformation.ps1
+    . $PSScriptRoot\..\..\Shared\Confirm-Administrator.ps1
+    . $PSScriptRoot\..\..\Shared\Confirm-ExchangeShell.ps1
+    . $PSScriptRoot\..\..\Shared\Invoke-ScriptBlockHandler.ps1
+    . $PSScriptRoot\..\..\Shared\Write-ErrorInformation.ps1
+
+    $computerNames = New-Object System.Collections.ArrayList
+}
+
+process {
+    foreach ($computer in $ComputerName) {
+        [void]$computerNames.Add($computer)
+    }
+}
+
+end {
+    try {
+        if (-not (Confirm-Administrator)) {
+            Write-Warning "Not running script as an Administrator. Please open a PowerShell session as Administrator"
+            exit
+        }
+
+        $exchangeSession = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+
+        if (-not ($exchangeSession.ShellLoaded)) {
+            Write-Warning "Failed to load Exchange Management Shell."
+            exit
+        }
+
+        foreach ($computer in $computerNames) {
+            $unifiedContentInformation = Invoke-ScriptBlockHandler -ComputerName $computer -ScriptBlock ${Function:Get-UnifiedContentInformation}
+
+            if ($unifiedContentInformation.Success) {
+
+                if ($unifiedContentInformation.ValidSetting) {
+                    Write-Host "$computer : Unified Content Path is set correctly."
+                    continue
+                } else {
+                    Write-Host "$computer : CleanupFolderResponderFolderPaths isn't set to what we expect."
+                    Write-Host "$computer : Expected Values: $($unifiedContentInformation.ExpectedCleanupFolderValue)"
+                    Write-Host "$computer : Attempting to backup and save the Expected Value... " -NoNewline
+
+                    Invoke-ScriptBlockHandler -ComputerName $computer -ArgumentList @($unifiedContentInformation, $computer) -ScriptBlock {
+                        param(
+                            [object]$UnifiedContentInformation,
+                            [string]$Computer
+                        )
+                        try {
+                            Copy-Item $unifiedContentInformation.AntiMalwareFilePath -Destination $unifiedContentInformation.AntiMalwareFilePath.Replace(".xml", ".xml.bak") -Force
+                            $unifiedContentInformation.LoadAntiMalwareFile.Definition.MaintenanceDefinition.ExtensionAttributes.CleanupFolderResponderFolderPaths = $unifiedContentInformation.ExpectedCleanupFolderValue
+                            $unifiedContentInformation.LoadAntiMalwareFile.Save($unifiedContentInformation.AntiMalwareFilePath)
+                            Write-Host "$computer : Successfully backup and save"
+                        } catch {
+                            Write-Host "$computer : Failed to backup and save new value"
+                            Write-HostErrorInformation
+                        }
+                    }
+                }
+            } else {
+                Write-Warning "$computer : Failed to determine the Unified Content Information"
+                continue
+            }
+        }
+    } catch {
+        Write-HostErrorInformation
+    }
+}

--- a/Shared/Invoke-ScriptBlockHandler.ps1
+++ b/Shared/Invoke-ScriptBlockHandler.ps1
@@ -65,7 +65,13 @@ function Invoke-ScriptBlockHandler {
 
                 if ($null -ne $ArgumentList) {
                     Write-Verbose "Running Script Block Locally with argument list"
-                    $returnValue = & $ScriptBlock $ArgumentList
+
+                    # if an object array type expect the result to be multiple parameters
+                    if ($ArgumentList.GetType().Name -eq "Object[]") {
+                        $returnValue = & $ScriptBlock @ArgumentList
+                    } else {
+                        $returnValue = & $ScriptBlock $ArgumentList
+                    }
                 } else {
                     Write-Verbose "Running Script Block Locally without argument list"
                     $returnValue = & $ScriptBlock

--- a/docs/Admin/SetUnifiedContentPath.md
+++ b/docs/Admin/SetUnifiedContentPath.md
@@ -1,0 +1,33 @@
+# SetUnifiedContentPath
+
+Download the latest release: [SetUnifiedContentPath.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetUnifiedContentPath.ps1)
+
+Sets the CleanupFolderREsponderFolderPaths in the AntiMalware.xml file that is responsible for having Exchange automatically clean up the Unified Content that is left behind.
+
+If this isn't properly set, you can have large amount of files left on the computer that is just using up space and can cause issues with Exchange.
+
+The script will keep the default values of `D:\ExchangeTemp\TransportCts\UnifiedContent`, `C:\Windows\Temp\UnifiedContent`, and `$ExInstall\TransportRoles\data\Temp\UnifiedContent` within the value and will include `TemporaryStoragePath` from the `EdgeTransport.exe.config` if different from the install path.
+
+In order for the new settings to take effect right away, use the `-RestartService` switch to have the MSExchangeHM service take in the new changes right away.
+
+## Common Usage
+
+The easiest way to run the script is against all the servers and restart the service.
+
+```powershell
+Get-ExchangeServer | .\SetUnifiedContentPath.ps1 -RestartService
+```
+
+If you don't want to change anything just yet, use the `-WhatIf` switch to see what servers will have something changed.
+
+```powershell
+Get-ExchangeServer | .\SetUnifiedContentPath.ps1 -WhatIf
+```
+
+Or you can just run it locally on the server
+
+```powershell
+.\SetUnifiedContentPath.ps1 -RestartService
+```
+
+**NOTE:** The switch `-RestartService` is only going to restart the service if a change has been detected and done. Otherwise, it will not restart the service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
     - Get-SimpleAuditLogReport: Admin/Get-SimpleAuditLogReport.md
     - Remove-CertExpiryNotifications: Admin/Remove-CertExpiryNotifications.md
     - Reset-ScanEngineVersion: Admin/Reset-ScanEngineVersion.md
+    - SetUnifiedContentPath: Admin/SetUnifiedContentPath.md
     - Test-AMSI: Admin/Test-AMSI.md
   - Databases:
     - VSSTester: Databases/VSSTester.md


### PR DESCRIPTION
**Reason:**
UnifiedContentCorrector.ps1 was a script that was floating around that is used by customers and engineers. Wasn't able to move it over to CSS-Exchange straight up, so created it basically as SetUnifiedContentPath. 

This version of the script it can be run remotely, and the main part that detects if there is an issue is pulled out into its own file to be able to pull it into HealthChecker. 

**Validation:**
Lab tested on 2019 locally, remotely, and from DC with Remote Exchange PowerShell. 

