### PR TITLE
Fixed false positive Security Vulnerability in HTML report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
@@ -26,9 +26,12 @@ function Invoke-AnalyzerSecurityVulnerability {
 
     Invoke-AnalyzerSecurityCveCheck -AnalyzeResults $AnalyzeResults -HealthServerObject $HealthServerObject -DisplayGroupingKey $keySecurityVulnerability
 
-    $securityVulnerabilities = $AnalyzeResults.Value.DisplayResults[$keySecurityVulnerability]
+    $allSecurityVulnerabilities = $AnalyzeResults.Value.DisplayResults[$keySecurityVulnerability]
+    $securityVulnerabilities = $allSecurityVulnerabilities | Where-Object { $_.Name -ne "IIS module anomalies detected" }
+    $iisModule = $allSecurityVulnerabilities | Where-Object { $_.Name -eq "IIS module anomalies detected" }
 
-    if ($null -eq $securityVulnerabilities) {
+    if ($null -eq $securityVulnerabilities -and
+        ($null -ne $iisModule -or $iisModule.DisplayValue -eq $false)) {
         $params = $baseParams + @{
             Details          = "All known security issues in this version of the script passed."
             DisplayWriteType = "Green"
@@ -43,12 +46,17 @@ function Invoke-AnalyzerSecurityVulnerability {
             AddHtmlOverviewValues     = $true
         }
         Add-AnalyzedResultInformation @params
-    } else {
+    } elseif ($null -ne $securityVulnerabilities -or
+        ($null -ne $iisModule -and $iisModule.DisplayValue -eq $true)) {
 
         $details = $securityVulnerabilities.DisplayValue |
             ForEach-Object {
                 return $_ + "<br>"
             }
+
+        # If details are null, but iisModule is showing a vulnerability,
+        # then just provide see IIS Module section
+        if ($null -eq $details) { $details = "See IIS module anomalies detected section above" }
 
         $params = $baseParams + @{
             Name                      = "Security Vulnerabilities"


### PR DESCRIPTION
**Issue:**
In the latest release of HC, the HTML Report is reporting a security vulnerability when there isn't one.

**Fix:**
Correctly report if there is a security vulnerability in the HTML report now that we have IIS Modules in the security vulnerability section. 

**Validation:**
Lab tested.
Resolved #1154 
