### PR TITLE
Adjust autoupdate behavior

### DIFF
--- a/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
+++ b/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
@@ -4,6 +4,19 @@
 . $PSScriptRoot\Invoke-WebRequestWithProxyDetection.ps1
 . $PSScriptRoot\Confirm-Signature.ps1
 
+<#
+.SYNOPSIS
+    Overwrites the current running script file with the latest version from the repository.
+.NOTES
+    This function always overwrites the current file with the latest file, which might be
+    the same. Get-ScriptUpdateAvailable should be called first to determine if an update is
+    needed.
+
+    In many situations, updates are expected to fail, because the server running the script
+    does not have internet access. This function writes out failures as warnings, because we
+    expect that Get-ScriptUpdateAvailable was already called and it successfully reached out
+    to the internet.
+#>
 function Invoke-ScriptUpdate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     [OutputType([boolean])]
@@ -20,7 +33,12 @@ function Invoke-ScriptUpdate {
     if ($PSCmdlet.ShouldProcess("$scriptName", "Update script to latest version")) {
         try {
             Invoke-WebRequestWithProxyDetection "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$scriptName" -OutFile $tempFullName
+        } catch {
+            Write-Warning "AutoUpdate: Failed to download update: $($_.Exception.Message)"
+            return $false
+        }
 
+        try {
             if (Confirm-Signature -File $tempFullName) {
                 Write-Host "AutoUpdate: Signature validated."
                 if (Test-Path $oldFullName) {
@@ -28,6 +46,7 @@ function Invoke-ScriptUpdate {
                 }
                 Move-Item $scriptFullName $oldFullName
                 Move-Item $tempFullName $scriptFullName
+                Remove-Item $oldFullName -Force -Confirm:$false -ErrorAction Stop
                 Write-Host "AutoUpdate: Succeeded."
                 return $true
             } else {
@@ -35,7 +54,7 @@ function Invoke-ScriptUpdate {
                 Write-Warning "AutoUpdate: Update was not applied."
             }
         } catch {
-            Write-Verbose "AutoUpdate: Failed to download update: $($_.Exception.Message)"
+            Write-Warning "AutoUpdate: Failed to apply update: $($_.Exception.Message)"
         }
     }
 


### PR DESCRIPTION
- Old script file is removed when update completes
- Failures to download are now written as warnings, see comments
- Fixes #1124 

Note the small behavior change. If we are able to *check* for updates, but we then fail to either *download* or *apply* the update, we now write those failures as warnings. A failure to *check* is still silent (unless -Verbose is used) since we expect that to be normal in most cases.

Successful check but then download failed:

![image](https://user-images.githubusercontent.com/4518572/177795985-0a88d221-c6f0-409b-a0b5-2e71f51cd13c.png)

Successful check, download succeeded, but applying the update (renaming files, etc) failed:

![image](https://user-images.githubusercontent.com/4518572/177796083-04343329-1f66-4cc3-92e7-527a5c87d0fb.png)
