### PR TITLE
Adjustment to properly handle IP filtering configurations on other vDirs than EWS Back End

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -54,9 +54,10 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                          ($_.ProperlySecuredConfiguration -eq $false))
                         }) {
                         # This means that EP is supported and configured. On at least 1 vDir is IP filtering configured to mitigate known issues with Extended Protection.
-                        # We've detected that EP was not set to "None" on the vDir for which the IP filtering was turned on. This can cause issues.
-                        # Recommended action: Set EP to "None" on the vDir where IP filtering is enabled and was configured.
-                        $epDetails = "Extended Protection should be set to 'None' on the vDir where IP filtering is enabled`n`t`t"
+                        # We've detected that EP was not set to "None" on the EWS Back End vDir for which the IP filtering was turned on. This can cause issues.
+                        # Recommended action: Set EP to "None" on the EWS Back End vDir where IP filtering is enabled and was configured.
+                        $epDetails = "Extended Protection must be set to 'None' on the EWS Back End vDir when IP filtering is enabled`n`t`t"
+                        $epDetails += "On other vDirs it must be set to the supported value regardless of whether IP filtering is enabled or not`n`t`t"
                     }
 
                     # This means that EP is supported but not configured for at least one vDir.
@@ -93,7 +94,7 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                     $listToAdd.Add(([PSCustomObject]@{
                                 $vDirArray[0]     = $vDirArray[1]
                                 Value             = $entry.ExtendedProtection
-                                SupportedValue    = if ($entry.MitigationEnabled) { "None" } else { $entry.ExpectedExtendedConfiguration }
+                                SupportedValue    = if ($entry.MitigationSupported) { "None" } else { $entry.ExpectedExtendedConfiguration }
                                 ConfigSupported   = $entry.ProperlySecuredConfiguration
                                 RequireSSL        = "$($ssl.RequireSSL) $(if($ssl.Ssl128Bit) { "(128-bit)" })".Trim()
                                 ClientCertificate = $ssl.ClientCertificate

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -83,7 +83,7 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                     $listToAdd.Add(([PSCustomObject]@{
                                 $vDirArray[0]     = $vDirArray[1]
                                 Value             = $entry.ExtendedProtection
-                                SupportedValue    = if ($entry.MitigationSupported) { "None" } else { $entry.ExpectedExtendedConfiguration }
+                                SupportedValue    = if ($entry.MitigationSupported -and $entry.MitigationEnabled) { "None" } else { $entry.ExpectedExtendedConfiguration }
                                 ConfigSupported   = $entry.ProperlySecuredConfiguration
                                 RequireSSL        = "$($ssl.RequireSSL) $(if($ssl.Ssl128Bit) { "(128-bit)" })".Trim()
                                 ClientCertificate = $ssl.ClientCertificate

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -49,17 +49,6 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                     # Recommended action: Upgrade to a supported build (Aug 2022 SU+) and enable EP afterwards.
                     $epDetails = "Your Exchange server is at risk. Install the latest SU and enable Extended Protection"
                 } else {
-                    if ($extendedProtection.ExtendedProtectionConfiguration | Where-Object {
-                        (($_.MitigationEnabled) -and
-                         ($_.ProperlySecuredConfiguration -eq $false))
-                        }) {
-                        # This means that EP is supported and configured. On at least 1 vDir is IP filtering configured to mitigate known issues with Extended Protection.
-                        # We've detected that EP was not set to "None" on the EWS Back End vDir for which the IP filtering was turned on. This can cause issues.
-                        # Recommended action: Set EP to "None" on the EWS Back End vDir where IP filtering is enabled and was configured.
-                        $epDetails = "Extended Protection must be set to 'None' on the EWS Back End vDir when IP filtering is enabled`n`t`t"
-                        $epDetails += "On other vDirs it must be set to the supported value regardless of whether IP filtering is enabled or not`n`t`t"
-                    }
-
                     # This means that EP is supported but not configured for at least one vDir.
                     # Recommended action: Enable EP for each vDir on the system by using the script provided by us.
                     $epDetails += "Extended Protection isn't configured as expected"

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionConfiguration.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionConfiguration.ps1
@@ -27,6 +27,7 @@ function Get-ExtendedProtectionConfiguration {
         [bool]$ExcludeEWS = $false,
 
         [Parameter(Mandatory = $false)]
+        [ValidateSet("Exchange Back End/EWS")]
         [string[]]$SiteVDirLocations,
 
         [Parameter(Mandatory = $false)]
@@ -289,10 +290,11 @@ function Get-ExtendedProtectionConfiguration {
             Write-Verbose "Not on Exchange Version 15"
         }
 
-        # Add all vDirs for which the IP filtering mitigation is supported - make sure to add additional entries are in lower case
-        $mitigationSupportedvDirs = @(
-            "exchange back end/ews"
-        )
+        # Add all vDirs for which the IP filtering mitigation is supported
+        $mitigationSupportedvDirs = $MyInvocation.MyCommand.Parameters["SiteVDirLocations"].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+            ForEach-Object { return $_.ValidValues.ToLower() }
+        Write-Verbose "Supported mitigated virtual directories: $([string]::Join(",", $mitigationSupportedvDirs))"
     }
     process {
         try {

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -311,7 +311,7 @@ begin {
                     $listToAdd.Add(([PSCustomObject]@{
                                 $vDirArray[0]     = $vDirArray[1]
                                 Value             = $entry.ExtendedProtection
-                                SupportedValue    = if ($entry.MitigationSupported) { "None" } else { $entry.ExpectedExtendedConfiguration }
+                                SupportedValue    = if ($entry.MitigationSupported -and $entry.MitigationEnabled) { "None" } else { $entry.ExpectedExtendedConfiguration }
                                 ConfigSupported   = $entry.ProperlySecuredConfiguration
                                 RequireSSL        = "$($ssl.RequireSSL) $(if($ssl.Ssl128Bit) { "(128-bit)" })".Trim()
                                 ClientCertificate = $ssl.ClientCertificate

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -311,7 +311,7 @@ begin {
                     $listToAdd.Add(([PSCustomObject]@{
                                 $vDirArray[0]     = $vDirArray[1]
                                 Value             = $entry.ExtendedProtection
-                                SupportedValue    = if ($entry.MitigationEnabled) { "None" } else { $entry.ExpectedExtendedConfiguration }
+                                SupportedValue    = if ($entry.MitigationSupported) { "None" } else { $entry.ExpectedExtendedConfiguration }
                                 ConfigSupported   = $entry.ProperlySecuredConfiguration
                                 RequireSSL        = "$($ssl.RequireSSL) $(if($ssl.Ssl128Bit) { "(128-bit)" })".Trim()
                                 ClientCertificate = $ssl.ClientCertificate


### PR DESCRIPTION
**Issue:**
We showed a warning if Extended Protection was configured properly but IP filtering was enabled on other vDirs than EWS Back End (where it can be enabled to mitigate some known issues).

**Reason:**
With this fix we now handle these scenarios as follows:
- IP filtering is enabled on EWS Back End and Extended Protection is set "None", this is good and not flagged as an issue
- IP filtering is enabled on other vDir (e.g., OWA) and Extended Protection is set to the SupportedValue, this is no longer flagged as an issue
- IP filtering is enabled on OWA or any other vDir (except EWS Back End) and Extended Protection isn't set to the EP SupportedValue, we flag this as an issue (for EWS Back End we flag this as an issue if it's not set to "None" -- see first bullet)

**Fix:**
Resolve #1260
Resolve #1283 

**Validation:**
Lab (E16)

