### PR TITLE
Fix to properly detect Azure certificates issued by MS-Organization-P2P-Access [YYYY] 

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -59,7 +59,7 @@ function Get-ExchangeServerCertificates {
         # These certificates can be deleted. The Azure VM Agent re-creates certificates if needed.
         # https://docs.microsoft.com/azure/virtual-machines/extensions/features-windows
         $certificatesToExclude = @(
-            NewCertificateExclusionEntry "CN=MS-Organization-P2P-Access \[[12][0-9]{3}\]$" $true
+            NewCertificateExclusionEntry "CN=MS-Organization-P2P-Access \[[12][0-9]{3}\]$" $false
             NewCertificateExclusionEntry "DC=Windows Azure CRP Certificate Generator" $true
         )
         Write-Verbose "Trying to receive certificates from Exchange server: $($Script:Server)"


### PR DESCRIPTION
**Issue:**
The certificate with the short life cycle of 24 hours wasn't properly excluded.
Resolve #1245 

**Reason:**
It's not a self-signed certificate. It's issued by the `MS-Organization-P2P-Access [YYYY]` CA

**Fix:**
Flipped isSelfSigned from `$true` to `$false`


