### PR TITLE
Ensure System.Core is loaded for HashSet support

### DIFF
--- a/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
+++ b/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
@@ -45,6 +45,9 @@ param (
 . $PSScriptRoot\..\..\Shared\ScriptUpdateFunctions\Test-ScriptVersion.ps1
 . $PSScriptRoot\..\..\Shared\Out-Columns.ps1
 
+# For HashSet support
+Add-Type -AssemblyName System.Core -ErrorAction Stop
+
 try {
     if (-not $SkipVersionCheck) {
         if (Test-ScriptVersion -AutoUpdate) {


### PR DESCRIPTION
See https://stackoverflow.com/questions/3321252/can-i-use-system-core-dll-system-collections-generic-hashset-in-powershell