### PR TITLE
Always use UTC for build number

### DIFF
--- a/.build/BuildFunctions/Get-FileMostRecentCommit.ps1
+++ b/.build/BuildFunctions/Get-FileMostRecentCommit.ps1
@@ -19,7 +19,7 @@ function Get-FileMostRecentCommit {
     }
 
     try {
-        $commitTime = [DateTime]::Parse((git log -n 1 --format="%ad" --date=rfc $File))
+        $commitTime = [DateTime]::Parse((git log -n 1 --format="%ad" --date=rfc $File)).ToUniversalTime()
         Write-Verbose "Commit time $commitTime for file $File"
         return $commitTime
     } catch {


### PR DESCRIPTION
We use time-based build numbers which come from the latest commit for the script. The git log command which produces the time shows the time with time zone included.

```
❯ git log -n 1 --format="%ad" --date=rfc
Wed, 14 Sep 2022 16:10:35 -0500
```

We then [DateTime]::Parse(), this value. This produces a DateTime with type Local. So then we call DateTime.ToString(). At that point we're producing a string representing the local time. This causes the build number to change dependiing on the time zone of the machine.

With this change we always return a Universal time type, so build numbers are consistent across machines.