### PR TITLE
Fixed bug with ShouldNotBeIndexed status being shown

### DIFF
--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexStateOfMessage.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-IndexStateOfMessage.ps1
@@ -17,7 +17,7 @@ function Get-IndexStateOfMessage {
     process {
 
         <#
-            ShouldNotBeIndexed - If BigFunnelPoiNotNeededReason (p365A0003) has any value besides 0
+            ShouldNotBeIndexed - If BigFunnelPoiNotNeededReason (p365A0003) has any value besides 0 besides NULL
             Indexed - If BigFunnelPOISize has value and BigFunnelPOIIsUpToDate (p3655000B) is set to true
                       while IsPartiallyIndexed property is not set to NULL or False
             PartiallyIndexed -  If BigFunnelPOISize has value and BigFunnelPOIIsUpToDate (p3655000B) is set to true
@@ -26,7 +26,8 @@ function Get-IndexStateOfMessage {
             Corrupted - If BigFunnelPOISize is NULL or a value of 0 and BigFunnelPOIIsUpToDate (p3655000B) is set to True
             Stale - If BigFunnelPOISize has a value and BigFunnelPOIIsUpToDate (p3655000B) is set to NULL or False
         #>
-        if ($Message.p365A0003 -gt 0) {
+        if ($Message.p365A0003 -gt 0 -and
+            $Message.p365A0003.ToString() -ne "NULL") {
             $status = "ShouldNotBeIndexed"
         } elseif ($Message.BigFunnelPOISize -gt 0 -and
             $Message.BigFunnelPOISize -ne "NULL" -and


### PR DESCRIPTION
**Reason:**
Incorrectly detecting the message index status as `ShouldNotBeIndexed` when it should be `NotIndexed`

**Validation:**
lab tested

