### PR TITLE
Fix Confirm-ExchangeShell for handling on Remote Shell and Tool boxes

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -182,7 +182,7 @@ function Main {
     }
 
     if ($LoadBalancingReport) {
-        Invoke-ScriptLogFileLocation -FileName "HealthChecker-LoadBalancingReport" -IgnoreToolsIdentity $true
+        Invoke-ScriptLogFileLocation -FileName "HealthChecker-LoadBalancingReport"
         Write-Green("Client Access Load Balancing Report on " + $date)
         Get-CASLoadBalancingReport
         Write-Grey("Output file written to " + $OutputFullPath)

--- a/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
@@ -5,7 +5,6 @@
 function Invoke-ScriptLogFileLocation {
     param(
         [Parameter(Mandatory = $true)][string]$FileName,
-        [Parameter(Mandatory = $false)][bool]$IgnoreToolsIdentity = $false,
         [Parameter(Mandatory = $false)][bool]$IncludeServerName = $false
     )
     $endName = "-{0}.txt" -f $dateTimeStringFormat
@@ -24,7 +23,6 @@ function Invoke-ScriptLogFileLocation {
     }
 
     $Script:ExchangeShellComputer = Confirm-ExchangeShell -Identity $Script:Server `
-        -IgnoreToolsIdentity $IgnoreToolsIdentity `
         -CatchActionFunction ${Function:Invoke-CatchActions}
 
     if (!($Script:ExchangeShellComputer.ShellLoaded)) {

--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -7,15 +7,12 @@
 function Confirm-ExchangeShell {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [string]$Identity,
+        [string]$Identity = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $false)]
         [bool]$LoadExchangeShell = $true,
-
-        [Parameter(Mandatory = $false)]
-        [bool]$IgnoreToolsIdentity = $false,
 
         [Parameter(Mandatory = $false)]
         [scriptblock]$CatchActionFunction
@@ -39,7 +36,7 @@ function Confirm-ExchangeShell {
         $edgeTransportKey = 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\EdgeTransportRole'
         $setupKey = 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup'
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-        Write-Verbose "Passed: LoadExchangeShell: $LoadExchangeShell | Identity: $Identity | IgnoreToolsIdentity: $IgnoreToolsIdentity"
+        Write-Verbose "Passed: LoadExchangeShell: $LoadExchangeShell | Identity: $Identity"
         $params = @{
             Identity    = $Identity
             ErrorAction = "Stop"
@@ -47,12 +44,13 @@ function Confirm-ExchangeShell {
 
         $toolsServer = (Test-Path $setupKey) -and (!(Test-Path $edgeTransportKey)) -and `
         ($null -eq (Get-ItemProperty -Path $setupKey -Name "Services" -ErrorAction SilentlyContinue))
+        $remoteShell = (!(Test-Path $setupKey))
 
-        if ($toolsServer) {
-            Write-Verbose "Tools Server: $env:ComputerName"
-            if ($env:ComputerName -eq $Identity -and
-                $IgnoreToolsIdentity) {
-                Write-Verbose "Removing Identity from Get-ExchangeServer cmdlet"
+        if ($toolsServer -or $remoteShell) {
+            Write-Verbose "Exchange Server Check against local: $env:ComputerName"
+            if ($env:ComputerName -eq $Identity -or
+                $env:ComputerName -eq $Identity.Split(".")[0]) {
+                Write-Verbose "Removing Identity from Get-ExchangeServer cmdlet due to passed value isn't an Exchange Server"
                 $params.Remove("Identity")
             } else {
                 Write-Verbose "Didn't remove Identity"
@@ -131,7 +129,7 @@ function Confirm-ExchangeShell {
             Revision    = ((Get-ItemProperty -Path $setupKey -Name "MsiBuildMinor" -ErrorAction SilentlyContinue).MsiBuildMinor)
             EdgeServer  = $passed -and (Test-Path $setupKey) -and (Test-Path $edgeTransportKey)
             ToolsOnly   = $passed -and $toolsServer
-            RemoteShell = $passed -and (!(Test-Path $setupKey))
+            RemoteShell = $passed -and $remoteShell
         }
 
         Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction

--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -62,7 +62,9 @@ function Confirm-ExchangeShell {
     process {
         try {
             $currentErrors = $Error.Count
-            Get-ExchangeServer @params | Out-Null
+            $isEMS = Get-ExchangeServer @params |
+                Select-Object -First 1 |
+                ForEach-Object { if ($_.GetType().Name -eq "ExchangeServer") { return $true } return $false }
             Write-Verbose "Exchange PowerShell Module already loaded."
             $passed = $true
             Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
@@ -100,7 +102,9 @@ function Confirm-ExchangeShell {
 
                     Write-Verbose "Imported Module. Trying Get-Exchange Server Again"
                     try {
-                        Get-ExchangeServer @params | Out-Null
+                        $isEMS = Get-ExchangeServer @params |
+                            Select-Object -First 1 |
+                            ForEach-Object { if ($_.GetType().Name -eq "ExchangeServer") { return $true } return $false }
                         $passed = $true
                         Write-Verbose "Successfully loaded Exchange Management Shell"
                         Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
@@ -130,6 +134,7 @@ function Confirm-ExchangeShell {
             EdgeServer  = $passed -and (Test-Path $setupKey) -and (Test-Path $edgeTransportKey)
             ToolsOnly   = $passed -and $toolsServer
             RemoteShell = $passed -and $remoteShell
+            EMS         = $isEMS
         }
 
         Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction


### PR DESCRIPTION
**Issue:**
By default, we don't always pass the Identity of an Exchange Server to `Confirm-ExchangeShell` because the script doesn't require it to target a single Exchange server. Because of this, we want to be able to support running on a tools box or a remote shell session by default within `Confirm-ExchangeShell`

**Fix:**
By default, we should be able to support `Confirm-ExchangeShell` when on a non-Exchange server and we pass the Identity of the local computer. If the Identity passed is the local computer name and is a non-Exchange servers, remove the Identity from the mix. 

**Validation:**
Lab tested. 

Scenario 1: 

- Single session exists
- Session uses short name
- Session is Imported
- From tools box
- Passed Identity with None, FQDN for an Exchange Server, FQDN for local server

Results: Expected

![image](https://user-images.githubusercontent.com/22776718/185271676-a3af0555-7e64-470c-aaef-ad14bc68a274.png)


Scenario 2: 

- From tools box
- Running from PowerShell before session is created 

Results: Load Shell and Removed Identity

![image](https://user-images.githubusercontent.com/22776718/185272142-1df1cbc1-2c57-4877-b9eb-d2dc86a7b8b5.png)


Scenario 3:

- Single session exists 
- Session uses FQDN 
- Session is Imported
- On tools box

Result: Uses the current session as expected 
![image](https://user-images.githubusercontent.com/22776718/185272672-d2558645-6db1-45a5-a3d5-a53c486cd33f.png)

Scenario 4: 

- No session is used or active
- On Remote Computer

Result: Failed as expected

![image](https://user-images.githubusercontent.com/22776718/185273118-e22745a4-f7af-4d1a-a275-9f730488d025.png)


Scenario 5:

- Single session exists
- Session uses short name
- Session is Imported
- On Remote Computer

Result: Works as expected

![image](https://user-images.githubusercontent.com/22776718/185273468-c78202fe-78fd-41a3-925a-f3e907fc45b6.png)
