### PR TITLE
Match the EEMS rule, which does not have a space

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
@@ -49,14 +49,14 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
                 foreach ($rule in $rules.rule) {
                     if ($defaultWebSite -and $rule.conditions.add.pattern -eq $verifyPattern) {
                         # Custom Response or AbortRequest should both work to prevent the security hole
-                        # Input must be {UrlDecode: {REQUEST_URI}}
+                        # Input must be {UrlDecode:{REQUEST_URI}}
                         # match type must be pattern
                         # stop processing should be set otherwise, more logic would need to be in place. If only 1 rule, then we are fine
                         # pattern is always going to be set if found. If foundSecureRule isn't set, then something is wrong with the config
                         Write-Verbose "Found valid pattern for mitigation"
                         $validAction = $rule.action.type -eq "AbortRequest" -or
                         $rule.action.type -eq "CustomResponse"
-                        $validConditionsInput = $rule.conditions.add.input -eq "{UrlDecode: {REQUEST_URI}}"
+                        $validConditionsInput = $rule.conditions.add.input -eq "{UrlDecode:{REQUEST_URI}}"
                         $validPatternSyntax = $rule.patternSyntax -ne "Wildcard"
                         $validMatchUrl = $rule.match.url -eq ".*"
                         $stopProcessing = $rule.stopProcessing -eq "true" -or $rules.rule.count -eq 1

--- a/Security/src/EOMTv2.ps1
+++ b/Security/src/EOMTv2.ps1
@@ -190,7 +190,7 @@ function Run-Mitigate {
     }
 
     #Configure Rewrite Rule consts
-    $HttpRequestInput = '{UrlDecode: {REQUEST_URI}}'
+    $HttpRequestInput = '{UrlDecode:{REQUEST_URI}}'
     $root = 'system.webServer/rewrite/rules'
     $inbound = '.*'
     $name = 'PowerShell - inbound'
@@ -457,7 +457,7 @@ Microsoft saved several files to your system to "$EOMTv2Dir". The only files tha
                 <rule name="PowerShell - inbound">
                     <match url=".*" />
                     <conditions>
-                        <add input="{UrlDecode: {REQUEST_URI}}" pattern=".*autodiscover\.json.*Powershell.*" />
+                        <add input="{UrlDecode:{REQUEST_URI}}" pattern=".*autodiscover\.json.*Powershell.*" />
                     </conditions>
                     <action type="AbortRequest" />
                 </rule>


### PR DESCRIPTION
When a server has the mitigation automatically applied by EEMS, there is no space in the rule. Therefore, the scripts conclude that the server is not properly mitigated.