### PR TITLE
Clean up text output

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureExtendedProtection.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureExtendedProtection.ps1
@@ -20,7 +20,7 @@ function Invoke-ConfigureExtendedProtection {
         foreach ($serverExtendedProtection in $ExtendedProtectionConfigurations) {
             # Check to make sure server is connected and valid information is provided.
             if (-not ($serverExtendedProtection.ServerConnected)) {
-                $line = "Server $($serverExtendedProtection.ComputerName) isn't online to get valid Extended Protection Configuration settings"
+                $line = "$($serverExtendedProtection.ComputerName): Server not online. Cannot get Extended Protection configuration settings."
                 Write-Verbose $line
                 Write-Warning $line
                 $failedServers.Add($serverExtendedProtection.ComputerName)
@@ -28,7 +28,7 @@ function Invoke-ConfigureExtendedProtection {
             }
 
             if ($serverExtendedProtection.ExtendedProtectionConfiguration.Count -eq 0) {
-                $line = "Server $($serverExtendedProtection.ComputerName) wasn't able to collect Extended Protection Configuration"
+                $line = "$($serverExtendedProtection.ComputerName): Server wasn't able to collect Extended Protection configuration."
                 Write-Verbose $line
                 Write-Warning $line
                 continue
@@ -42,8 +42,8 @@ function Invoke-ConfigureExtendedProtection {
             }
 
             foreach ($virtualDirectory in $serverExtendedProtection.ExtendedProtectionConfiguration) {
-                Write-Verbose "Virtual Directory Name: $($virtualDirectory.VirtualDirectoryName) Current Set Extended Protection: $($virtualDirectory.ExtendedProtection) Expected Value $($virtualDirectory.ExpectedExtendedConfiguration)"
-                Write-Verbose "Current Set SSL Flags: $($virtualDirectory.Configuration.SslSettings.Value) Expected SSL Flags: $($virtualDirectory.ExpectedSslFlags) Set Correctly: $($virtualDirectory.SslFlagsSetCorrectly)"
+                Write-Verbose "$($serverExtendedProtection.ComputerName): Virtual Directory Name: $($virtualDirectory.VirtualDirectoryName) Current Set Extended Protection: $($virtualDirectory.ExtendedProtection) Expected Value $($virtualDirectory.ExpectedExtendedConfiguration)"
+                Write-Verbose "$($serverExtendedProtection.ComputerName): Current Set SSL Flags: $($virtualDirectory.Configuration.SslSettings.Value) Expected SSL Flags: $($virtualDirectory.ExpectedSslFlags) Set Correctly: $($virtualDirectory.SslFlagsSetCorrectly)"
                 if ($virtualDirectory.ExtendedProtection -ne $virtualDirectory.ExpectedExtendedConfiguration) {
                     $commandParameters.TokenChecking.Add($virtualDirectory.VirtualDirectoryName, $virtualDirectory.ExpectedExtendedConfiguration)
 
@@ -55,11 +55,10 @@ function Invoke-ConfigureExtendedProtection {
             }
 
             if ($commandParameters.TokenChecking.Count -gt 0) {
-                Write-Host "An update has occurred to the application host config file for server $($serverExtendedProtection.ComputerName). Backing up the application host config file and updating it."
+                Write-Host "$($serverExtendedProtection.ComputerName): Backing up applicationHost.config."
                 # provide what we are changing outside of the script block for remote servers.
-                Write-Verbose "Setting the following values on the server $($serverExtendedProtection.ComputerName)"
-                $commandParameters.TokenChecking.Keys | ForEach-Object { Write-Verbose "Setting the $_ with the tokenChecking value of $($commandParameters.TokenChecking[$_])" }
-                $commandParameters.SSLFlags.Keys | ForEach-Object { Write-Verbose "Setting the $_ with the SSLFlags value of $($commandParameters.SSLFlags[$_])" }
+                $commandParameters.TokenChecking.Keys | ForEach-Object { Write-Verbose "$($serverExtendedProtection.ComputerName): Setting the $_ with the tokenChecking value of $($commandParameters.TokenChecking[$_])" }
+                $commandParameters.SSLFlags.Keys | ForEach-Object { Write-Verbose "$($serverExtendedProtection.ComputerName): Setting the $_ with the SSLFlags value of $($commandParameters.SSLFlags[$_])" }
                 $results = Invoke-ScriptBlockHandler -ComputerName $serverExtendedProtection.ComputerName -ScriptBlock {
                     param(
                         [object]$Commands,
@@ -74,7 +73,7 @@ function Invoke-ConfigureExtendedProtection {
                         $errorContext = New-Object 'System.Collections.Generic.List[object]'
                         $setAllTokenChecking = $true
                         $setAllSslFlags = $true
-                        Write-Host "Successful backup of the application host config file to $backupLocation"
+                        Write-Host "$($env:COMPUTERNAME): Successful backup to $backupLocation"
                         foreach ($siteKey in $Commands.TokenChecking.Keys) {
                             try {
                                 $params = @{
@@ -88,7 +87,7 @@ function Invoke-ConfigureExtendedProtection {
                                 }
                                 Set-WebConfigurationProperty @params
                             } catch {
-                                Write-Host "Failed to set tokenChecking for $env:COMPUTERNAME SITE: $siteKey with the value $($Commands.TokenChecking[$siteKey]). Inner Exception $_"
+                                Write-Host "$($env:COMPUTERNAME): Failed to set tokenChecking for $siteKey with the value $($Commands.TokenChecking[$siteKey]). Inner Exception $_"
                                 $setAllTokenChecking = $false
                                 $errorContext.Add($_)
                             }
@@ -106,7 +105,7 @@ function Invoke-ConfigureExtendedProtection {
                                 }
                                 Set-WebConfigurationProperty @params
                             } catch {
-                                Write-Host "Failed to set sslFlags for $env:COMPUTERNAME SITE: $siteKey with the value $($Commands.SSLFlags[$siteKey]). Inner Exception $_"
+                                Write-Host "$($env:COMPUTERNAME): Failed to set sslFlags for $siteKey with the value $($Commands.SSLFlags[$siteKey]). Inner Exception $_"
                                 $setAllSslFlags = $false
                                 $errorContext.Add($_)
                             }
@@ -114,7 +113,7 @@ function Invoke-ConfigureExtendedProtection {
                         # Save out our changes
                         Copy-Item -Path $saveToPath -Destination $backupLocation.Replace(".cep.", ".cepChanges") -ErrorAction Stop -WhatIf:$PassedWhatIf
                     } catch {
-                        Write-Host "Failed to save application host file on server $env:COMPUTERNAME. Inner Exception $_"
+                        Write-Host "$($env:COMPUTERNAME): Failed to backup applicationHost.config. Inner Exception $_"
                     }
                     return [PSCustomObject]@{
                         BackupSuccess       = $backupSuccessful
@@ -125,46 +124,44 @@ function Invoke-ConfigureExtendedProtection {
                     }
                 } -ArgumentList $commandParameters, $WhatIfPreference
 
-                Write-Verbose "Backup Success: $($results.BackupSuccess) SetAllTokenChecking: $($results.SetAllTokenChecking) SetAllSslFlags: $($results.SetAllSslFlags)"
+                Write-Verbose "$($serverExtendedProtection.ComputerName): Backup Success: $($results.BackupSuccess) SetAllTokenChecking: $($results.SetAllTokenChecking) SetAllSslFlags: $($results.SetAllSslFlags)"
 
                 if ($results.BackupSuccess -and ($results.SetAllTokenChecking -and $results.SetAllSslFlags)) {
-                    Write-Verbose "Backed up the file to $($results.BackupLocation)"
-                    Write-Host "Successfully backed up and saved new application host config file."
+                    Write-Verbose "$($serverExtendedProtection.ComputerName): Backed up the file to $($results.BackupLocation)"
+                    Write-Host "$($serverExtendedProtection.ComputerName): Successfully updated applicationHost.config."
                     $updatedServers.Add($serverExtendedProtection.ComputerName)
                     continue
                 } elseif ($results.BackupSuccess -eq $false) {
-                    $line = "Failed to backup the application host config file. No settings were applied."
+                    $line = "$($serverExtendedProtection.ComputerName): Failed to backup the applicationHost.config. No settings were applied."
                     Write-Verbose $line
                     Write-Warning $line
                 } else {
-                    $line = "Failed to properly set all the correct values on the server $($serverExtendedProtection.ComputerName) required for Extended Protection. Recommended to address!"
+                    $line = "$($serverExtendedProtection.ComputerName): Failed to set the values required for Extended Protection."
                     Write-Verbose $line
                     Write-Warning $line
                 }
                 $failedServers.Add($serverExtendedProtection.ComputerName)
-                Start-Sleep 5 # Sleep to bring to attention to the customer
-                Write-Host "Errors that occurred on the backup and set attempt:"
-                # Not able to group the error from remote context, so need to display them all.
-                $results.ErrorContext | ForEach-Object { Write-HostErrorInformation $_ }
+                $results.ErrorContext | ForEach-Object { Write-HostErrorInformation "$($serverExtendedProtection.ComputerName): $_" }
                 Write-Host ""
             } else {
-                Write-Host "No change was made for the server $($serverExtendedProtection.ComputerName) - Exchange build supports Extended Protection? $($serverExtendedProtection.SupportedVersionForExtendedProtection)"
+                Write-Host "$($serverExtendedProtection.ComputerName): No changes made. Exchange build supports Extended Protection? $($serverExtendedProtection.SupportedVersionForExtendedProtection)"
                 $noChangesMadeServers.Add($serverExtendedProtection.ComputerName)
             }
         }
     } end {
+        Write-Host ""
         if ($failedServers.Count -gt 0) {
-            $line = "These are the servers that failed to apply extended protection: $([string]::Join(", " ,$failedServers))"
+            $line = "Failed to enable Extended Protection: $([string]::Join(", " ,$failedServers))"
             Write-Verbose $line
             Write-Warning $line
         }
 
         if ($noChangesMadeServers.Count -gt 0) {
-            Write-Host "No changes were made to these servers: $([string]::Join(", " ,$noChangesMadeServers))"
+            Write-Host "No changes made: $([string]::Join(", " ,$noChangesMadeServers))"
         }
 
         if ($updatedServers.Count -gt 0 ) {
-            Write-Host "Successfully updated all of the following servers for extended protection:  $([string]::Join(", " ,$updatedServers))"
+            Write-Host "Successfully enabled Extended Protection: $([string]::Join(", " ,$updatedServers))"
         }
     }
 }


### PR DESCRIPTION
Phase 1 of cleaning up the output.

It would be nice to remove all this text output and move it to Write-Progress until the final result. The prereq check does a great job of sending progress to Write-Progress, but the actual settings piece just sends text to the screen.

This PR makes the text better, but hopefully we can remove it and change all these Write-Host calls to Write-Verbose.

I also removed the 5 second pause. Pausing is not a good way to call attention to something. If we want to call more attention to something, put it at the bottom of the output, separate it with whitespace, and colorize it if necessary.

Before:

![image](https://user-images.githubusercontent.com/4518572/184943949-0780aba9-d948-4cbb-bde7-1a8c295231c5.png)

After:

![image](https://user-images.githubusercontent.com/4518572/184943981-3f14109d-53bc-4513-adae-d45a78adfff5.png)
