### PR TITLE
Updateexevolatile rebootpending addcheck

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -210,6 +210,7 @@ using System.Collections;
             public bool ComponentBasedServicingPendingReboot;   // bool HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
             public bool AutoUpdatePendingReboot;                // bool HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
             public bool PendingReboot;                         // bool if reboot types are set to true
+            public bool UpdateExeVolatile;                      // bool HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags
         }
 
         public class InstalledUpdatesInformation

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetServerRebootPending.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetServerRebootPending.xml
@@ -8,6 +8,7 @@
       <B N="PendingFileRenameOperations">false</B>
       <B N="ComponentBasedServicingPendingReboot">false</B>
       <B N="AutoUpdatePendingReboot">false</B>
+      <B N="UpdateExeVolatileValue">false</B>
       <B N="CcmRebootPending">false</B>
       <B N="PendingReboot">false</B>
       <Obj N="PendingRebootLocations" RefId="1">

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetServerRebootPending.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetServerRebootPending.xml
@@ -8,6 +8,7 @@
       <B N="PendingFileRenameOperations">false</B>
       <B N="ComponentBasedServicingPendingReboot">false</B>
       <B N="AutoUpdatePendingReboot">false</B>
+      <B N="UpdateExeVolatileValue">false</B>
       <B N="CcmRebootPending">false</B>
       <B N="PendingReboot">false</B>
       <Obj N="PendingRebootLocations" RefId="1">

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetServerRebootPending.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetServerRebootPending.xml
@@ -8,6 +8,7 @@
       <B N="PendingFileRenameOperations">false</B>
       <B N="ComponentBasedServicingPendingReboot">false</B>
       <B N="AutoUpdatePendingReboot">false</B>
+      <B N="UpdateExeVolatileValue">false</B>
       <B N="CcmRebootPending">false</B>
       <B N="PendingReboot">false</B>
       <Obj N="PendingRebootLocations" RefId="1">

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetServerRebootPending1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetServerRebootPending1.xml
@@ -8,6 +8,7 @@
       <B N="PendingFileRenameOperations">true</B>
       <B N="ComponentBasedServicingPendingReboot">true</B>
       <B N="AutoUpdatePendingReboot">false</B>
+      <B N="UpdateExeVolatileValue">true</B>
       <B N="CcmRebootPending">false</B>
       <B N="PendingReboot">true</B>
       <Obj N="PendingRebootLocations" RefId="1">
@@ -18,6 +19,7 @@
         <LST>
           <S>HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations</S>
           <S>HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending</S>
+          <S>HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags</S>
         </LST>
       </Obj>
     </MS>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
@@ -339,6 +339,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Server Pending Reboot" "True" -WriteType "Yellow"
             TestObjectMatch "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations" "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations" -WriteType "Yellow"
             TestObjectMatch "HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" "HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" -WriteType "Yellow"
+            TestObjectMatch "HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags" "HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags" -WriteType "Yellow"
             TestObjectMatch "Reboot More Information" "True" -WriteType "Yellow"
         }
 

--- a/Shared/Get-ServerRebootPending.ps1
+++ b/Shared/Get-ServerRebootPending.ps1
@@ -22,6 +22,18 @@ function Get-ServerRebootPending {
             }
         }
 
+        function Get-UpdateExeVolatile {
+            try {
+                $updateFlags = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\"  -Name "Flags" -ErrorAction Stop
+                if ($null -ne $updateFlags -and $updateFlags.Flags -ne "" -and $updateFlags.Flags -ne "0") {
+                    return $true
+                }
+                return $false
+            } catch {
+                throw
+            }
+        }
+
         function Get-PendingCCMReboot {
             try {
                 return (Invoke-CimMethod -Namespace 'Root\ccm\clientSDK' -ClassName 'CCM_ClientUtilities' -Name 'DetermineIfRebootPending' -ErrorAction Stop)
@@ -64,8 +76,12 @@ function Get-ServerRebootPending {
             -ArgumentList "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired" `
             -CatchActionFunction $CatchActionFunction
 
+        $updateExeVolatileValue = Invoke-ScriptBlockHandler -ComputerName $ServerName -ScriptBlock ${Function:Get-UpdateExeVolatile} `
+            -ScriptBlockDescription "UpdateExeVolatile Reboot Pending" `
+            -CatchActionFunction $CatchActionFunction
+
         $ccmRebootPending = $ccmReboot -and ($ccmReboot.RebootPending -or $ccmReboot.IsHardRebootPending)
-        $pendingReboot = $ccmRebootPending -or $pendingFileRenameOperationValue -or $componentBasedServicingPendingRebootValue -or $autoUpdatePendingRebootValue
+        $pendingReboot = $ccmRebootPending -or $pendingFileRenameOperationValue -or $componentBasedServicingPendingRebootValue -or $autoUpdatePendingRebootValue -or $updateExeVolatileValue
 
         if ($ccmRebootPending) {
             Write-Verbose "RebootPending in CCM_ClientUtilities"
@@ -86,12 +102,18 @@ function Get-ServerRebootPending {
             Write-Verbose "RebootPending at HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired"
             $pendingRebootLocations.Add("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired")
         }
+
+        if ($updateExeVolatileValue) {
+            Write-Verbose "RebootPending at HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags"
+            $pendingRebootLocations.Add("HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags")
+        }
     }
     end {
         return [PSCustomObject]@{
             PendingFileRenameOperations          = $pendingFileRenameOperationValue
             ComponentBasedServicingPendingReboot = $componentBasedServicingPendingRebootValue
             AutoUpdatePendingReboot              = $autoUpdatePendingRebootValue
+            UpdateExeVolatileValue               = $updateExeVolatileValue
             CcmRebootPending                     = $ccmRebootPending
             PendingReboot                        = $pendingReboot
             PendingRebootLocations               = $pendingRebootLocations

--- a/Shared/Get-ServerRebootPending.ps1
+++ b/Shared/Get-ServerRebootPending.ps1
@@ -24,8 +24,8 @@ function Get-ServerRebootPending {
 
         function Get-UpdateExeVolatile {
             try {
-                $updateFlags = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\"  -Name "Flags" -ErrorAction Stop
-                if ($null -ne $updateFlags -and $updateFlags.Flags -ne "" -and $updateFlags.Flags -ne "0") {
+                $updateExeVolatileProps = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\" -ErrorAction Stop
+                if ($null -ne $updateExeVolatileProps -and $null -ne $updateExeVolatileProps.Flags) {
                     return $true
                 }
                 return $false

--- a/docs/Diagnostics/HealthChecker/RebootPending.md
+++ b/docs/Diagnostics/HealthChecker/RebootPending.md
@@ -9,6 +9,7 @@ We show a warning if we detect an outstanding pending reboot. We also display th
 - SccmRebootPending
 - ComponentBasedServicingRebootPending
 - AutoUpdatePendingReboot
+- UpdateExeVolatile\Flags
 
 It is best to reboot the server to address these issues. It may take some time after a reboot to have the keys automatically removed. However, if they don't remove automatically, follow these steps to address the issue for the keys that were provided to be a problem.
 


### PR DESCRIPTION
**Issue:**
Exchange OnPremise setup looks for a registry key: HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags to determine if reboot is needed on the machine. This is one of the keys that it looks for.

**Reason:**
Currently Server Reboot Pending script does not check for said key.

**Fix:**
Added a separate function to check for HKLM:\Software\Microsoft\Updates\UpdateExeVolatile\Flags in the pending reboot script

**Validation:**
Updated existing tests to account for the new registry check
