### PR TITLE
Include Out of Date error in HTML output

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -67,7 +67,7 @@ function Invoke-AnalyzerExchangeInformation {
             DisplayCustomTabNumber = 2
             TestingName            = "Out of Date"
             DisplayTestingValue    = $true
-            AddHtmlDetailRow       = $false
+            HtmlName               = "Out of date"
         }
         Add-AnalyzedResultInformation @params
     }


### PR DESCRIPTION
**Reason:**
Customer requested that `Out of Date` be included in the HTML report as well. 

**Fix:**
Include the `Out of Date` in the HTML report

**Validation:**
Lab tested. 

Resolved #1105 