### PR TITLE
Extended Protection SiteVDirLocations null value exception

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -43,7 +43,10 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 IsClientAccessServer = $server.IsClientAccessServer
                 IsMailboxServer      = $server.IsMailboxServer
                 ExcludeEWS           = $SkipEWS
-                SiteVDirLocations    = $SiteVDirLocations
+            }
+
+            if ($null -ne $SiteVDirLocations) {
+                $params.Add("SiteVDirLocations", $SiteVDirLocations)
             }
             $extendedProtectionConfiguration = Get-ExtendedProtectionConfiguration @params
 


### PR DESCRIPTION
**Issue:**
Multiple customers reported the following issue:

```
Get-ExtendedProtectionPrerequisitesCheck : Cannot validate argument on parameter 'SiteVDirLocations'. the argument is
null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain
any null values and then try the command again.
At C:\admin\ExchangeExtendedProtectionManagement.ps1:4241 char:35
+ ... itesCheck = Get-ExtendedProtectionPrerequisitesCheck -ExchangeServers ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
     + CategoryInfo : InvalidData: (:) [Get-ExtendedProtectionPrerequisitesCheck], ParameterBindingValidationException
     + FullyQualifiedErrorId : ParameterArgumentValidationError,Get-ExtendedProtectionPrerequisitesCheck
```

**Reason:**
We pass a parameter with a `$null` value. This is causing the issue.

**Fix:**
Add `SiteVDirLocations` to parameter hashtable if it's not `$null`

Resolve #1296 

**Validation:**
Script runs as expected in my lab after the fix. Please validate carefully too.

