### PR TITLE
Add Server Setting Overrides to Health Checker

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -308,6 +308,27 @@ function Invoke-AnalyzerExchangeInformation {
         Add-AnalyzedResultInformation @params
     }
 
+    if ($null -ne $exchangeInformation.SettingOverrides) {
+
+        $overridesDetected = $null -ne $exchangeInformation.SettingOverrides.SettingOverrides
+        $params = $baseParams + @{
+            Name    = "Setting Overrides Detected"
+            Details = $overridesDetected
+        }
+        Add-AnalyzedResultInformation @params
+
+        if ($overridesDetected) {
+            $params = $baseParams + @{
+                OutColumns = ([PSCustomObject]@{
+                        DisplayObject = $exchangeInformation.SettingOverrides.SimpleSettingOverrides
+                        IndentSpaces  = 12
+                    })
+                HtmlName   = "Setting Overrides"
+            }
+            Add-AnalyzedResultInformation @params
+        }
+    }
+
     Write-Verbose "Working on Exchange Server Maintenance"
     $serverMaintenance = $exchangeInformation.ServerMaintenance
     $getMailboxServer = $exchangeInformation.GetMailboxServer

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -4,6 +4,7 @@
 . $PSScriptRoot\..\..\..\..\Security\src\ExchangeExtendedProtectionManagement\DataCollection\Get-ExtendedProtectionConfiguration.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ErrorMonitorFunctions.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-ExchangeBuildVersionInformation.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-ExchangeSettingOverride.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\Get-ExchangeAdPermissions.ps1
 . $PSScriptRoot\Get-ExchangeAdSchemaClass.ps1
