### PR TITLE
Update Export Columns to Out-String

### DIFF
--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -69,7 +69,19 @@ function RunAllTests {
 function Main {
 
     $results = RunAllTests
-    $results | Export-Csv "$PSScriptRoot\SetupAssistResults-$((Get-Date).ToString("yyyyMMddhhmm")).csv" -NoTypeInformation
+    $exportObject = New-Object 'System.Collections.Generic.List[object]'
+
+    $results |
+        ForEach-Object {
+            $exportObject.Add([PSCustomObject]@{
+                    TestName      = $_.TestName
+                    Result        = $_.Result
+                    Details       = $_.Details | Out-String
+                    ReferenceInfo = $_.ReferenceInfo | Out-String
+                })
+        }
+
+    $exportObject | Export-Csv "$PSScriptRoot\SetupAssistResults-$((Get-Date).ToString("yyyyMMddhhmm")).csv" -NoTypeInformation
 
     $sbResults = {
         param($o, $p)


### PR DESCRIPTION
**Issue:**
In the csv export, you would always have `System.Object[]` in the output for the `Details` of the `Prepare AD Requirements` Test. 

**Reason:**
Makes the CSV file unusable for this test.

**Fix:**
Convert the array list to a string type with the correct format for the export with `Out-String`

**Validation:**
Lab tested

