### PR TITLE
Address down server with Get-OutlookAnywhere

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -327,10 +327,11 @@ begin {
                         PercentComplete = 0
                     }
 
-                    try {
-                        $outlookAnywhere = Get-OutlookAnywhere -ErrorAction Stop
-                    } catch {
-                        Write-Warning "Failed to run Get-OutlookAnywhere. Failing out the script. Inner Exception: $_"
+                    # Needs to be SilentlyContinue to handle down servers
+                    $outlookAnywhere = Get-OutlookAnywhere -ErrorAction SilentlyContinue
+
+                    if ($null -eq $outlookAnywhere) {
+                        Write-Warning "Failed to run Get-OutlookAnywhere. Failing out the script."
                         exit
                     }
 


### PR DESCRIPTION
**Issue:**
When server is down, we fail out the script. 

**Reason:**
Shouldn't fail out the script, should continue. 

**Fix:**
Change the `ErrorAction` to be `SilentlyContinue` 

**Validation:**
Lab tested

