### PR TITLE
Do null check for ACLs and fallback if true

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -119,6 +119,13 @@ function Get-ExchangeAdPermissions {
                     }
                     $domainAcl = Get-ActiveDirectoryAcl $domainDN.ToString()
                     $adminSdHolderAcl = Get-ActiveDirectoryAcl $adminSdHolderDN
+
+                    if ($null -eq $domainAcl -or
+                        $null -eq $domainAcl.Access -or
+                        $null -eq $adminSdHolderAcl -or
+                        $null -eq $adminSdHolderAcl.Access) {
+                        throw "Failed to get required ACL information. Fallback to 'objectVersion (Default)' validation initiated."
+                    }
                 } catch {
                     Invoke-CatchActions
                     $objectVersionTestingValue = 13243


### PR DESCRIPTION
**Reason:**
Customer is reporting that `CVE-2022-21978` is being called out in the Health Checker but has done the correct steps. 

Turns out that `$domainAcl.Access` is `$null` causing the problem.

**Fix:**
Do a null check for the ACLs and Access properties, then go to the fallback logic. 

**Validation:**
Customer tested. 

