### PR TITLE
Fix unordered list rendering

### DIFF
--- a/docs/Security/EOMTv2.md
+++ b/docs/Security/EOMTv2.md
@@ -3,6 +3,7 @@
 Download the latest release: [EOMTv2.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/EOMTv2.ps1)
 
 The Exchange On-premises Mitigation Tool v2 script (EOMTv2.ps1) can be used to mitigate **CVE-2022-41040**. This script does the following:
+
 - Check for the latest version of EOMTv2.ps1 and download it.
 - Mitigate against current known attacks using **CVE-2022-41040** via a URL Rewrite configuration
 


### PR DESCRIPTION
This list currently does not render properly:

![image](https://user-images.githubusercontent.com/4518572/193869510-afbb9a51-91f7-40cf-8cc2-0a10d38f9af4.png)

It needs to be preceded by a blank line to be recognized as a list by the docs markdown parser.