### PR TITLE
Fix for Extended Protection Management Server usage and preparation work for PSSession usage

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -84,7 +84,7 @@ begin {
             $Script:SkipEWS = $false
         }
 
-        if (-not((Confirm-ExchangeShell -Identity $env:COMPUTERNAME).ShellLoaded)) {
+        if (-not((Confirm-ExchangeShell -Identity $env:COMPUTERNAME -IgnoreToolsIdentity $true).ShellLoaded)) {
             Write-Warning "Failed to load the Exchange Management Shell. Start the script using the Exchange Management Shell."
             exit
         }


### PR DESCRIPTION
**Issue:**
The script fails if it was executed on a management server in the following scenarios:

- Executed via EMS on a management server
- Executed via Exchange PowerShell session (`New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri http://e2k16-1/PowerShell | Import-PSSession`)

**Reason:**
- Scenario 1) wasn't properly handled in the `ExchangeExtendedProtectionManagement.ps1`.
- Scenario 2) wasn't properly handled in the `Confirm-ExchangeShell.ps1`

**Fix:**
- Scenario 1): `IgnoreToolsIdentity $true` was added
- Scenario 2): Logic added to `Confirm-ExchangeShell.ps1` to check for an active Exchange PowerShell session

We have not yet validated scenario 2) in the `ExchangeExtendedProtectionManagement.ps1` script. Therefore, it's not yet supported and may be added at a later date.

**Validation:**
Lab

