### PR TITLE
Require EMS for Extended Protection

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -84,8 +84,12 @@ begin {
             $Script:SkipEWS = $false
         }
 
-        if (-not((Confirm-ExchangeShell -Identity $env:COMPUTERNAME).ShellLoaded)) {
+        $exchangeShell = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+        if (-not($exchangeShell.ShellLoaded)) {
             Write-Warning "Failed to load the Exchange Management Shell. Start the script using the Exchange Management Shell."
+            exit
+        } elseif (-not ($exchangeShell.EMS)) {
+            Write-Warning "This script requires to be run inside of Exchange Management Shell. Please run on an Exchange Management Server or an Exchange Server with Exchange Management Shell."
             exit
         }
 


### PR DESCRIPTION
**Issue:**
Customer reported an issue with the script erroring out due to `$outlookAnywhere = $outlookAnywhereServers | Get-OutlookAnywhere -ErrorAction SilentlyContinue` wasn't finding the objects in AD. This was because prior to the pipeline, the object was getting changed to be a `string`. 

Turns out if you are connected remotely, this causes that problem. 

**Fix:**
Force `ExchnageExtendedProtectionManagement` to use a session that is in `EMS`. 

**Validation:**
Lab tested

