### PR TITLE
Add Try Catch to NewServiceObject

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDependentServices.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDependentServices.ps1
@@ -36,10 +36,25 @@ function Get-ExchangeDependentServices {
             param(
                 [object]$Service
             )
+            $name = $Service.Name
+            $status = "Unknown"
+            $startType = "Unknown"
+            try {
+                $status = $Service.Status.ToString()
+            } catch {
+                Write-Verbose "Failed to set Status of service '$name'"
+                Invoke-CatchActions
+            }
+            try {
+                $startType = $Service.StartType.ToString()
+            } catch {
+                Write-Verbose "Failed to set Start Type of service '$name'"
+                Invoke-CatchActions
+            }
             return [PSCustomObject]@{
-                Name      = $Service.Name
-                Status    = $Service.Status.ToString()
-                StartType = $Service.StartType.ToString()
+                Name      = $name
+                Status    = $status
+                StartType = $startType
             }
         }
     } process {


### PR DESCRIPTION
**Issue:**
Script is failing to complete due to some services not having Status or StartType provided. 

**Fix:**
Placed a `try` `catch` around the `ToString()`. 

**Validation:**
None

Resolved #1112
