### PR TITLE
Health Checker to include TLS 1.3 in the report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -32,54 +32,108 @@ function Invoke-AnalyzerSecuritySettings {
     ##############
     Write-Verbose "Working on TLS Settings"
 
-    $tlsVersions = @("1.0", "1.1", "1.2")
+    function NewDisplayObject {
+        param (
+            [string]$RegistryKey,
+            [string]$Location,
+            [object]$Value
+        )
+        return [PSCustomObject]@{
+            RegistryKey = $RegistryKey
+            Location    = $Location
+            Value       = if ($null -eq $Value) { "NULL" } else { $Value }
+        }
+    }
+
+    $tlsVersions = @("1.0", "1.1", "1.2", "1.3")
     $currentNetVersion = $osInformation.TLSSettings.Registry.NET["NETv4"]
 
     $tlsSettings = $osInformation.TLSSettings.Registry.TLS
-    $outputObjectDisplayValue = New-Object System.Collections.Generic.List[object]
     $misconfiguredClientServerSettings = ($tlsSettings.Values | Where-Object { $_.TLSMisconfigured -eq $true }).Count -ne 0
     $displayLinkToDocsPage = ($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Enabled" -and $_.TLSConfiguration -ne "Disabled" }).Count -ne 0
     $lowerTlsVersionDisabled = ($tlsSettings.Values | Where-Object { $_.TLSVersionDisabled -eq $true -and $_.TLSVersion -ne "1.2" }).Count -ne 0
+    $tls13NotDisabled = ($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Disabled" -and $_.TLSVersion -eq "1.3" }).Count -gt 0
 
-    foreach ($tlsKey in $tlsVersions) {
-        $currentTlsVersion = $osInformation.TLSSettings.Registry.TLS[$tlsKey]
-        $outputObjectDisplayValue.Add(([PSCustomObject]@{
-                    TLSVersion    = $tlsKey
-                    ServerEnabled = $currentTlsVersion.ServerEnabled
-                    ServerDbD     = $currentTlsVersion.ServerDisabledByDefault
-                    ClientEnabled = $currentTlsVersion.ClientEnabled
-                    ClientDbD     = $currentTlsVersion.ClientDisabledByDefault
-                    Configuration = $currentTlsVersion.TLSConfiguration
-                })
-        )
-    }
-
-    $sbConfiguration = {
+    $sbValue = {
         param ($o, $p)
-        if ($p -eq "Configuration") {
-            if ($o.$p -eq "Misconfigured" -or $o.$p -eq "Half Disabled") {
+        if ($p -eq "Value") {
+            if ($o.$p -eq "NULL" -and -not $o.Location.Contains("1.3")) {
                 "Red"
-            } elseif ($o.$p -eq "Disabled") {
-                if ($o.TLSVersion -eq "1.2") {
-                    "Red"
-                } else {
-                    "Green"
-                }
-            } else {
-                "Green"
+            } elseif ($o.$p -ne "NULL" -and
+                $o.$p -ne 1 -and
+                $o.$p -ne 0) {
+                "Red"
             }
         }
     }
 
+    foreach ($tlsKey in $tlsVersions) {
+        $currentTlsVersion = $osInformation.TLSSettings.Registry.TLS[$tlsKey]
+        $outputObjectDisplayValue = New-Object System.Collections.Generic.List[object]
+        $outputObjectDisplayValue.Add((NewDisplayObject "Enabled" -Location $currentTlsVersion.ServerRegistryPath -Value $currentTlsVersion.ServerEnabledValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "DisabledByDefault" -Location $currentTlsVersion.ServerRegistryPath -Value $currentTlsVersion.ServerDisabledByDefaultValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "Enabled" -Location $currentTlsVersion.ClientRegistryPath -Value $currentTlsVersion.ClientEnabledValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "DisabledByDefault" -Location $currentTlsVersion.ClientRegistryPath -Value $currentTlsVersion.ClientDisabledByDefaultValue))
+        $displayWriteType = "Green"
+
+        # Any TLS version is Misconfigured or Half Disabled is Red
+        # Only TLS 1.2 being Disabled is Red
+        # Currently TLS 1.3 being Enabled is Red
+        if (($currentTlsVersion.TLSConfiguration -eq "Misconfigured" -or
+                $currentTlsVersion.TLSConfiguration -eq "Half Disabled") -or
+                ($tlsKey -eq "1.2" -and $currentTlsVersion.TLSConfiguration -eq "Disabled") -or
+                ($tlsKey -eq "1.3" -and $currentTlsVersion.TLSConfiguration -eq "Enabled")) {
+            $displayWriteType = "Red"
+        }
+
+        $params = $baseParams + @{
+            Name             = "TLS $tlsKey"
+            Details          = $currentTlsVersion.TLSConfiguration
+            DisplayWriteType = $displayWriteType
+        }
+        Add-AnalyzedResultInformation @params
+
+        $params = $baseParams + @{
+            OutColumns           = ([PSCustomObject]@{
+                    DisplayObject      = $outputObjectDisplayValue
+                    ColorizerFunctions = @($sbValue)
+                    IndentSpaces       = 8
+                })
+            OutColumnsColorTests = @($sbValue)
+            HtmlName             = "TLS Settings $tlsKey"
+            TestingName          = "TLS Settings Group $tlsKey"
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
+    $netVersions = @("NETv4", "NETv2")
+    $outputObjectDisplayValue = New-Object System.Collections.Generic.List[object]
+
+    $sbValue = {
+        param ($o, $p)
+        if ($p -eq "Value") {
+            if ($o.$p -eq "NULL" -and $o.Location -like "*v4.0.30319") {
+                "Red"
+            }
+        }
+    }
+
+    foreach ($netVersion in $netVersions) {
+        $currentNetVersion = $osInformation.TLSSettings.Registry.NET[$netVersion]
+        $outputObjectDisplayValue.Add((NewDisplayObject "SystemDefaultTlsVersions" -Location $currentNetVersion.MicrosoftRegistryLocation -Value $currentNetVersion.SystemDefaultTlsVersionsValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "SchUseStrongCrypto" -Location $currentNetVersion.MicrosoftRegistryLocation -Value $currentNetVersion.SchUseStrongCryptoValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "SystemDefaultTlsVersions" -Location $currentNetVersion.WowRegistryLocation -Value $currentNetVersion.WowSystemDefaultTlsVersionsValue))
+        $outputObjectDisplayValue.Add((NewDisplayObject "SchUseStrongCrypto" -Location $currentNetVersion.WowRegistryLocation -Value $currentNetVersion.WowSchUseStrongCryptoValue))
+    }
+
     $params = $baseParams + @{
-        OutColumns           = ([PSCustomObject]@{
+        OutColumns  = ([PSCustomObject]@{
                 DisplayObject      = $outputObjectDisplayValue
-                ColorizerFunctions = @($sbConfiguration)
+                ColorizerFunctions = @($sbValue)
                 IndentSpaces       = 8
             })
-        OutColumnsColorTests = @($sbConfiguration)
-        HtmlName             = "TLS Settings"
-        TestingName          = "TLS Settings Group"
+        HtmlName    = "TLS NET Settings"
+        TestingName = "NET TLS Settings Group"
     }
     Add-AnalyzedResultInformation @params
 
@@ -102,7 +156,7 @@ function Invoke-AnalyzerSecuritySettings {
         }
 
         # if value not defined, we should call that out.
-        $results = $tlsSettings.Values | Where-Object { $null -eq $_."$testValue" }
+        $results = $tlsSettings.Values | Where-Object { $null -eq $_."$testValue" -and $_.TLSVersion -ne "1.3" }
 
         if ($null -ne $results) {
             $displayLinkToDocsPage = $true
@@ -117,11 +171,31 @@ function Invoke-AnalyzerSecuritySettings {
         }
     }
 
+    # Check for NULL values on NETv4 registry settings
+    $testValues = @("SystemDefaultTlsVersionsValue", "SchUseStrongCryptoValue", "WowSystemDefaultTlsVersionsValue", "WowSchUseStrongCryptoValue")
+
+    foreach ($testValue in $testValues) {
+        $results = $osInformation.TLSSettings.Registry.NET["NETv4"] | Where-Object { $null -eq $_."$testValue" }
+        if ($null -ne $results) {
+            $displayLinkToDocsPage = $true
+            foreach ($result in $results) {
+                $params = $baseParams + @{
+                    Name             = "$($result.NetVersion) $testValue"
+                    Details          = "NULL --- Error: Value should be defined in registry for consistent results."
+                    DisplayWriteType = "Red"
+                }
+                Add-AnalyzedResultInformation @params
+            }
+        }
+    }
+
     if ($lowerTlsVersionDisabled -and
-        ($currentNetVersion.SystemDefaultTlsVersions -eq $false -or
-        $currentNetVersion.WowSystemDefaultTlsVersions -eq $false)) {
+        ($osInformation.TLSSettings.Registry.NET["NETv4"].SystemDefaultTlsVersions -eq $false -or
+        $osInformation.TLSSettings.Registry.NET["NETv4"].WowSystemDefaultTlsVersions -eq $false -or
+        $osInformation.TLSSettings.Registry.NET["NETv4"].SchUseStrongCrypto -eq $false -or
+        $osInformation.TLSSettings.Registry.NET["NETv4"].WowSchUseStrongCrypto -eq $false)) {
         $params = $baseParams + @{
-            Details                = "Error: SystemDefaultTlsVersions is not set to the recommended value. Please visit on how to properly enable TLS 1.2 https://aka.ms/HC-TLSGuide"
+            Details                = "Error: SystemDefaultTlsVersions or SchUseStrongCrypto is not set to the recommended value. Please visit on how to properly enable TLS 1.2 https://aka.ms/HC-TLSGuide"
             DisplayWriteType       = "Red"
             DisplayCustomTabNumber = 2
         }
@@ -146,60 +220,16 @@ function Invoke-AnalyzerSecuritySettings {
         Add-AnalyzedResultInformation @params
     }
 
-    if ($displayLinkToDocsPage) {
+    if ($tls13NotDisabled) {
+        $displayLinkToDocsPage = $true
         $params = $baseParams + @{
-            Details                = "More Information: https://aka.ms/HC-TLSConfigDocs"
-            DisplayWriteType       = "Yellow"
+            Details                = "Error: TLS 1.3 is not disabled and not supported currently on Exchange and is known to cause issues within the cluster."
+            DisplayWriteType       = "Red"
             DisplayTestingValue    = $true
             DisplayCustomTabNumber = 2
-            TestingName            = "Display Link to Docs Page"
+            TestingName            = "TLS 1.3 not disabled"
         }
         Add-AnalyzedResultInformation @params
-    }
-
-    $netVersions = @("NETv4", "NETv2")
-    $outputObjectDisplayValue = New-Object System.Collections.Generic.List[object]
-
-    foreach ($netVersion in $netVersions) {
-        $currentNetVersion = $osInformation.TLSSettings.Registry.NET[$netVersion]
-        $outputObjectDisplayValue.Add(([PSCustomObject]@{
-                    FrameworkVersion                    = $netVersion
-                    SystemDefaultTlsVersions            = $currentNetVersion.SystemDefaultTlsVersions
-                    Wow6432NodeSystemDefaultTlsVersions = $currentNetVersion.WowSystemDefaultTlsVersions
-                    SchUseStrongCrypto                  = $currentNetVersion.SchUseStrongCrypto
-                    Wow6432NodeSchUseStrongCrypto       = $currentNetVersion.WowSchUseStrongCrypto
-                })
-        )
-    }
-
-    $params = $baseParams + @{
-        OutColumns  = ([PSCustomObject]@{
-                DisplayObject = $outputObjectDisplayValue
-                IndentSpaces  = 8
-            })
-        HtmlName    = "TLS NET Settings"
-        TestingName = "NET TLS Settings Group"
-    }
-    Add-AnalyzedResultInformation @params
-
-    # Check for NULL values on NETv4 registry settings
-    $testValues = @("SystemDefaultTlsVersionsValue", "SchUseStrongCryptoValue", "WowSystemDefaultTlsVersionsValue", "WowSchUseStrongCryptoValue")
-    $displayLinkToDocsPage = $false
-
-    foreach ($testValue in $testValues) {
-        $results = $osInformation.TLSSettings.Registry.NET["NETv4"] | Where-Object { $null -eq $_."$testValue" }
-
-        if ($null -ne $results) {
-            $displayLinkToDocsPage = $true
-            foreach ($result in $results) {
-                $params = $baseParams + @{
-                    Name             = "$($result.NetVersion) $testValue"
-                    Details          = "NULL --- Error: Value should be defined in registry for consistent results."
-                    DisplayWriteType = "Red"
-                }
-                Add-AnalyzedResultInformation @params
-            }
-        }
     }
 
     if ($displayLinkToDocsPage) {

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetAllTlsSettings.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetAllTlsSettings.xml
@@ -24,10 +24,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -45,10 +47,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -66,10 +70,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <Nil N="ServerDisabledByDefaultValue" />
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -92,10 +98,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">true</B>
                     <I32 N="SchUseStrongCryptoValue">1</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="WowSystemDefaultTlsVersions">true</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">true</B>
                     <I32 N="WowSchUseStrongCryptoValue">1</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">true</B>
                   </MS>
@@ -111,10 +119,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">true</B>
                     <I32 N="SchUseStrongCryptoValue">1</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="WowSystemDefaultTlsVersions">true</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">true</B>
                     <I32 N="WowSchUseStrongCryptoValue">1</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">true</B>
                   </MS>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetAllTlsSettings.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetAllTlsSettings.xml
@@ -24,10 +24,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -45,10 +47,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -66,10 +70,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <Nil N="ServerDisabledByDefaultValue" />
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">true</B>
                     <Nil N="ClientEnabledValue" />
                     <B N="ClientDisabledByDefault">false</B>
                     <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -92,10 +98,12 @@
                     <Nil N="SystemDefaultTlsVersionsValue" />
                     <B N="SchUseStrongCrypto">false</B>
                     <Nil N="SchUseStrongCryptoValue" />
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="WowSystemDefaultTlsVersions">false</B>
                     <Nil N="WowSystemDefaultTlsVersionsValue" />
                     <B N="WowSchUseStrongCrypto">false</B>
                     <Nil N="WowSchUseStrongCryptoValue" />
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">false</B>
                   </MS>
@@ -111,10 +119,12 @@
                     <Nil N="SystemDefaultTlsVersionsValue" />
                     <B N="SchUseStrongCrypto">false</B>
                     <Nil N="SchUseStrongCryptoValue" />
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="WowSystemDefaultTlsVersions">false</B>
                     <Nil N="WowSystemDefaultTlsVersionsValue" />
                     <B N="WowSchUseStrongCrypto">false</B>
                     <Nil N="WowSchUseStrongCryptoValue" />
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">false</B>
                   </MS>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings.xml
@@ -24,10 +24,12 @@
                     <I32 N="ServerEnabledValue">0</I32>
                     <B N="ServerDisabledByDefault">true</B>
                     <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server</S>
                     <B N="ClientEnabled">false</B>
                     <I32 N="ClientEnabledValue">0</I32>
                     <B N="ClientDisabledByDefault">true</B>
                     <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client</S>
                     <B N="TLSVersionDisabled">true</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -45,10 +47,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">true</B>
                     <I32 N="ClientEnabledValue">1</I32>
                     <B N="ClientDisabledByDefault">false</B>
                     <I32 N="ClientDisabledByDefaultValue">0</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -66,10 +70,12 @@
                     <I32 N="ServerEnabledValue">0</I32>
                     <B N="ServerDisabledByDefault">true</B>
                     <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">false</B>
                     <I32 N="ClientEnabledValue">0</I32>
                     <B N="ClientDisabledByDefault">true</B>
                     <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client</S>
                     <B N="TLSVersionDisabled">true</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -92,10 +98,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">false</B>
                     <I32 N="SchUseStrongCryptoValue">0</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="WowSystemDefaultTlsVersions">false</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">false</B>
                     <I32 N="WowSchUseStrongCryptoValue">0</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="SdtvConfiguredCorrectly">false</B>
                     <B N="SdtvEnabled">false</B>
                   </MS>
@@ -111,10 +119,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">true</B>
                     <I32 N="SchUseStrongCryptoValue">1</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="WowSystemDefaultTlsVersions">true</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">true</B>
                     <I32 N="WowSchUseStrongCryptoValue">1</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">true</B>
                   </MS>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings1.xml
@@ -24,10 +24,12 @@
                     <I32 N="ServerEnabledValue">0</I32>
                     <B N="ServerDisabledByDefault">true</B>
                     <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server</S>
                     <B N="ClientEnabled">false</B>
                     <I32 N="ClientEnabledValue">0</I32>
                     <B N="ClientDisabledByDefault">true</B>
                     <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client</S>
                     <B N="TLSVersionDisabled">true</B>
                     <B N="TLSMisconfigured">true</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -45,10 +47,12 @@
                     <I32 N="ServerEnabledValue">1</I32>
                     <B N="ServerDisabledByDefault">false</B>
                     <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
                     <B N="ClientEnabled">true</B>
                     <I32 N="ClientEnabledValue">1</I32>
                     <B N="ClientDisabledByDefault">false</B>
                     <I32 N="ClientDisabledByDefaultValue">0</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client</S>
                     <B N="TLSVersionDisabled">false</B>
                     <B N="TLSMisconfigured">false</B>
                     <B N="TLSHalfDisabled">false</B>
@@ -66,14 +70,39 @@
                     <I32 N="ServerEnabledValue">0</I32>
                     <B N="ServerDisabledByDefault">true</B>
                     <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server</S>
                     <B N="ClientEnabled">true</B>
                     <I32 N="ClientEnabledValue">-1</I32>
                     <B N="ClientDisabledByDefault">true</B>
                     <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client</S>
                     <B N="TLSVersionDisabled">true</B>
                     <B N="TLSMisconfigured">true</B>
                     <B N="TLSHalfDisabled">false</B>
                     <S N="TLSConfiguration">Misconfigured</S>
+                  </MS>
+                </Obj>
+              </En>
+              <En>
+                <S N="Key">1.3</S>
+                <Obj N="Value" RefId="5">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="TLSVersion">1.3</S>
+                    <B N="ServerEnabled">false</B>
+                    <Nil N="ServerEnabledValue" />
+                    <B N="ServerDisabledByDefault">false</B>
+                    <Nil N="ServerDisabledByDefaultValue" />
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server</S>
+                    <B N="ClientEnabled">false</B>
+                    <Nil N="ClientEnabledValue" />
+                    <B N="ClientDisabledByDefault">false</B>
+                    <Nil N="ClientDisabledByDefaultValue" />
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client</S>
+                    <B N="TLSVersionDisabled">true</B>
+                    <B N="TLSMisconfigured">true</B>
+                    <B N="TLSHalfDisabled">false</B>
+                    <S N="TLSConfiguration">Disabled</S>
                   </MS>
                 </Obj>
               </En>
@@ -92,10 +121,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">false</B>
                     <I32 N="SchUseStrongCryptoValue">0</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="WowSystemDefaultTlsVersions">false</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">false</B>
                     <I32 N="WowSchUseStrongCryptoValue">0</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319</S>
                     <B N="SdtvConfiguredCorrectly">false</B>
                     <B N="SdtvEnabled">false</B>
                   </MS>
@@ -111,10 +142,12 @@
                     <I32 N="SystemDefaultTlsVersionsValue">1</I32>
                     <B N="SchUseStrongCrypto">true</B>
                     <I32 N="SchUseStrongCryptoValue">1</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="WowSystemDefaultTlsVersions">true</B>
                     <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
                     <B N="WowSchUseStrongCrypto">true</B>
                     <I32 N="WowSchUseStrongCryptoValue">1</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727</S>
                     <B N="SdtvConfiguredCorrectly">true</B>
                     <B N="SdtvEnabled">true</B>
                   </MS>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings2.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetAllTlsSettings2.xml
@@ -1,0 +1,386 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <Obj N="Registry" RefId="1">
+        <TNRef RefId="0" />
+        <MS>
+          <Obj N="TLS" RefId="2">
+            <TN RefId="1">
+              <T>System.Collections.Hashtable</T>
+              <T>System.Object</T>
+            </TN>
+            <DCT>
+              <En>
+                <S N="Key">1.1</S>
+                <Obj N="Value" RefId="3">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="TLSVersion">1.1</S>
+                    <B N="ServerEnabled">true</B>
+                    <I32 N="ServerEnabledValue">0</I32>
+                    <B N="ServerDisabledByDefault">true</B>
+                    <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server</S>
+                    <B N="ClientEnabled">false</B>
+                    <I32 N="ClientEnabledValue">0</I32>
+                    <B N="ClientDisabledByDefault">true</B>
+                    <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client</S>
+                    <B N="TLSVersionDisabled">true</B>
+                    <B N="TLSMisconfigured">true</B>
+                    <B N="TLSHalfDisabled">false</B>
+                    <S N="TLSConfiguration">Misconfigured</S>
+                  </MS>
+                </Obj>
+              </En>
+              <En>
+                <S N="Key">1.2</S>
+                <Obj N="Value" RefId="4">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="TLSVersion">1.2</S>
+                    <B N="ServerEnabled">true</B>
+                    <I32 N="ServerEnabledValue">1</I32>
+                    <B N="ServerDisabledByDefault">false</B>
+                    <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server</S>
+                    <B N="ClientEnabled">true</B>
+                    <I32 N="ClientEnabledValue">1</I32>
+                    <B N="ClientDisabledByDefault">false</B>
+                    <I32 N="ClientDisabledByDefaultValue">0</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client</S>
+                    <B N="TLSVersionDisabled">false</B>
+                    <B N="TLSMisconfigured">false</B>
+                    <B N="TLSHalfDisabled">false</B>
+                    <S N="TLSConfiguration">Enabled</S>
+                  </MS>
+                </Obj>
+              </En>
+              <En>
+                <S N="Key">1.0</S>
+                <Obj N="Value" RefId="5">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="TLSVersion">1.0</S>
+                    <B N="ServerEnabled">false</B>
+                    <I32 N="ServerEnabledValue">0</I32>
+                    <B N="ServerDisabledByDefault">true</B>
+                    <I32 N="ServerDisabledByDefaultValue">1</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server</S>
+                    <B N="ClientEnabled">true</B>
+                    <I32 N="ClientEnabledValue">-1</I32>
+                    <B N="ClientDisabledByDefault">true</B>
+                    <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client</S>
+                    <B N="TLSVersionDisabled">true</B>
+                    <B N="TLSMisconfigured">true</B>
+                    <B N="TLSHalfDisabled">false</B>
+                    <S N="TLSConfiguration">Misconfigured</S>
+                  </MS>
+                </Obj>
+              </En>
+              <En>
+                <S N="Key">1.3</S>
+                <Obj N="Value" RefId="5">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="TLSVersion">1.3</S>
+                    <B N="ServerEnabled">true</B>
+                    <I32 N="ServerEnabledValue">1</I32>
+                    <B N="ServerDisabledByDefault">false</B>
+                    <I32 N="ServerDisabledByDefaultValue">0</I32>
+                    <S N="ServerRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server</S>
+                    <B N="ClientEnabled">true</B>
+                    <I32 N="ClientEnabledValue">1</I32>
+                    <B N="ClientDisabledByDefault">false</B>
+                    <I32 N="ClientDisabledByDefaultValue">1</I32>
+                    <S N="ClientRegistryPath">SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client</S>
+                    <B N="TLSVersionDisabled">false</B>
+                    <B N="TLSMisconfigured">false</B>
+                    <B N="TLSHalfDisabled">false</B>
+                    <S N="TLSConfiguration">Enabled</S>
+                  </MS>
+                </Obj>
+              </En>
+            </DCT>
+          </Obj>
+          <Obj N="NET" RefId="6">
+            <TNRef RefId="1" />
+            <DCT>
+              <En>
+                <S N="Key">NETv4</S>
+                <Obj N="Value" RefId="7">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="NetVersion">v4.0.30319</S>
+                    <B N="SystemDefaultTlsVersions">false</B>
+                    <I32 N="SystemDefaultTlsVersionsValue">1</I32>
+                    <B N="SchUseStrongCrypto">false</B>
+                    <I32 N="SchUseStrongCryptoValue">0</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v4.0.30319</S>
+                    <B N="WowSystemDefaultTlsVersions">false</B>
+                    <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
+                    <B N="WowSchUseStrongCrypto">false</B>
+                    <I32 N="WowSchUseStrongCryptoValue">0</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319</S>
+                    <B N="SdtvConfiguredCorrectly">false</B>
+                    <B N="SdtvEnabled">false</B>
+                  </MS>
+                </Obj>
+              </En>
+              <En>
+                <S N="Key">NETv2</S>
+                <Obj N="Value" RefId="8">
+                  <TNRef RefId="0" />
+                  <MS>
+                    <S N="NetVersion">v2.0.50727</S>
+                    <B N="SystemDefaultTlsVersions">true</B>
+                    <I32 N="SystemDefaultTlsVersionsValue">1</I32>
+                    <B N="SchUseStrongCrypto">true</B>
+                    <I32 N="SchUseStrongCryptoValue">1</I32>
+                    <S N="MicrosoftRegistryLocation">SOFTWARE\Microsoft\.NETFramework\v2.0.50727</S>
+                    <B N="WowSystemDefaultTlsVersions">true</B>
+                    <I32 N="WowSystemDefaultTlsVersionsValue">1</I32>
+                    <B N="WowSchUseStrongCrypto">true</B>
+                    <I32 N="WowSchUseStrongCryptoValue">1</I32>
+                    <S N="WowRegistryLocation">SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v2.0.50727</S>
+                    <B N="SdtvConfiguredCorrectly">true</B>
+                    <B N="SdtvEnabled">true</B>
+                  </MS>
+                </Obj>
+              </En>
+            </DCT>
+          </Obj>
+        </MS>
+      </Obj>
+      <S N="SecurityProtocol">Tls, Tls11, Tls12</S>
+      <Obj N="TlsCipherSuite" RefId="9">
+        <TN RefId="2">
+          <T>System.Object[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="10">
+            <TN RefId="3">
+              <T>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">ECDSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">0</U32>
+              <S N="Hash"></S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">256</U32>
+              <U32 N="BaseCipherSuite">49196</U32>
+              <U32 N="CipherSuite">49196</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384</S>
+              <Obj N="Protocols" RefId="11">
+                <TN RefId="4">
+                  <T>System.Collections.Generic.List`1[[System.UInt32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+                  <T>System.Object</T>
+                </TN>
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="12">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">ECDSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">0</U32>
+              <S N="Hash"></S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">128</U32>
+              <U32 N="BaseCipherSuite">49195</U32>
+              <U32 N="CipherSuite">49195</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256</S>
+              <Obj N="Protocols" RefId="13">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="14">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">RSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">0</U32>
+              <S N="Hash"></S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">256</U32>
+              <U32 N="BaseCipherSuite">49200</U32>
+              <U32 N="CipherSuite">49200</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384</S>
+              <Obj N="Protocols" RefId="15">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="16">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">RSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">0</U32>
+              <S N="Hash"></S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">128</U32>
+              <U32 N="BaseCipherSuite">49199</U32>
+              <U32 N="CipherSuite">49199</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256</S>
+              <Obj N="Protocols" RefId="17">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="18">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">ECDSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">384</U32>
+              <S N="Hash">SHA384</S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">256</U32>
+              <U32 N="BaseCipherSuite">49188</U32>
+              <U32 N="CipherSuite">49188</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384</S>
+              <Obj N="Protocols" RefId="19">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="20">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">ECDSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">256</U32>
+              <S N="Hash">SHA256</S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">128</U32>
+              <U32 N="BaseCipherSuite">49187</U32>
+              <U32 N="CipherSuite">49187</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256</S>
+              <Obj N="Protocols" RefId="21">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="22">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">RSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">384</U32>
+              <S N="Hash">SHA384</S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">256</U32>
+              <U32 N="BaseCipherSuite">49192</U32>
+              <U32 N="CipherSuite">49192</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384</S>
+              <Obj N="Protocols" RefId="23">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+          <Obj RefId="24">
+            <TNRef RefId="3" />
+            <ToString>Microsoft.WindowsAuthenticationProtocols.Commands.TlsCipherSuite</ToString>
+            <Props>
+              <U32 N="KeyType">0</U32>
+              <S N="Certificate">RSA</S>
+              <U32 N="MaximumExchangeLength">65536</U32>
+              <U32 N="MinimumExchangeLength">0</U32>
+              <S N="Exchange">ECDH</S>
+              <U32 N="HashLength">256</U32>
+              <S N="Hash">SHA256</S>
+              <U32 N="CipherBlockLength">16</U32>
+              <U32 N="CipherLength">128</U32>
+              <U32 N="BaseCipherSuite">49191</U32>
+              <U32 N="CipherSuite">49191</U32>
+              <S N="Cipher">AES</S>
+              <S N="Name">TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256</S>
+              <Obj N="Protocols" RefId="25">
+                <TNRef RefId="4" />
+                <LST>
+                  <U32>771</U32>
+                  <U32>65277</U32>
+                </LST>
+              </Obj>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -118,7 +118,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "SMB1 Installed" "True" -WriteType "Red"
             TestObjectMatch "SMB1 Blocked" "False" -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 62
+            $Script:ActiveGrouping.Count | Should -Be 69
         }
 
         It "Display Results - Security Vulnerability" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -122,7 +122,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Pattern service" "Unreachable`r`n`t`tMore information: https://aka.ms/HelpConnectivityEEMS" -WriteType "Yellow"
             TestObjectMatch "Telemetry enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 73
+            $Script:ActiveGrouping.Count | Should -Be 79
         }
 
         It "Display Results - Security Vulnerability" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
@@ -124,7 +124,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Pattern service" "200 - Reachable"
             TestObjectMatch "Telemetry enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 60
+            $Script:ActiveGrouping.Count | Should -Be 67
         }
 
         It "Display Results - Security Vulnerability" {
@@ -347,55 +347,14 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
         It "TLS Settings" {
             SetActiveDisplayGrouping "Security Settings"
-            $tlsSettings = GetObject "TLS Settings Group"
-            $tls10 = $tlsSettings | Where-Object { $_.TLSVersion.Value -eq "1.0" }
-            $tls11 = $tlsSettings | Where-Object { $_.TLSVersion.Value -eq "1.1" }
-            $tls12 = $tlsSettings | Where-Object { $_.TLSVersion.Value -eq "1.2" }
-
-            $tls10CompareObject = [PSCustomObject]@{
-                ServerEnabled = (NewOutColumnCompareValue $false)
-                ServerDbd     = (NewOutColumnCompareValue $true)
-                ClientEnabled = (NewOutColumnCompareValue $true)
-                ClientDbd     = (NewOutColumnCompareValue $true)
-                Configuration = (NewOutColumnCompareValue "Misconfigured" "Red")
-            }
-
-            $tls11CompareObject = [PSCustomObject]@{
-                ServerEnabled = (NewOutColumnCompareValue $true)
-                ServerDbd     = (NewOutColumnCompareValue $true)
-                ClientEnabled = (NewOutColumnCompareValue $false)
-                ClientDbd     = (NewOutColumnCompareValue $true)
-                Configuration = (NewOutColumnCompareValue "Misconfigured" "Red")
-            }
-
-            $tls12CompareObject = [PSCustomObject]@{
-                ServerEnabled = (NewOutColumnCompareValue $true)
-                ServerDbd     = (NewOutColumnCompareValue $false)
-                ClientEnabled = (NewOutColumnCompareValue $true)
-                ClientDbd     = (NewOutColumnCompareValue $false)
-                Configuration = (NewOutColumnCompareValue "Enabled" "Green")
-            }
-
-            TestOutColumnObjectCompare $tls10CompareObject $tls10
-
-            TestOutColumnObjectCompare $tls11CompareObject $tls11
-
-            TestOutColumnObjectCompare $tls12CompareObject $tls12
+            TestObjectMatch "TLS 1.0" "Misconfigured" -WriteType "Red"
+            TestObjectMatch "TLS 1.1" "Misconfigured" -WriteType "Red"
+            TestObjectMatch "TLS 1.2" "Enabled" -WriteType "Green"
+            TestObjectMatch "TLS 1.3" "Disabled" -WriteType "Green"
 
             TestObjectMatch "Display Link to Docs Page" "True" -WriteType "Yellow"
 
             TestObjectMatch "Detected TLS Mismatch Display More Info" "True" -WriteType "Yellow"
-
-            $netTlsSettings = (GetObject "NET TLS Settings Group") | Where-Object { $_.FrameworkVersion.Value -eq "NETv4" }
-
-            $netv4CompareObject = [PSCustomObject]@{
-                SystemDefaultTlsVersions            = (NewOutColumnCompareValue $false)
-                Wow6432NodeSystemDefaultTlsVersions = (NewOutColumnCompareValue $false)
-                SchUseStrongCrypto                  = (NewOutColumnCompareValue $false)
-                Wow6432NodeSchUseStrongCrypto       = (NewOutColumnCompareValue $false)
-            }
-
-            TestOutColumnObjectCompare $netv4CompareObject $netTlsSettings
 
             $tlsCipherSuite = (GetObject "TLS Cipher Suite Group")
             $tlsCipherSuite.Count | Should -Be 8

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
@@ -41,6 +41,8 @@ function Invoke-ExtendedProtectionTlsPrerequisitesCheck {
             foreach ($serverTls in $TlsSettingsList) {
                 $currentServer = $serverTls.ComputerName
                 $tlsSettings = $serverTls.Settings
+                # Removing TLS 1.3 here to avoid it being displayed
+                $tlsSettings.Registry.TLS.Remove("1.3")
                 $tlsRegistry = $tlsSettings.Registry.TLS
                 $netRegistry = $tlsSettings.Registry.NET
                 $listIndex = 0

--- a/Shared/TLS/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
+++ b/Shared/TLS/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
@@ -521,6 +521,81 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
         }
     }
 
+    Context "Testing TLS 1.3 Differences with NULL Check" {
+
+        BeforeAll {
+            $Script:tlsCompareObject = [PSCustomObject]@{
+                ServerEnabled                = $true
+                ServerEnabledValue           = $null
+                ClientEnabled                = $true
+                ClientEnabledValue           = $null
+                ServerDisabledByDefault      = $false
+                ServerDisabledByDefaultValue = $null
+                ClientDisabledByDefault      = $false
+                ClientDisabledByDefaultValue = $null
+                TLSConfiguration             = "Enabled"
+            }
+
+            $Script:tls13CompareObject = [PSCustomObject]@{
+                ServerEnabled                = $false
+                ServerEnabledValue           = $null
+                ClientEnabled                = $false
+                ClientEnabledValue           = $null
+                ServerDisabledByDefault      = $false
+                ServerDisabledByDefaultValue = $null
+                ClientDisabledByDefault      = $false
+                ClientDisabledByDefaultValue = $null
+                TLSConfiguration             = "Disabled"
+            }
+
+            $Script:netCompareObject = [PSCustomObject]@{
+                SystemDefaultTlsVersions    = $false
+                SchUseStrongCrypto          = $false
+                WowSystemDefaultTlsVersions = $false
+                WowSchUseStrongCrypto       = $false
+                SdtvConfiguredCorrectly     = $true
+                SdtvEnabled                 = $false
+            }
+
+            Mock Get-RemoteRegistryValue {
+                param (
+                    [string]$MachineName,
+                    [string]$SubKey,
+                    [string]$GetValue,
+                    [string]$ValueType,
+                    [scriptblock]$CatchActionFunction
+                )
+                return $null
+            }
+
+            SetVariables
+        }
+
+        It "TLS 1.0 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls10
+        }
+
+        It "TLS 1.1 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls11
+        }
+
+        It "TLS 1.2 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tls13CompareObject $tls13
+        }
+
+        It "NET v4 Testing Values" {
+            TestObjectCompare $Script:netCompareObject $netv4
+        }
+
+        It "NET v2 Testing Values" {
+            TestObjectCompare $Script:netCompareObject $netv2
+        }
+    }
+
     Context "Testing NET Settings Enabled" {
         BeforeAll {
             $Script:netCompareObject = [PSCustomObject]@{

--- a/Shared/TLS/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
+++ b/Shared/TLS/Tests/Get-AllTlsSettingsFromRegistry.Tests.ps1
@@ -11,9 +11,11 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
         $Script:tlsServer10 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server"
         $Script:tlsServer11 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server"
         $Script:tlsServer12 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server"
+        $Script:tlsServer13 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server"
         $Script:tlsClient10 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client"
         $Script:tlsClient11 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client"
         $Script:tlsClient12 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client"
+        $Script:tlsClient13 = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client"
         $Script:net4 = "SOFTWARE\Microsoft\.NETFramework\v4.0.30319"
         $Script:net4Wow = "SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319"
         $Script:net2 = "SOFTWARE\Microsoft\.NETFramework\v2.0.50727"
@@ -25,6 +27,7 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
             $Script:tls10 = $result.TLS["1.0"]
             $Script:tls11 = $result.TLS["1.1"]
             $Script:tls12 = $result.TLS["1.2"]
+            $Script:tls13 = $result.TLS["1.3"]
             $Script:netv4 = $result.NET["NETv4"]
             $Script:netv2 = $result.NET["NETv2"]
         }
@@ -65,6 +68,9 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                 } elseif ($SubKey -eq $Script:tlsServer12) {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
+                } elseif ($SubKey -eq $Script:tlsServer13) {
+                    if ($GetValue -eq $Script:enabledKey) { return 1 }
+                    return 0
                 } elseif ($SubKey -eq $Script:tlsClient10) {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
@@ -72,6 +78,9 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
                 } elseif ($SubKey -eq $Script:tlsClient12) {
+                    if ($GetValue -eq $Script:enabledKey) { return 1 }
+                    return 0
+                } elseif ($SubKey -eq $Script:tlsClient13) {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
                 } elseif ($SubKey -eq $Script:net4) {
@@ -117,6 +126,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
 
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
         }
 
         It "NET v4 Testing Values" {
@@ -165,6 +178,9 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                 } elseif ($SubKey -eq $Script:tlsServer12) {
                     if ($GetValue -eq $Script:enabledKey) { return 0 }
                     return 1
+                } elseif ($SubKey -eq $Script:tlsServer13) {
+                    if ($GetValue -eq $Script:enabledKey) { return 0 }
+                    return 1
                 } elseif ($SubKey -eq $Script:tlsClient10) {
                     if ($GetValue -eq $Script:enabledKey) { return 0 }
                     return 1
@@ -172,6 +188,9 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     if ($GetValue -eq $Script:enabledKey) { return 0 }
                     return 1
                 } elseif ($SubKey -eq $Script:tlsClient12) {
+                    if ($GetValue -eq $Script:enabledKey) { return 0 }
+                    return 1
+                } elseif ($SubKey -eq $Script:tlsClient13) {
                     if ($GetValue -eq $Script:enabledKey) { return 0 }
                     return 1
                 } elseif ($SubKey -eq $Script:net4) {
@@ -200,6 +219,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
 
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
         }
 
         It "NET v4 Testing Values" {
@@ -246,6 +269,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
         }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
+        }
     }
 
     Context "Testing TLS Half Disabled - Part 2" {
@@ -283,6 +310,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
         }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
+        }
     }
 
     Context "Testing TLS Misconfigured - Part 1" {
@@ -309,11 +340,15 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     return 1
                 } elseif ($SubKey -eq $Script:tlsServer12) {
                     return 1
+                } elseif ($SubKey -eq $Script:tlsServer13) {
+                    return 1
                 } elseif ($SubKey -eq $Script:tlsClient10) {
                     return 0
                 } elseif ($SubKey -eq $Script:tlsClient11) {
                     return 0
                 } elseif ($SubKey -eq $Script:tlsClient12) {
+                    return 0
+                } elseif ($SubKey -eq $Script:tlsClient13) {
                     return 0
                 } elseif ($SubKey -eq $Script:net4) {
                     return 1
@@ -341,6 +376,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
 
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
         }
     }
 
@@ -368,11 +407,15 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     return 0
                 } elseif ($SubKey -eq $Script:tlsServer12) {
                     return 0
+                } elseif ($SubKey -eq $Script:tlsServer13) {
+                    return 0
                 } elseif ($SubKey -eq $Script:tlsClient10) {
                     return 1
                 } elseif ($SubKey -eq $Script:tlsClient11) {
                     return 1
                 } elseif ($SubKey -eq $Script:tlsClient12) {
+                    return 1
+                } elseif ($SubKey -eq $Script:tlsClient13) {
                     return 1
                 } elseif ($SubKey -eq $Script:net4) {
                     return 1
@@ -400,6 +443,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
 
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
         }
     }
 
@@ -427,6 +474,8 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     return 1
                 } elseif ($SubKey -eq $Script:tlsServer12) {
                     return 1
+                } elseif ($SubKey -eq $Script:tlsServer13) {
+                    return 1
                 } elseif ($SubKey -eq $Script:tlsClient10) {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
@@ -434,6 +483,9 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
                 } elseif ($SubKey -eq $Script:tlsClient12) {
+                    if ($GetValue -eq $Script:enabledKey) { return 1 }
+                    return 0
+                } elseif ($SubKey -eq $Script:tlsClient13) {
                     if ($GetValue -eq $Script:enabledKey) { return 1 }
                     return 0
                 } elseif ($SubKey -eq $Script:net4) {
@@ -462,6 +514,10 @@ Describe "Testing Get-AllTlsSettingsFromRegistry.ps1" {
 
         It "TLS 1.2 Testing Values" {
             TestObjectCompare $Script:tlsCompareObject $tls12
+        }
+
+        It "TLS 1.3 Testing Values" {
+            TestObjectCompare $Script:tlsCompareObject $tls13
         }
     }
 

--- a/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
+++ b/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
@@ -1,6 +1,8 @@
 # TLS Configuration Check
 
-We check and validate Exchange servers TLS 1.0 - 1.2 configuration. We can detect mismatches in TLS versions for client and server. This is important because Exchange can be both a client and a server.
+We check and validate Exchange servers TLS 1.0 - 1.3 configuration. We can detect mismatches in TLS versions for client and server. This is important because Exchange can be both a client and a server.
+
+At this time TLS 1.3 is **not** supported by Exchange and has been known to cause issues if enabled. If detected to be anything but disabled on Exchange, it will be thrown as an error and needs to be addressed right away.
 
 We also check for the SystemDefaultTlsVersions registry value which controls if .NET Framework will inherit its defaults from the Windows Schannel DisabledByDefault registry values or not.
 
@@ -27,6 +29,8 @@ The location where we are checking for the TLS values are here:
 `SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server`
 `SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client`
 `SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Server`
+`SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client`
+`SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server`
 
 At each location, we are looking at the value of `Enabled` and `DisabledByDefault`. If the key isn't present, `Enabled` is set to `true` and `DisabledByDefault` is set to `false`.
 


### PR DESCRIPTION
**Issue:**
Multiple customers have been trying to enable TLS 1.3 lately and causing issues with Exchange. Currently TLS 1.3 is not supported by Exchange and is not supported by Windows unless on Server 2022. 

**Reason:**
Not supported yet, and customer have been trying to enable it. 

**Fix:**
Include data collection for TLS 1.3 key and make sure they are not yet enabled on the Exchange Server. 
Also updated the TLS display to allow for a better display of where the key/values are.

![image](https://user-images.githubusercontent.com/22776718/186475705-4ae67fe3-807e-45e8-acb1-4267049d4ad7.png)

![image](https://user-images.githubusercontent.com/22776718/186475767-6850e0fb-9cac-4536-88af-c01b6c9468c8.png)

Resolved #1181
Resolved #1153 

**Validation:**
Lab tested 

