### PR TITLE
Fix false/positive in proxy detection

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -254,7 +254,8 @@ function Invoke-AnalyzerOsInformation {
     $displayWriteType = "Grey"
     $displayValue = $osInformation.NetworkInformation.HttpProxy.ProxyAddress
 
-    if ($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne "None") {
+    if (($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne "None") -and
+        ($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge)) {
         $displayValue = "$($osInformation.NetworkInformation.HttpProxy.ProxyAddress) --- Warning this can cause client connectivity issues."
         $displayWriteType = "Yellow"
     }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -276,8 +276,9 @@ function Invoke-AnalyzerOsInformation {
         Add-AnalyzedResultInformation @params
     }
 
-    if ($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne "None" -and
-        $osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne $exchangeInformation.GetExchangeServer.InternetWebProxy) {
+    if (($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne "None") -and
+        ($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) -and
+        ($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne $exchangeInformation.GetExchangeServer.InternetWebProxy.Authority)) {
         $params = $baseParams + @{
             Details                = "Error: Exchange Internet Web Proxy doesn't match OS Web Proxy."
             DisplayWriteType       = "Red"


### PR DESCRIPTION
**Issue:**
We show a warning if the proxy server which has been set via `Set-ExchangeServer` contains the protocol part (http or https). Proxy server set via WinHTTP is always without protocol part. At the moment, we're flagging this as a proxy mismatch between Exchange and WinHTTP.

**Reason:**
This fix makes sure that we compare both values without using the protocol part. We achieve this by using the `Authority` property which contains the proxy server without the protocol part. We also exclude the proxy check from servers who are running the Edge Transport role as there is no need to set a proxy server via `Set-ExchangeServer` on these machines.

**Fix:**
Resolve #1091 

**Validation:**
Lab (E15 + E16)