@@ -530,6 +531,7 @@ function Get-ExchangeInformation {
 
         $exchangeInformation.RegistryValues = Get-ExchangeRegistryValues -MachineName $Script:Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $exchangeInformation.ServerMaintenance = Get-ExchangeServerMaintenanceState -ComponentsToSkip "ForwardSyncDaemon", "ProvisioningRps"
+        $exchangeInformation.SettingOverrides = Get-ExchangeSettingOverride -Server $Script:Server -CatchActionFunction ${Function:Invoke-CatchActions}
 
         if (($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess) -and
             ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::None)) {

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -44,6 +44,7 @@ using System.Collections;
             public Hashtable ApplicationConfigFileStatus = new Hashtable();
             public object DependentServices; // store the results for the dependent services of Exchange.
             public object IISSettings;  //Stores the IISConfigurationSettings, applicationHostConfig and IISModulesInformation
+            public object SettingOverrides; //Stores the information regarding the Exchange Setting Overrides on the server.
         }
 
         public class ExchangeBuildInformation

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeSettingOverride.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeSettingOverride.xml
@@ -1,0 +1,20 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Server">ADT-E19A</S>
+      <S N="LastUpdated">2022-08-31T15:21:00.0167306Z</S>
+      <Nil N="SettingOverrides" />
+      <Obj N="SimpleSettingOverrides" RefId="1">
+        <TN RefId="1">
+          <T>System.Collections.Generic.List`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeSettingOverride.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeSettingOverride.xml
@@ -1,0 +1,20 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Server">ADT-E19A</S>
+      <S N="LastUpdated">2022-08-31T15:21:00.0167306Z</S>
+      <Nil N="SettingOverrides" />
+      <Obj N="SimpleSettingOverrides" RefId="1">
+        <TN RefId="1">
+          <T>System.Collections.Generic.List`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeSettingOverride.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeSettingOverride.xml
@@ -1,0 +1,20 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Server">ADT-E19A</S>
+      <S N="LastUpdated">2022-08-31T15:21:00.0167306Z</S>
+      <Nil N="SettingOverrides" />
+      <Obj N="SimpleSettingOverrides" RefId="1">
+        <TN RefId="1">
+          <T>System.Collections.Generic.List`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeSettingOverride1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeSettingOverride1.xml
@@ -1,0 +1,465 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Server">VNext-E19A</S>
+      <S N="LastUpdated">2022-08-31T14:57:00.8458197Z</S>
+      <Obj N="SettingOverrides" RefId="1">
+        <TN RefId="1">
+          <T>System.Object[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="2">
+            <TN RefId="2">
+              <T>System.Xml.XmlElement</T>
+              <T>System.Xml.XmlLinkedNode</T>
+              <T>System.Xml.XmlNode</T>
+              <T>System.Object</T>
+            </TN>
+            <IE>
+              <Obj RefId="3">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="4">
+                    <TN RefId="3">
+                      <T>System.Xml.XmlText</T>
+                      <T>System.Xml.XmlCharacterData</T>
+                      <T>System.Xml.XmlLinkedNode</T>
+                      <T>System.Xml.XmlNode</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Improve Discovery Settings</S>
+                </Props>
+              </Obj>
+              <Obj RefId="5">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="6">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Testing Mutliple</S>
+                </Props>
+              </Obj>
+              <Obj RefId="7">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="8">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">VNext.local/Users/Han</S>
+                </Props>
+              </Obj>
+              <Obj RefId="9">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="10">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnel</S>
+                </Props>
+              </Obj>
+              <Obj RefId="11">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="12">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnelDiscoveryQuerySettings</S>
+                </Props>
+              </Obj>
+              <Obj RefId="13">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="14">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Accepted</S>
+                </Props>
+              </Obj>
+              <Obj RefId="15">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="16">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+                </Props>
+              </Obj>
+              <Obj RefId="17">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="18">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="19">
+                        <TNRef RefId="3" />
+                        <ToString>#text</ToString>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <S N="#text">StoreRetryCount=5</S>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="20">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="21">
+                        <TNRef RefId="3" />
+                        <ToString>#text</ToString>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <S N="#text">NoSearchFolder=false</S>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="22">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="23">
+                        <TNRef RefId="3" />
+                        <ToString>#text</ToString>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <S N="#text">StoreDiagnosticLevel=5</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <Obj N="Parameter" RefId="24">
+                    <TNRef RefId="1" />
+                    <LST>
+                      <S>StoreRetryCount=5</S>
+                      <S>NoSearchFolder=false</S>
+                      <S>StoreDiagnosticLevel=5</S>
+                    </LST>
+                  </Obj>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <S N="Name">Improve Discovery Settings</S>
+              <S N="Reason">Testing Mutliple</S>
+              <S N="ModifiedBy">VNext.local/Users/Han</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelDiscoveryQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <S N="Message">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+              <Ref N="Parameters" RefId="17" />
+            </Props>
+          </Obj>
+          <Obj RefId="25">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="26">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="27">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Update Timer</S>
+                </Props>
+              </Obj>
+              <Obj RefId="28">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="29">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Update timer</S>
+                </Props>
+              </Obj>
+              <Obj RefId="30">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="31">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">VNext.local/Users/Han</S>
+                </Props>
+              </Obj>
+              <Obj RefId="32">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="33">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnel</S>
+                </Props>
+              </Obj>
+              <Obj RefId="34">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="35">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnelFailedItemsQuerySettings</S>
+                </Props>
+              </Obj>
+              <Obj RefId="36">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="37">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Accepted</S>
+                </Props>
+              </Obj>
+              <Obj RefId="38">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="39">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+                </Props>
+              </Obj>
+              <Obj RefId="40">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="41">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="42">
+                        <TNRef RefId="3" />
+                        <ToString>#text</ToString>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <S N="#text">BigFunnelFailedItemsFolderSearchTimeout=00:01:00</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="Parameter">BigFunnelFailedItemsFolderSearchTimeout=00:01:00</S>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <S N="Name">Update Timer</S>
+              <S N="Reason">Update timer</S>
+              <S N="ModifiedBy">VNext.local/Users/Han</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelFailedItemsQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <S N="Message">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+              <Ref N="Parameters" RefId="40" />
+            </Props>
+          </Obj>
+          <Obj RefId="43">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="44">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="45">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Big Funnel Permanent Retry</S>
+                </Props>
+              </Obj>
+              <Obj RefId="46">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="47">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Re-Index Messages</S>
+                </Props>
+              </Obj>
+              <Obj RefId="48">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="49">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">VNext.local/Users/Han</S>
+                </Props>
+              </Obj>
+              <Obj RefId="50">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="51">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnel</S>
+                </Props>
+              </Obj>
+              <Obj RefId="52">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="53">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">BigFunnelFailedItemsQuerySettings</S>
+                </Props>
+              </Obj>
+              <Obj RefId="54">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="55">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">Accepted</S>
+                </Props>
+              </Obj>
+              <Obj RefId="56">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="57">
+                    <TNRef RefId="3" />
+                    <ToString>#text</ToString>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="#text">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+                </Props>
+              </Obj>
+              <Obj RefId="58">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="59">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="60">
+                        <TNRef RefId="3" />
+                        <ToString>#text</ToString>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <S N="#text">ExcludePermanentFailures=false</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <S N="Parameter">ExcludePermanentFailures=false</S>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <S N="Name">Big Funnel Permanent Retry</S>
+              <S N="Reason">Re-Index Messages</S>
+              <S N="ModifiedBy">VNext.local/Users/Han</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelFailedItemsQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <S N="Message">This override synced to the server but whether it applies to the services running on this server depends on the override parameters, current configuration and the context.</S>
+              <Ref N="Parameters" RefId="58" />
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="SimpleSettingOverrides" RefId="61">
+        <TN RefId="4">
+          <T>System.Collections.Generic.List`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="62">
+            <TNRef RefId="0" />
+            <MS>
+              <S N="Name">Improve Discovery Settings</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelDiscoveryQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <Obj N="Parameters" RefId="63">
+                <TNRef RefId="1" />
+                <LST>
+                  <S>StoreRetryCount=5</S>
+                  <S>NoSearchFolder=false</S>
+                  <S>StoreDiagnosticLevel=5</S>
+                </LST>
+              </Obj>
+            </MS>
+          </Obj>
+          <Obj RefId="64">
+            <TNRef RefId="0" />
+            <MS>
+              <S N="Name">Update Timer</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelFailedItemsQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <S N="Parameters">BigFunnelFailedItemsFolderSearchTimeout=00:01:00</S>
+            </MS>
+          </Obj>
+          <Obj RefId="65">
+            <TNRef RefId="0" />
+            <MS>
+              <S N="Name">Big Funnel Permanent Retry</S>
+              <S N="ComponentName">BigFunnel</S>
+              <S N="SectionName">BigFunnelFailedItemsQuerySettings</S>
+              <S N="Status">Accepted</S>
+              <S N="Parameters">ExcludePermanentFailures=false</S>
+            </MS>
+          </Obj>
+        </LST>
+      </Obj>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -33,7 +33,8 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "MAPI Front End App Pool GC Mode" "Workstation --- Warning" -WriteType "Yellow"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 15
+            TestObjectMatch "Setting Overrides Detected" $false
+            $Script:ActiveGrouping.Count | Should -Be 16
         }
 
         It "Display Results - Operating System Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -34,7 +34,8 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "Exchange Server Maintenance" "Server is not in Maintenance Mode" -WriteType "Green"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 12
