### PR TITLE
Address for possible removed rules on child vdirs

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2022-41040.ps1
@@ -30,6 +30,7 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
         $anyClearSetOnHttpProxy = $false
         $failedToConvertList = @()
         $clearSetOnList = @()
+        $validRulesRemovedList = @()
         $iisRewriteRules = $SecurityObject.ExchangeInformation.IISSettings.IISConfigurationSettings |
             Where-Object {
                 try {
@@ -43,10 +44,46 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
             }
 
         if ($null -ne $iisRewriteRules) {
-            foreach ($config in $iisRewriteRules) {
-                $defaultWebSite = $config.Location -like "*\wwwroot\web.config"
+
+            $defaultWebSiteRewriteRules = $iisRewriteRules | Where-Object { $_.Location -like "*\wwwroot\web.config" }
+            $otherWebSitesRewriteRules = $iisRewriteRules | Where-Object { $_.Location -notlike "*\wwwroot\web.config" }
+            $defaultWebSiteRewriteRuleNames = New-Object System.Collections.Generic.List[string]
+
+            if ($defaultWebSiteRewriteRules.Count -gt 1) { "Found more than 1 wwwroot\web.config file" | ForEach-Object { Write-Verbose $_; Write-Warning $_ } }
+
+            # Custom Response or AbortRequest should both work to prevent the security hole
+            # Input must be {UrlDecode:{REQUEST_URI}}
+            # match type must be pattern
+            # stop processing should be set otherwise, more logic would need to be in place. If only 1 rule, then we are fine
+            # pattern is always going to be set if found. If foundSecureRule isn't set, then something is wrong with the config
+            foreach ($config in $defaultWebSiteRewriteRules) {
                 $rules = ([xml]$config.Content).configuration.'system.webServer'.rewrite.rules
-                # If we determine clear was set on AutoD, then any rules in Default Web Site can't be applied
+
+                foreach ($rule in $rules.rule) {
+                    $validPattern = $rule.conditions.add.pattern -eq $verifyPattern
+                    $validAction = $rule.action.type -eq "AbortRequest" -or
+                    $rule.action.type -eq "CustomResponse"
+                    $validConditionsInput = $rule.conditions.add.input -eq "{UrlDecode:{REQUEST_URI}}"
+                    $validPatternSyntax = $rule.patternSyntax -ne "Wildcard"
+                    $validMatchUrl = $rule.match.url -eq ".*"
+                    $stopProcessing = $rule.stopProcessing -eq "true" -or $rules.rule.count -eq 1
+                    $enabledRule = $rule.enabled -eq "true" -or $null -eq $rule.enabled
+
+                    if ($validAction -and $validConditionsInput -and $validPatternSyntax -and
+                        $validMatchUrl -and $stopProcessing -and $enabledRule -and $validPattern) {
+                        Write-Verbose "Found a valid rule for mitigation"
+                        $foundSecureRuleDefaultWebSite = $true
+                        $defaultWebSiteRewriteRuleNames.Add($rule.name.ToLower())
+                    } else {
+                        Write-Verbose "Rule didn't meet all the criteria for secure rule"
+                    }
+                }
+            }
+
+            foreach ($config in $otherWebSitesRewriteRules) {
+                $rules = ([xml]$config.Content).configuration.'system.webServer'.rewrite.rules
+                $removedRulesList = New-Object System.Collections.Generic.List[string]
+
                 if ($config.Location -like "*\HttpProxy\*") {
                     $clearBeenSet = $null -ne $rules.clear
                     Write-Verbose "Location: $($config.Location) has clear set: $clearBeenSet"
@@ -57,30 +94,19 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
                     }
                 }
 
-                foreach ($rule in $rules.rule) {
-                    if ($defaultWebSite -and $rule.conditions.add.pattern -eq $verifyPattern) {
-                        # Custom Response or AbortRequest should both work to prevent the security hole
-                        # Input must be {UrlDecode:{REQUEST_URI}}
-                        # match type must be pattern
-                        # stop processing should be set otherwise, more logic would need to be in place. If only 1 rule, then we are fine
-                        # pattern is always going to be set if found. If foundSecureRule isn't set, then something is wrong with the config
-                        Write-Verbose "Found valid pattern for mitigation"
-                        $validAction = $rule.action.type -eq "AbortRequest" -or
-                        $rule.action.type -eq "CustomResponse"
-                        $validConditionsInput = $rule.conditions.add.input -eq "{UrlDecode:{REQUEST_URI}}"
-                        $validPatternSyntax = $rule.patternSyntax -ne "Wildcard"
-                        $validMatchUrl = $rule.match.url -eq ".*"
-                        $stopProcessing = $rule.stopProcessing -eq "true" -or $rules.rule.count -eq 1
-                        $enabledRule = $rule.enabled -eq "true" -or $null -eq $rule.enabled
-
-                        if ($validAction -and $validConditionsInput -and $validPatternSyntax -and
-                            $validMatchUrl -and $stopProcessing -and $enabledRule) {
-                            Write-Verbose "Found a valid rule for mitigation"
-                            $foundSecureRuleDefaultWebSite = $true
-                        } else {
-                            Write-Verbose "Rule didn't meet all the criteria for secure rule"
-                        }
+                # check for all rules that match in remove that are what we are looking for
+                foreach ($ruleName in $rules.remove.name) {
+                    if ($defaultWebSiteRewriteRuleNames.Contains($ruleName.ToLower())) {
+                        Write-Verbose "Rule '$ruleName' is changed on this configuration file. Therefore, possibly not secure."
+                        $removedRulesList.Add($ruleName)
+                    } else {
+                        Write-Verbose "Rule '$ruleName' is not a valid rule that we care about"
                     }
+                }
+
+                if ($removedRulesList.Count -eq $defaultWebSiteRewriteRuleNames.Count) {
+                    Write-Verbose "No mitigation is applied to this location: $($config.Location)"
+                    $validRulesRemovedList += $config.Location
                 }
             }
         } else {
@@ -93,6 +119,8 @@ function Invoke-AnalyzerSecurityCve-2022-41040 {
             $details = "CVE-2022-41040`r`n`t`tPlease run the EOMTv2 script from: https://aka.ms/EOMTv2"
         } elseif ($failedToConvertList.Count -gt 0) {
             $details = "CVE-2022-41040`r`n`t`tUnknown - Failed to determine the configuration of the following files when trying to convert to XML type: $([string]::Join("," ,$failedToConvertList))`r`n`t`tAddress this as soon as possible, as this app pool might not be working properly."
+        } elseif ($validRulesRemovedList.Count -gt 0) {
+            $details = "CVE-2022-41040`r`n`t`tRule is present on Default Web Site, however, the following configuration files are removing all Inherited rules to possibly be different. $([string]::Join("," ,$validRulesRemovedList)).`r`n`t`tSelect 'Revert to Parent' in URL Rewrite of IIS Manager to address this."
         } else {
             Write-Verbose "Mitigation applied for CVE-2022-41040"
         }


### PR DESCRIPTION
**Issue:**
If someone goes and modifies or removes all mitigation rules on child vdir, then the server is not secure from the mitigation. We should flag that as an issue then.

**Fix:**
Create a list of all rules on `Default Web Site` configuration file that met the criteria for the mitigation and if all those rules are removed on child vdirs, flag this as a security issue.

**Validation:**
Lab tested

