### PR TITLE
Use Out-Columns for registry display

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -50,6 +50,7 @@ begin {
     . $PSScriptRoot\..\..\..\Shared\Confirm-Administrator.ps1
     . $PSScriptRoot\..\..\..\Shared\Confirm-ExchangeShell.ps1
     . $PSScriptRoot\..\..\..\Shared\LoggerFunctions.ps1
+    . $PSScriptRoot\..\..\..\Shared\Out-Columns.ps1
     . $PSScriptRoot\..\..\..\Shared\Show-Disclaimer.ps1
     . $PSScriptRoot\..\..\..\Shared\Write-Host.ps1
     $includeExchangeServerNames = New-Object 'System.Collections.Generic.List[string]'
@@ -289,10 +290,12 @@ begin {
                                 $displayObject += NewDisplayObject "SystemTlsVersions" -Location $_.WowRegistryLocation -Value $_.WowSystemDefaultTlsVersionsValue
                                 $displayObject += NewDisplayObject "SchUseStrongCrypto" -Location $_.WowRegistryLocation -Value $_.WowSchUseStrongCryptoValue
                             }
+                        $stringOutput = [string]::Empty
+                        SetWriteHostAction $null
                         $displayObject | Sort-Object Location, RegistryName |
-                            Format-Table |
-                            Out-String |
-                            Write-Host
+                            Out-Columns -StringOutput ([ref]$stringOutput)
+                        Write-HostLog $stringOutput
+                        SetWriteHostAction ${Function:Write-HostLog}
                     }
 
                     # If TLS Prerequisites Check passed, then we are good to go.


### PR DESCRIPTION
**Issue:**
On 2013 EMS when running the script, the registry locations are truncated. 

**Fix:**
Use Out-Columns.
Out-Columns allows for default 2013 EMS sizing to not truncate the displayed line

![image](https://user-images.githubusercontent.com/22776718/186936830-ba35124b-b30c-4e1c-8183-cf4b5c2fb98a.png)


Resolved #1198 

**Validation:**
Lab Tested 

