### PR TITLE
Forced eicar detection

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -139,9 +139,11 @@ foreach ($path in $BaseFolders) {
 Write-SimpleLogfile -String "Creating EICAR Files" -name $LogFile -OutHost
 
 # Create the EICAR file in each path
+$EicarFileName = "eicar.bat"
+
 foreach ($Folder in $FolderList) {
 
-    [string] $FilePath = (Join-Path $Folder eicar.bat)
+    [string] $FilePath = (Join-Path $Folder $EicarFileName)
     Write-SimpleLogfile -String ("Creating EICAR file " + $FilePath) -name $LogFile
 
     #Base64 of Eicar string
@@ -157,18 +159,18 @@ foreach ($Folder in $FolderList) {
         }
 
         catch {
-            Write-Warning "$Folder Eicar.bat file couldn't be created. Either permissions or AV prevented file creation."
+            Write-Warning "$Folder $EicarFileName file couldn't be created. Either permissions or AV prevented file creation."
         }
     }
 
     else {
-        Write-SimpleLogfile -string ("[WARNING] - Eicar.bat already exists!: " + $FilePath) -name $LogFile -OutHost
+        Write-SimpleLogfile -string ("[WARNING] - $EicarFileName already exists!: " + $FilePath) -name $LogFile -OutHost
     }
 }
 
 # Try to open each EICAR file to force detection
 foreach ($Folder in $FolderList) {
-    $FilePath = (Join-Path $Folder eicar.bat)
+    $FilePath = (Join-Path $Folder $EicarFileName)
     if (Test-Path $FilePath -PathType Leaf) {
         Start-Process $FilePath -ErrorAction SilentlyContinue -WindowStyle Minimized
     }
@@ -185,7 +187,7 @@ Write-SimpleLogfile -string "Testing for EICAR files" -name $LogFile -OutHost
 # Test each location for the EICAR file
 foreach ($Folder in $FolderList) {
 
-    $FilePath = (Join-Path $Folder eicar.bat)
+    $FilePath = (Join-Path $Folder $EicarFileName)
 
     # If the file exists delete it -- this means the folder is not being scanned
     if (Test-Path $FilePath ) {
@@ -194,7 +196,7 @@ foreach ($Folder in $FolderList) {
     }
     # If the file doesn't exist Add that to the bad folder list -- means the folder is being scanned
     else {
-        Write-SimpleLogfile -String ("[FAIL] - Possible AV Scanning: " + $FilePath) -name $LogFile -OutHost
+        Write-SimpleLogfile -String ("[FAIL] - Possible AV Scanning: " + $Folder) -name $LogFile -OutHost
         $BadFolderList.Add($Folder)
     }
 }

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -185,7 +185,7 @@ Write-SimpleLogfile -string "Testing for EICAR files" -name $LogFile -OutHost
 # Test each location for the EICAR file
 foreach ($Folder in $FolderList) {
 
-    $FilePath = (Join-Path $Folder eicar.com)
+    $FilePath = (Join-Path $Folder eicar.bat)
 
     # If the file exists delete it -- this means the folder is not being scanned
     if (Test-Path $FilePath ) {


### PR DESCRIPTION
**Issue:**
If we just create the Eicar file, could be possible that in only one
minute is not detected by the AV.
Added the execution of the Eicar to force detection and extend the time
from one minutes to 5 as the comment said.

**Reason:**
Avoid to give correct configuration when the AV has not time to detect eicar

**Fix:**
Force the execution of the eicar and expand the time to detect.

**Validation:**
Tested in lab

