### PR TITLE
Call out broken web.config files for Cve-2022-41040

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\..\Add-AnalyzedResultInformation.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ErrorMonitorFunctions.ps1
 function Invoke-AnalyzerSecurityCve-2022-41040 {
     [CmdletBinding()]
     param(
@@ -27,9 +28,19 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
         $verifyPattern = ".*autodiscover\.json.*Powershell.*"
         $foundSecureRuleDefaultWebSite = $false
         $anyClearSetOnHttpProxy = $false
+        $failedToConvertList = @()
         $clearSetOnList = @()
         $iisRewriteRules = $SecurityObject.ExchangeInformation.IISSettings.IISConfigurationSettings |
-            Where-Object { $null -ne ([xml]$_.Content).configuration.'system.webServer'.rewrite.rules }
+            Where-Object {
+                try {
+                    $location = $_.Location
+                    $null -ne ([xml]$_.Content).configuration.'system.webServer'.rewrite.rules
+                } catch {
+                    Write-Verbose "Failed to convert $location to XML"
+                    $failedToConvertList += $location
+                    Invoke-CatchActions
+                }
+            }
 
         if ($null -ne $iisRewriteRules) {
             foreach ($config in $iisRewriteRules) {
@@ -80,6 +91,8 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
             $details = "CVE-2022-41040`r`n`t`tRule is present on Default Web Site, however, the following configuration files are ignoring the rule. $([string]::Join("," ,$clearSetOnList)).`r`n`t`tSelect 'Revert to Parent' in URL Rewrite of IIS Manager to address this."
         } elseif (-not $foundSecureRuleDefaultWebSite) {
             $details = "CVE-2022-41040`r`n`t`tPlease run the EOMTv2 script from: https://aka.ms/EOMTv2"
+        } elseif ($failedToConvertList.Count -gt 0) {
+            $details = "CVE-2022-41040`r`n`t`tUnknown - Failed to determine the configuration of the following files when trying to convert to XML type: $([string]::Join("," ,$failedToConvertList))`r`n`t`tAddress this as soon as possible, as this app pool might not be working properly."
         } else {
             Write-Verbose "Mitigation applied for CVE-2022-41040"
         }


### PR DESCRIPTION
**Issue:**

Customer reporting the following error

```
Errors that occurred that wasn't handled
Error Index: 0
 : Cannot convert value "System.Object[]" to type "System.Xml.XmlDocument". Error: "The specified node cannot be inserted as the valid child of this node, because the specified node is the wrong type."
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at <ScriptBlock>(Closure , FunctionContext )
   at System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Object[] args)
   at System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   at System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   at System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   at System.Management.Automation.ScriptBlock.DoInvokeReturnAsIs(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Object[] args)
   at Microsoft.PowerShell.Commands.WhereObjectCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
Script Stack: at <ScriptBlock>, C:\Scripts\HealthChecker.ps1: line 4301
at Invoke-AnalyzerSecurityCve-2022-41040, C:\Scripts\HealthChecker.ps1: line 4300
at Invoke-AnalyzerSecurityCveCheck, C:\Scripts\HealthChecker.ps1: line 5149
at Invoke-AnalyzerSecurityVulnerability, C:\Scripts\HealthChecker.ps1: line 5174
at Invoke-AnalyzerEngine, C:\Scripts\HealthChecker.ps1: line 5285
at Main, C:\Scripts\HealthChecker.ps1: line 12045
at <ScriptBlock>, C:\Scripts\HealthChecker.ps1: line 12077
at <ScriptBlock>, <No file>: line 1
-----------------------------------
```

**Fix:**
Placed initial casting of content of the web.config to `xml` in a `try` `catch` block and notify that this CVE status is unknown.

**Validation:**
Lab tested
Resolved #1273 

