### PR TITLE
Updated Mitigation for ProxyNoShell

### DIFF
--- a/Security/src/EOMTv2.ps1
+++ b/Security/src/EOMTv2.ps1
@@ -190,7 +190,7 @@ function Run-Mitigate {
     }
 
     #Configure Rewrite Rule consts
-    $HttpRequestInput = '{REQUEST_URI}'
+    $HttpRequestInput = '{UrlDecode:{REQUEST_URI}}
     $root = 'system.webServer/rewrite/rules'
     $inbound = '.*'
     $name = 'PowerShell - inbound'
@@ -457,7 +457,7 @@ Microsoft saved several files to your system to "$EOMTv2Dir". The only files tha
                 <rule name="PowerShell - inbound">
                     <match url=".*" />
                     <conditions>
-                        <add input="{REQUEST_URI}" pattern=".*autodiscover\.json.*Powershell.*" />
+                        <add input="{UrlDecode:{REQUEST_URI}}" pattern=".*autodiscover\.json.*Powershell.*" />
                     </conditions>
                     <action type="AbortRequest" />
                 </rule>


### PR DESCRIPTION


**Issue:**
The Current versions mitigations can be bypassed by using UrlEncoding.

**Reason:**
The current URI Request filtering is inadequate and easily bypassed.

**Fix:**
This fixes that bypass by adding {UrlDecode:{REQUEST_URI}} as the rule type vs simply {REQUEST_URI}

**Validation:**
https://twitter.com/GossiTheDog/status/1577685200825470976?s=20&t=yUCsH7dhssr6azzrlZ8wfw

