### PR TITLE
Out of range exception when running Get-OutlookAnywhere in co-existence env with pre 2013 servers

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -332,7 +332,8 @@ begin {
                     $counter = 0
                     $totalCount = $ExchangeServers.Count
                     $outlookAnywhereCount = 0
-                    $outlookAnywhereTotalCount = ($ExchangeServersPrerequisitesCheckSettingsCheck | Where-Object { $_.IsClientAccessServer -eq $true }).Count
+                    $outlookAnywhereServers = $ExchangeServersPrerequisitesCheckSettingsCheck | Where-Object { $_.IsClientAccessServer -eq $true }
+                    $outlookAnywhereTotalCount = $outlookAnywhereServers.Count
 
                     $progressParams = @{
                         Id              = 1
@@ -349,8 +350,8 @@ begin {
 
                     Write-Progress @progressParams
                     Write-Progress @outlookAnywhereProgressParams
-                    # Needs to be SilentlyContinue to handle down servers
-                    $outlookAnywhere = Get-OutlookAnywhere -ErrorAction SilentlyContinue |
+                    # Needs to be SilentlyContinue to handle down servers, we must also exclude pre Exchange 2013 servers
+                    $outlookAnywhere = $outlookAnywhereServers | Get-OutlookAnywhere -ErrorAction SilentlyContinue |
                         ForEach-Object {
                             $outlookAnywhereCount++
                             $outlookAnywhereProgressParams.PercentComplete = ($outlookAnywhereCount / $outlookAnywhereTotalCount * 100)


### PR DESCRIPTION
**Issue:**
Customer reported the following issue:

```
ForEach-Object : Cannot validate argument on parameter 'PercentComplete'. The 200 argument is greater than the maximum
allowed range of 100. Supply an argument that is less than or equal to 100 and then try the command again.
At C:\Scripts\ExchangeExtendedProtectionManagement\ExchangeExtendedProtectionManagement.ps1:2280 char:25
+                         ForEach-Object {
+                         ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [ForEach-Object], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.ForEachObjectCommand
```

**Reason:**
`$outlookAnywhereTotalCount` is determined by doing some version filtering based on `AdminDisplayVersion`
```
$ExchangeServers = Get-ExchangeServer | Where-Object { $_.AdminDisplayVersion -like "Version 15*" -and $_.ServerRole -ne "Edge" }
$ExchangeServersPrerequisitesCheckSettingsCheck = $ExchangeServers
$outlookAnywhereTotalCount = ($ExchangeServersPrerequisitesCheckSettingsCheck | Where-Object { $_.IsClientAccessServer -eq $true }).Count
```
`Get-OutlookAnywhere` isn't filtered and so, returns also results for Exchange 2010 servers which may exist in co-existence environments. Therefore, we could end up in the exception if more servers are returned for `Get-OutlookAnywhere` than expected in `$outlookAnywhereTotalCount`
```
$outlookAnywhere = Get-OutlookAnywhere -ErrorAction SilentlyContinue |
	ForEach-Object {
		$outlookAnywhereCount++
		$outlookAnywhereProgressParams.PercentComplete = ($outlookAnywhereCount / $outlookAnywhereTotalCount * 100)
		Write-Progress @outlookAnywhereProgressParams
		$_
	}
```

**Fix:**
Run `Get-OutlookAnywhere` only for Exchange 2013+ servers. However, this could lead to situations where SSL offloading is enabled for EOL Exchange 2010 servers. I don't think that this is a big problem as Exchange 2010 isn't supported anymore and was never tested against Extended Protection. Let's discuss this internal and decide how we would like to proceed with this. 

**Validation:**
Lab / Customer

