### PR TITLE
Show MRS Proxy status in 'Exchange Information' section

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -163,6 +163,27 @@ function Invoke-AnalyzerExchangeInformation {
     }
     Add-AnalyzedResultInformation @params
 
+    if (($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) -and
+        ($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Hub) -and
+        ($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::None)) {
+
+        Write-Verbose "Working on MRS Proxy Settings"
+        $mrsProxyDetails = $exchangeInformation.GetWebServicesVirtualDirectory.MRSProxyEnabled
+        if ($exchangeInformation.GetWebServicesVirtualDirectory.MRSProxyEnabled) {
+            $mrsProxyDetails = "$mrsProxyDetails`n`r`t`tKeep MRS Proxy disabled if you do not plan to move mailboxes cross-forest or remote"
+            $mrsProxyWriteType = "Yellow"
+        } else {
+            $mrsProxyWriteType = "Grey"
+        }
+
+        $params = $baseParams + @{
+            Name             = "MRS Proxy Enabled"
+            Details          = $mrsProxyDetails
+            DisplayWriteType = $mrsProxyWriteType
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
     if ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2013 -and
         $exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge -and
         $exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Mailbox) {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -30,9 +30,10 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "DAG Name" "Standalone Server"
             TestObjectMatch "AD Site" "Default-First-Site-Name"
             TestObjectMatch "MAPI/HTTP Enabled" "True"
+            TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "MAPI Front End App Pool GC Mode" "Workstation --- Warning" -WriteType "Yellow"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 13
+            $Script:ActiveGrouping.Count | Should -Be 14
         }
 
         It "Display Results - Operating System Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -31,9 +31,10 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "DAG Name" "Standalone Server"
             TestObjectMatch "AD Site" "Default-First-Site-Name"
             TestObjectMatch "MAPI/HTTP Enabled" "True"
+            TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "Exchange Server Maintenance" "Server is not in Maintenance Mode" -WriteType "Green"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - Operating System Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
@@ -32,9 +32,10 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "DAG Name" "Standalone Server"
             TestObjectMatch "AD Site" "Default-First-Site-Name"
             TestObjectMatch "MAPI/HTTP Enabled" "True"
+            TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "Exchange Server Maintenance" "Server is not in Maintenance Mode" -WriteType "Green"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - Operating System Information" {


### PR DESCRIPTION
**Description:**
Display the status of the MRS Proxy in the 'Exchange Information' section and highlight in yellow (warning) if it is enabled.
We recommend disabling it if no cross-forest or remote moves are ongoing/planned.

`If you don't perform cross-forest moves or remote move migrations, keep MRS Proxy endpoints disabled on Mailbox servers to reduce the attack surface of your organization.`

![image](https://user-images.githubusercontent.com/40993616/177177245-1dac8efe-f3d6-4bf6-b624-de078f58ff8f.png)

Resolve: #898 

**Validation:**
Lab

