### PR TITLE
Update PacketsLossCheck.md

### DIFF
--- a/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
+++ b/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
@@ -17,4 +17,5 @@ Yes
 **Additional Information**
 
 [Large packet loss in the guest OS using VMXNET3 in ESXi (2039495)](https://kb.vmware.com/s/article/2039495)
+[Disable "adaptive rx ring sizing" to avoid random interface reset (78343)](https://kb.vmware.com/s/article/78343)
 


### PR DESCRIPTION
**Issue:**
"Adaptive rx ring size" in vmxnet3 can trigger a warning in the packet loss check

**Reason:**
It may be enabled in some environments and cause packet loss when the rx ring size is changed:
https://kb.vmware.com/s/article/78343

**Fix:**
Add a link to the documentation.