+            TestObjectMatch "Setting Overrides Detected" $false
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
 
         It "Display Results - Operating System Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Tests.ps1
@@ -35,7 +35,8 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "MRS Proxy Enabled" "False"
             TestObjectMatch "Exchange Server Maintenance" "Server is not in Maintenance Mode" -WriteType "Green"
             TestObjectMatch "Internet Web Proxy" "Not Set"
-            $Script:ActiveGrouping.Count | Should -Be 12
+            TestObjectMatch "Setting Overrides Detected" $false
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
 
         It "Display Results - Operating System Information" {
@@ -255,6 +256,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-ReceiveConnector -Exactly 1
             Assert-MockCalled Get-SendConnector -Exactly 1
             Assert-MockCalled Get-IISModules -Exactly 1
+            Assert-MockCalled Get-ExchangeSettingOverride -Exactly 1
         }
     }
 
@@ -272,6 +274,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Mock Get-HttpProxySetting { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetHttpProxySetting1.xml" }
             Mock Get-AcceptedDomain { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetAcceptedDomain_Problem.xml" }
             Mock Get-ExchangeIISConfigSettings { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeIISConfigSettings1.xml" }
+            Mock Get-ExchangeSettingOverride { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeSettingOverride1.xml" }
             Mock Get-Service {
                 param(
                     [string]$ComputerName,
@@ -292,6 +295,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Critical Pla" ($displayFormat -f "pla", "Stopped", "Manual") -WriteType "Red"
             TestObjectMatch "Critical HostControllerService" ($displayFormat -f "HostControllerService", "Stopped", "Disabled") -WriteType "Red"
             TestObjectMatch "Common MSExchangeDagMgmt" ($displayFormat -f "MSExchangeDagMgmt", "Stopped", "Automatic") -WriteType "Yellow"
+            TestObjectMatch "Setting Overrides Detected" $true
         }
 
         It "Http Proxy Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -157,6 +157,10 @@ Mock Get-IISModules {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetIISModules.xml"
 }
 
+Mock Get-ExchangeSettingOverride {
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeSettingOverride.xml"
+}
+
 # Do nothing
 Mock Invoke-CatchActions { }
 

--- a/Shared/Get-ExchangeSettingOverride.ps1
+++ b/Shared/Get-ExchangeSettingOverride.ps1
@@ -1,0 +1,60 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Invoke-CatchActionError.ps1
+
+function Get-ExchangeSettingOverride {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Server,
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$CatchActionFunction
+    )
+
+    begin {
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        $updatedTime = [DateTime]::MinValue
+        $settingOverrides = $null
+        $simpleSettingOverrides = New-Object 'System.Collections.Generic.List[object]'
+    }
+    process {
+        try {
+            $params = @{
+                Process     = "Microsoft.Exchange.Directory.TopologyService"
+                Component   = "VariantConfiguration"
+                Argument    = "Overrides"
+                Server      = $Server
+                ErrorAction = "Stop"
+            }
+            $diagnosticInfo = Get-ExchangeDiagnosticInfo @params
+            Write-Verbose "Successfully got the Exchange Diagnostic Information"
+            $xml = [xml]$diagnosticInfo.Result
+            $overrides = $xml.Diagnostics.Components.VariantConfiguration.Overrides
+            $updatedTime = $overrides.Updated
+            $settingOverrides = $overrides.SettingOverride
+
+            foreach ($override in $settingOverrides) {
+                Write-Verbose "Working on $($override.Name)"
+                $simpleSettingOverrides.Add([PSCustomObject]@{
+                        Name          = $override.Name
+                        ComponentName = $override.ComponentName
+                        SectionName   = $override.SectionName
+                        Status        = $override.Status
+                        Parameters    = $override.Parameters.Parameter
+                    })
+            }
+        } catch {
+            Write-Verbose "Failed to get the Exchange setting override"
+            Invoke-CatchActionError $CatchActionFunction
+        }
+    }
+    end {
+        return [PSCustomObject]@{
+            Server                 = $Server
+            LastUpdated            = $updatedTime
+            SettingOverrides       = $settingOverrides
+            SimpleSettingOverrides = $simpleSettingOverrides
+        }
+    }
+}


### PR DESCRIPTION
**Reason:**
Need to know what server setting overrides are on the server to understand the configuration better of Exchange.

Placed the `Get-ExchangeSettingOverride` in `Shared` because it can be used in other scripts, like `Troubleshoot-ModernSearch` to assist with some of those issues. 

**Validation:**
Lab tested

