### PR TITLE
Do not lose characters due to wrap

### DIFF
--- a/Shared/Out-Columns.ps1
+++ b/Shared/Out-Columns.ps1
@@ -73,7 +73,7 @@ function Out-Columns {
                                 [void]$lines.Add($split[$i])
                             } else {
                                 [void]$lines.Add($split[$i].Substring(0, $width))
-                                $split[$i] = $split[$i].Substring($width + 1)
+                                $split[$i] = $split[$i].Substring($width)
                                 $i--
                             }
                         }


### PR DESCRIPTION
Fixes #1239

We were incorrectly incrementing the index by 1 when getting a substring. This only occurred in the scenario where we are forced to wrap without a word break.

Before:

![image](https://user-images.githubusercontent.com/4518572/191069111-1cff7736-8ac3-4cd5-b2bf-804f0cb9e4ed.png)

After:

![image](https://user-images.githubusercontent.com/4518572/191069173-8f07fb8a-00d2-4125-a9a6-0bef006b04a7.png)
