### PR TITLE
IIS modules check fails on Server 2012 / 2012 R2

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -480,6 +480,7 @@ function Get-ExchangeInformation {
             $exchangeServerIISParams = @{
                 ComputerName        = $Script:Server
                 ExchangeInstallPath = $serverExchangeInstallDirectory
+                IsLegacyOS          = ($OSMajorVersion -lt [HealthChecker.OSServerVersion]::Windows2016)
                 CatchActionFunction = ${Function:Invoke-CatchActions}
             }
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerIISSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerIISSettings.ps1
@@ -9,6 +9,7 @@ function Get-ExchangeServerIISSettings {
     param(
         [string]$ComputerName,
         [string]$ExchangeInstallPath,
+        [bool]$IsLegacyOS = $false,
         [scriptblock]$CatchActionFunction
     )
     process {
@@ -28,8 +29,9 @@ function Get-ExchangeServerIISSettings {
         if ($null -ne $applicationHostConfig) {
             Write-Verbose "Trying to query the modules which are loaded by IIS"
             $iisModulesParams = @{
-                ApplicationHostConfig = $applicationHostConfig
-                CatchActionFunction   = $CatchActionFunction
+                ApplicationHostConfig    = $applicationHostConfig
+                SkipLegacyOSModulesCheck = $IsLegacyOS
+                CatchActionFunction      = $CatchActionFunction
             }
             $iisModulesInformation = Get-IISModules @iisModulesParams
         } else {

--- a/Shared/Tests/Get-IISModules.Tests.ps1
+++ b/Shared/Tests/Get-IISModules.Tests.ps1
@@ -158,4 +158,25 @@ Describe "Testing Get-IISModules.ps1" {
             }
         }
     }
+
+    Context "Exchange 2016 Default applicationHost.config On Pre-Windows 2016 Server" {
+        BeforeAll {
+            $Script:iisModules = Get-IISModules -ApplicationHostConfig $E16_ApplicationHost_Default -SkipLegacyOSModulesCheck $true
+        }
+
+        It "Should Return The IISModules Object" {
+            $iisModules.GetType() | Should -Be PSCustomObject
+            $iisModules.ModuleList.GetType() | Should -Be System.Object[]
+            $iisModules.Count | Should -Be 1
+            $iisModules.ModuleList.Count | Should -Be 6
+        }
+
+        It "Should Not Contain Default Modules Which Are Excluded" {
+            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetsrv\protsup.dll") | Should -Be $false
+            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetsrv\iisfreb.dll") | Should -Be $false
+            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetsrv\protsup.dll") | Should -Be $false
+            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetsrv\isapi.dll") | Should -Be $false
+            $iisModules.ModuleList.Path.Contains("C:\windows\system32\rpcproxy\rpcproxy.dll") | Should -Be $false
+        }
+    }
 }


### PR DESCRIPTION
**Issue:**
The IIS modules check fails on Server 2012 / 2012 R2. The reason for this is that the default modules loaded by IIS are not digitally signed. 

**Fix:**
Added a list of modules which will be excluded on OS < Windows Server 2016. We validate the full path incl. file name and extension to make this a little more trusted.

Resolve #1162 

**Validation:**
Lab / Unit test

