### PR TITLE
Include -ADPropertiesOnly with Get-OutlookAnywhere

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -512,7 +512,7 @@ begin {
                     Write-Progress @progressParams
                     Write-Progress @outlookAnywhereProgressParams
                     # Needs to be SilentlyContinue to handle down servers, we must also exclude pre Exchange 2013 servers
-                    $outlookAnywhere = $outlookAnywhereServers | Get-OutlookAnywhere -ErrorAction SilentlyContinue |
+                    $outlookAnywhere = $outlookAnywhereServers | Get-OutlookAnywhere -ADPropertiesOnly -ErrorAction SilentlyContinue |
                         ForEach-Object {
                             $outlookAnywhereCount++
                             $outlookAnywhereProgressParams.PercentComplete = ($outlookAnywhereCount / $outlookAnywhereTotalCount * 100)


### PR DESCRIPTION
**Issue:**
In a large organization, running just `Get-OutlookAnywhere` can take a long time because we need to go to each server. 

**Reason:**
We shouldn't need to go to each server, when the only thing we care about is the `SSLOffloading` which is stored in AD. This will show up correctly when doing `-ADPropertiesOnly`

Before 
![image](https://user-images.githubusercontent.com/22776718/194553780-9286607a-93d6-4ec1-bd52-cce502600b8f.png)

After
![image](https://user-images.githubusercontent.com/22776718/194553881-5e421df7-a68a-468f-a4c9-7cead39eeb06.png)


**Fix:**
Include  `-ADPropertiesOnly` switch in the `Get-OutlookAnywhere` cmdlet

**Validation:**
Lab tested

