### PR TITLE
Docs index fixed (removed duplicate HealthChecker)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ This project contains scripts for supporting and troubleshooting Microsoft Excha
 ## Popular Scripts
 
 | Script                               | Docs                                                   | Download                                                                                                            |
-| ------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| HealthChecker.ps1                    | [Docs](Diagnostics/HealthChecker)                      | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/HealthChecker.ps1)                    |
-| HealthChecker.ps1                    | [Docs](Security/ExchangeExtendedProtectionManagement)  | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ExchangeExtendedProtectionManagement.ps1) |
-| SetupAssist.ps1                      | [Docs](Setup/SetupAssist)                              | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1)                      |
-| SourceSideValidations.ps1            | [Docs](PublicFolders/SourceSideValidations)            | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SourceSideValidations.ps1)            |
-| Test-AMSI.ps1                        | [Docs](Admin/Test-AMSI)                                | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-AMSI.ps1)                        |
+| ---------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| HealthChecker.ps1                        | [Docs](Diagnostics/HealthChecker)                      | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/HealthChecker.ps1)                        |
+| ExchangeExtendedProtectionManagement.ps1 | [Docs](Security/ExchangeExtendedProtectionManagement)  | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/ExchangeExtendedProtectionManagement.ps1) |
+| SetupAssist.ps1                          | [Docs](Setup/SetupAssist)                              | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SetupAssist.ps1)                          |
+| SourceSideValidations.ps1                | [Docs](PublicFolders/SourceSideValidations)            | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/SourceSideValidations.ps1)                |
+| Test-AMSI.ps1                            | [Docs](Admin/Test-AMSI)                                | [Download](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Test-AMSI.ps1)                            |


### PR DESCRIPTION
**Issue:**
HealthChecker was listed twice (the second one linked to the `ExchangeExtendedProtectionManagement.ps1` script). 


