### PR TITLE
Improve FIP-FS check logic to better handle fixed Exchange builds

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -328,7 +328,7 @@ function Invoke-AnalyzerSecuritySettings {
             Add-AnalyzedResultInformation @params
 
             $params = $baseParams + @{
-                Details                = "We've detected the problematic FIP-FS version: $highestVersion`r`n`t`tAlthough it should not cause any problems, we recommend performing a FIP-FS reset.`r`n`t`t$moreInformation"
+                Details                = "Detected problematic FIP-FS version $highestVersion directory`r`n`t`tAlthough it should not cause any problems, we recommend performing a FIP-FS reset`r`n`t`t$moreInformation"
                 DisplayWriteType       = "Yellow"
                 DisplayCustomTabNumber = 2
             }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -293,26 +293,58 @@ function Invoke-AnalyzerSecuritySettings {
     Invoke-AnalyzerSecurityAMSIConfigState -AnalyzeResults $AnalyzeResults -HealthServerObject $HealthServerObject -DisplayGroupingKey $keySecuritySettings
     Invoke-AnalyzerSecurityMitigationService -AnalyzeResults $AnalyzeResults -HealthServerObject $HealthServerObject -DisplayGroupingKey $keySecuritySettings
 
-    if ($HealthServerObject.ExchangeInformation.BuildInformation.AffectedByFIPFSUpdateIssue) {
-        $params = $baseParams + @{
+    if ($null -ne $HealthServerObject.ExchangeInformation.BuildInformation.FIPFSUpdateIssue) {
+        $fipfsInfoObject = $HealthServerObject.ExchangeInformation.BuildInformation.FIPFSUpdateIssue
+        $highestVersion = $fipfsInfoObject.HighesVersionNumberDetected
+        $fipfsIssueBaseParams = @{
             Name             = "FIP-FS Update Issue Detected"
             Details          = $true
             DisplayWriteType = "Red"
         }
-        Add-AnalyzedResultInformation @params
+        $moreInformation = "More Information: https://aka.ms/HC-FIPFSUpdateIssue"
 
-        $params = $baseParams + @{
-            Details                = "More Information: https://aka.ms/HC-FIPFSUpdateIssue"
-            DisplayWriteType       = "Red"
-            DisplayCustomTabNumber = 2
+        if ($fipfsInfoObject.ServerRoleAffected -eq $false) {
+            # Server role is not affected by the FIP-FS issue so we don't need to check for the other conditions.
+            Write-Verbose "The Exchange server runs a role which is not affected by the FIP-FS issue"
+        } elseif (($fipfsInfoObject.FIPFSFixedBuild -eq $false) -and
+            ($fipfsInfoObject.BadVersionNumberDirDetected)) {
+            # Exchange doesn't run a build which is resitent against the problematic pattern
+            # and a folder with the problematic version number was detected on the computer.
+            $params = $baseParams + $fipfsIssueBaseParams
+            Add-AnalyzedResultInformation @params
+
+            $params = $baseParams + @{
+                Details                = $moreInformation
+                DisplayWriteType       = "Red"
+                DisplayCustomTabNumber = 2
+            }
+            Add-AnalyzedResultInformation @params
+        } elseif (($fipfsInfoObject.FIPFSFixedBuild) -and
+            ($fipfsInfoObject.BadVersionNumberDirDetected)) {
+            # Exchange runs a build that can handle the problematic pattern. However, we found
+            # a high-version folder which should be removed (recommendation).
+            $fipfsIssueBaseParams.DisplayWriteType = "Yellow"
+            $params = $baseParams + $fipfsIssueBaseParams
+            Add-AnalyzedResultInformation @params
+
+            $params = $baseParams + @{
+                Details                = "We've detected the problematic FIP-FS version: $highestVersion`r`n`t`tAlthough it should not cause any problems, we recommend performing a FIP-FS reset.`r`n`t`t$moreInformation"
+                DisplayWriteType       = "Yellow"
+                DisplayCustomTabNumber = 2
+            }
+            Add-AnalyzedResultInformation @params
+        } elseif ($null -eq $fipfsInfoObject.HighesVersionNumberDetected) {
+            # No scan engine was found on the Exchange server. This will cause multiple issues on transport.
+            $fipfsIssueBaseParams.Details = "Error: Failed to find the scan engines on server, this can cause issues with transport rules as well as the malware agent."
+            $params = $baseParams + $fipfsIssueBaseParams
+            Add-AnalyzedResultInformation @params
+        } else {
+            Write-Verbose "Server runs a FIP-FS fixed build: $($fipfsInfoObject.FIPFSFixedBuild) - Highest version number: $highestVersion"
         }
-        Add-AnalyzedResultInformation @params
-    } elseif ($null -eq $HealthServerObject.ExchangeInformation.BuildInformation.AffectedByFIPFSUpdateIssue) {
-        $params = $baseParams + @{
-            Name             = "FIP-FS Update Issue Detected"
-            Details          = "Error: Failed to find the scan engines on server, this can cause issues with transport rules as well as the malware agent."
-            DisplayWriteType = "Red"
-        }
+    } else {
+        $fipfsIssueBaseParams.Details = "Warning: Unable to check if the system is vulnerable to the FIP-FS bad pattern issue. Please re-run. $moreInformation"
+        $fipfsIssueBaseParams.DisplayWriteType = "Yellow"
+        $params = $baseParams + $fipfsIssueBaseParams
         Add-AnalyzedResultInformation @params
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -503,15 +503,14 @@ function Get-ExchangeInformation {
             Invoke-CatchActions
         }
 
-        if (($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) -and
-            ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::None) -and
-            ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess)) {
-            Write-Verbose "Checking if FIP-FS is affected by the pattern issue"
-            $buildInformation.AffectedByFIPFSUpdateIssue = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server
-        } else {
-            Write-Verbose "This Exchange server role is not affected by the pattern issue - skipping check"
-            $buildInformation.AffectedByFIPFSUpdateIssue = $false
+        Write-Verbose "Checking if FIP-FS is affected by the pattern issue"
+        $fipfsParams = @{
+            ComputerName   = $Script:Server
+            ExSetupVersion = $buildInformation.ExchangeSetup.FileVersion
+            ServerRole     = $buildInformation.ServerRole
         }
+
+        $buildInformation.FIPFSUpdateIssue = Get-FIPFSScanEngineVersionState @fipfsParams
 
         $exchangeInformation.RegistryValues = Get-ExchangeRegistryValues -MachineName $Script:Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $exchangeInformation.ServerMaintenance = Get-ExchangeServerMaintenanceState -ComponentsToSkip "ForwardSyncDaemon", "ProvisioningRps"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-FIPFSScanEngineVersionState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-FIPFSScanEngineVersionState.ps1
@@ -10,7 +10,13 @@ function Get-FIPFSScanEngineVersionState {
     param (
         [Parameter(Mandatory = $true)]
         [string]
-        $ComputerName
+        $ComputerName,
+        [Parameter(Mandatory = $true)]
+        [System.Version]
+        $ExSetupVersion,
+        [Parameter(Mandatory = $true)]
+        [HealthChecker.ExchangeServerRole]
+        $ServerRole
     )
 
     begin {
@@ -49,7 +55,8 @@ function Get-FIPFSScanEngineVersionState {
 
         function GetHighestScanEngineVersionNumber {
             param (
-                [string]$ComputerName
+                [string]
+                $ComputerName
             )
 
             Write-Verbose "Calling: $($MyInvocation.MyCommand)"
@@ -75,27 +82,90 @@ function Get-FIPFSScanEngineVersionState {
             }
             return $null
         }
+
+        function IsServerRoleAffected {
+            param (
+                [HealthChecker.ExchangeServerRole]
+                $ServerRole
+            )
+
+            Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+            # Affected roles are Hub Transport, Mailbox and MultiRole
+            if (($ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) -and
+                ($ServerRole -ne [HealthChecker.ExchangeServerRole]::None) -and
+                ($ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess)) {
+                Write-Verbose "Server role is affected by this FIP-FS issue"
+                return $true
+            } else {
+                Write-Verbose "Server role is NOT affected by this FIP-FS issue"
+                return $false
+            }
+        }
+        function IsFIPFSFixedBuild {
+            param (
+                [System.Version]
+                $BuildNumber
+            )
+
+            Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+            $fixedFIPFSBuild = $false
+
+            # Fixed on Exchange side with March 2022 Security update
+            if ($BuildNumber.Major -eq 15) {
+                if ($BuildNumber.Minor -eq 2) {
+                    $fixedFIPFSBuild = ($BuildNumber.Build -gt 986) -or
+                        (($BuildNumber.Build -eq 986) -and ($BuildNumber.Revision -ge 22)) -or
+                        (($BuildNumber.Build -eq 922) -and ($BuildNumber.Revision -ge 27))
+                } elseif ($BuildNumber.Minor -eq 1) {
+                    $fixedFIPFSBuild = ($BuildNumber.Build -gt 2375) -or
+                        (($BuildNumber.Build -eq 2375) -and ($BuildNumber.Revision -ge 24)) -or
+                        (($BuildNumber.Build -eq 2308) -and ($BuildNumber.Revision -ge 27))
+                } else {
+                    Write-Verbose "Looks like we're on Exchange 2013 which is not affected by this FIP-FS issue"
+                    $fixedFIPFSBuild = $true
+                }
+            } else {
+                Write-Verbose "We are not on Exchange version 15"
+                $fixedFIPFSBuild = $true
+            }
+
+            return $fixedFIPFSBuild
+        }
     } process {
         $isAffectedByFIPFSUpdateIssue = $false
         try {
 
-            $highestScanEngineVersionNumber = GetHighestScanEngineVersionNumber -ComputerName $ComputerName
+            $serverRoleAffected = IsServerRoleAffected -ServerRole $ServerRole
+            if ($serverRoleAffected) {
+                $highestScanEngineVersionNumber = GetHighestScanEngineVersionNumber -ComputerName $ComputerName
+                $fipfsIssueFixedBuild = IsFIPFSFixedBuild -BuildNumber $ExSetupVersion
 
-            if ($null -eq $highestScanEngineVersionNumber) {
-                Write-Verbose "No scan engine version found on the computer - this can cause issues still with some transport rules"
-                $isAffectedByFIPFSUpdateIssue = $null
-            } elseif ($highestScanEngineVersionNumber -ge 2201010000) {
-                Write-Verbose "Scan engine: $highestScanEngineVersionNumber will cause transport queue or pattern update issues"
-                $isAffectedByFIPFSUpdateIssue = $true
-            } else {
-                Write-Verbose "Scan engine: $highestScanEngineVersionNumber is safe to use"
+                if ($null -eq $highestScanEngineVersionNumber) {
+                    Write-Verbose "No scan engine version found on the computer - this can cause issues still with some transport rules"
+                } elseif ($highestScanEngineVersionNumber -ge 2201010000) {
+                    if ($fipfsIssueFixedBuild) {
+                        Write-Verbose "Scan engine: $highestScanEngineVersionNumber detected but Exchange runs a fixed build that doesn't crash"
+                    } else {
+                        Write-Verbose "Scan engine: $highestScanEngineVersionNumber will cause transport queue or pattern update issues"
+                    }
+                    $isAffectedByFIPFSUpdateIssue = $true
+                } else {
+                    Write-Verbose "Scan engine: $highestScanEngineVersionNumber is safe to use"
+                }
             }
         } catch {
             Write-Verbose "Failed to check for the FIP-FS update issue"
-            $isAffectedByFIPFSUpdateIssue = $null
             Invoke-CatchActions
+            return $null
         }
     } end {
-        return $isAffectedByFIPFSUpdateIssue
+        return [PSCustomObject]@{
+            FIPFSFixedBuild             = $fipfsIssueFixedBuild
+            ServerRoleAffected          = $serverRoleAffected
+            HighesVersionNumberDetected = $highestScanEngineVersionNumber
+            BadVersionNumberDirDetected = $isAffectedByFIPFSUpdateIssue
+        }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-FIPFSScanEngineVersionState.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-FIPFSScanEngineVersionState.Tests.ps1
@@ -8,34 +8,75 @@ param()
 BeforeAll {
     $Script:parentPath = (Split-Path -Parent $PSScriptRoot)
     $Script:Server = $env:COMPUTERNAME
+    . $Script:parentPath\..\..\Helpers\Class.ps1
     . $Script:parentPath\Get-FIPFSScanEngineVersionState.ps1
 
     function Invoke-CatchActions {
         param()
     }
+
+    $Script:serverRoles = New-Object HealthChecker.ExchangeServerRole
+    [System.Version]$Script:fixed = "15.1.2308.27"
+    [System.Version]$Script:notFixed = "15.1.2300.20"
 }
 
 Describe "Testing Get-FIPFSScanEngineVersionState.ps1" {
 
-    Context "Invalid Pattern Detected" {
+    Context "Invalid Pattern Detected On Affected Exchange Build" {
         BeforeAll {
             Mock Invoke-ScriptBlockHandler -MockWith { return Import-Clixml $Script:parentPath\Tests\GetChildItemInvalidPattern.xml }
-            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:notFixed -ServerRole $Script:serverRoles
         }
 
         It "System Affected By Transport Queue Issue" {
-            $results | Should -Be $true
+            $results.FIPFSFixedBuild | Should -Be $false
+            $results.ServerRoleAffected | Should -Be $true
+            $results.HighesVersionNumberDetected | Should -Be 2201010000
+            $results.BadVersionNumberDirDetected | Should -Be $true
         }
     }
 
-    Context "Valid Pattern Detected" {
+    Context "Valid Pattern Detected On Affected Exchange Build" {
         BeforeAll {
             Mock Invoke-ScriptBlockHandler -MockWith { return Import-Clixml $Script:parentPath\Tests\GetChildItemValidPattern.xml }
-            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:notFixed -ServerRole $Script:serverRoles
         }
 
         It "System NOT Affected By Transport Queue Issue" {
-            $results | Should -Be $false
+            $results.FIPFSFixedBuild | Should -Be $false
+            $results.ServerRoleAffected | Should -Be $true
+            $results.HighesVersionNumberDetected | Should -Be 2110070014
+            $results.BadVersionNumberDirDetected | Should -Be $false
+        }
+    }
+
+    Context "Invalid Pattern Detected On Fixed Exchange Build" {
+        BeforeAll {
+            Mock Invoke-ScriptBlockHandler -MockWith { return Import-Clixml $Script:parentPath\Tests\GetChildItemInvalidPattern.xml }
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:Fixed -ServerRole $Script:serverRoles
+        }
+
+        It "System NOT Affected By Transport Queue Issue Due To Fixed Exchange Build" {
+            $results.FIPFSFixedBuild | Should -Be $true
+            $results.ServerRoleAffected | Should -Be $true
+            $results.HighesVersionNumberDetected | Should -Be 2201010000
+            $results.BadVersionNumberDirDetected | Should -Be $true
+        }
+    }
+
+    Context "Exchange Server Role Not Affected" {
+        BeforeAll {
+            $edgeRole = $Script:serverRoles
+            $edgeRole = [HealthChecker.ExchangeServerRole]::Edge
+            Mock Invoke-ScriptBlockHandler -MockWith { return Import-Clixml $Script:parentPath\Tests\GetChildItemInvalidPattern.xml }
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:Fixed -ServerRole $edgeRole
+        }
+
+        It "Edge Transport Server Role Isn't Affected" {
+            $results.FIPFSFixedBuild | Should -Be $null
+            $results.ServerRoleAffected | Should -Be $false
+            $results.HighesVersionNumberDetected | Should -Be $null
+            $results.BadVersionNumberDirDetected | Should -Be $false
         }
     }
 
@@ -45,9 +86,10 @@ Describe "Testing Get-FIPFSScanEngineVersionState.ps1" {
             Mock Write-Verbose {}
         }
 
-        It "Result return null" {
-            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server
-            $results | Should -Be $null
+        It "HighesVersionNumberDetected return null" {
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:notFixed -ServerRole $Script:serverRoles
+            $results.HighesVersionNumberDetected | Should -Be $null
+            $results.BadVersionNumberDirDetected | Should -Be $false
             Assert-MockCalled -CommandName Write-Verbose -Exactly 1 -ParameterFilter { $Message -eq "No FIP-FS scan engine version(s) detected - GetFolderFromExchangeInstallPath returned null" }
         }
     }
@@ -58,9 +100,10 @@ Describe "Testing Get-FIPFSScanEngineVersionState.ps1" {
             Mock Write-Verbose {}
         }
 
-        It "Results return null back" {
-            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server
-            $results | Should -Be $null
+        It "HighesVersionNumberDetected return null" {
+            $Script:results = Get-FIPFSScanEngineVersionState -ComputerName $Script:Server -ExSetupVersion $Script:notFixed -ServerRole $Script:serverRoles
+            $results.HighesVersionNumberDetected | Should -Be $null
+            $results.BadVersionNumberDirDetected | Should -Be $false
             Assert-MockCalled -CommandName Write-Verbose -Exactly 1 -ParameterFilter { $Message -eq "Failed to find the scan engine directory" }
         }
     }

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -59,7 +59,7 @@ using System.Collections;
             public object ExchangeSetup;    //Stores the Get-Command ExSetup object
             public System.Array KBsInstalled;  //Stored object IU or Security KB fixes
             public bool March2021SUInstalled;    //True if March 2021 SU is installed
-            public object AffectedByFIPFSUpdateIssue; //True if FIP-FS Update issue is detected
+            public object FIPFSUpdateIssue; //Stores FIP-FS update issue information
         }
 
         public class ExchangeNetFrameworkInformation

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetFIPFSScanEngineVersionState.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetFIPFSScanEngineVersionState.xml
@@ -1,0 +1,14 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <B N="FIPFSFixedBuild">true</B>
+      <B N="ServerRoleAffected">true</B>
+      <I64 N="HighesVersionNumberDetected">2201010000</I64>
+      <B N="BadVersionNumberDirDetected">true</B>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetFIPFSScanEngineVersionState.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetFIPFSScanEngineVersionState.xml
@@ -1,0 +1,14 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <B N="FIPFSFixedBuild">true</B>
+      <B N="ServerRoleAffected">true</B>
+      <I64 N="HighesVersionNumberDetected">2201010000</I64>
+      <B N="BadVersionNumberDirDetected">true</B>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetFIPFSScanEngineVersionState.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetFIPFSScanEngineVersionState.xml
@@ -1,0 +1,14 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <B N="FIPFSFixedBuild">true</B>
+      <B N="ServerRoleAffected">true</B>
+      <I64 N="HighesVersionNumberDetected">2201010000</I64>
+      <B N="BadVersionNumberDirDetected">true</B>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -141,7 +141,7 @@ Mock Get-HttpProxySetting {
 }
 
 Mock Get-FIPFSScanEngineVersionState {
-    return $true
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetFIPFSScanEngineVersionState.xml"
 }
 
 Mock Get-ExchangeIISConfigSettings {

--- a/docs/Diagnostics/HealthChecker/FIPFSCheck.md
+++ b/docs/Diagnostics/HealthChecker/FIPFSCheck.md
@@ -8,9 +8,13 @@ The version checking performed against the signature file is causing the malware
 
 This check validates if the problematic signature file has already downloaded and processed. It shows a red warning indicating that the FIP-FS scan engine should be reset to avoid running into the transport or pattern update issue.
 
-- Exchange 2013 is **not affected** by the transport queue issue, however, if invalid patterns has been applied, no newer update pattern with a lower version number (like `2112330001`) will be applied
-- We check if a folder with number `2201010000` or greater exists under `ExchangeInstallPath\FIP-FS\Data\Engines\amd64\Microsoft\Bin`
-- If that's the case, we point out that the scan engine should be reset
+- Exchange 2013 is **not affected** by the transport queue issue, however, if invalid patterns has been applied, no newer update pattern with a lower version number (like `2112330001`) will be applied.
+- We check if a folder with number `2201010000` or greater exists under `ExchangeInstallPath\FIP-FS\Data\Engines\amd64\Microsoft\Bin`.
+- We also check if the server runs a fixed Exchange build (March 2022 Security Update or higher) that does not crash when the problematic version is used.
+
+- If we detect the problematic version folder and the server doesn't run a fixed build, we recommend to reset the scan engine version (see `Email Stuck in Exchange On-premises Transport Queues` in the "Additional resources" section).
+
+- If we detect the problematic version folder but the server runs a fixed build, it should be safe to delete the folder without performing a scan engine reset. If the directory cannot be deleted, it means that the problematic version is in use. This is a problem because in this case, no new scan engine version will be applied. In this case, a reset of the scan engine must be performed.
 
 Please follow the instructions in the references below to reset the scan engine.
 


### PR DESCRIPTION
**Description:**
The new logic checks if the Exchange build is "vulnerable" to the problematic version or not. 
We show a `warning` if the problematic version folder `2201010000` was detected but the Exchange build can handle it. We recommend resetting the FIP-FS. Otherwise, we will show a red `error`.

Resolve #1106 

![image](https://user-images.githubusercontent.com/40993616/176451888-3a99a8e7-1f12-4acb-85d8-472acabbb0d7.png)

**Fix:**
Logic improved to improve the handling of findings in case the Exchange server runs a fixed build (e.g. builds that can handle the problematic version number and don't crash).

**Validation:**
Pester / Lab

