### PR TITLE
Error handling improvements for Exchange Log Collector

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -222,7 +222,7 @@ function Main {
         try {
             Invoke-Command -ComputerName $Script:ValidServers -ScriptBlock ${Function:Invoke-RemoteFunctions} -ArgumentList $argumentList -ErrorAction Stop
         } catch {
-            Write-Error "An error has occurred attempting to call Invoke-Command to do a remote collect all at once. Please notify ExToolsFeedback@microsoft.com of this issue. Stopping the script."
+            Write-Host "An error has occurred attempting to call Invoke-Command to do a remote collect all at once. Please notify ExToolsFeedback@microsoft.com of this issue. Stopping the script." -ForegroundColor "Red"
             Invoke-CatchActions
             exit
         }

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-RegistryHive.ps1
@@ -32,12 +32,12 @@ function Save-RegistryHive {
         reg export $updatedRegistryPath "$baseSaveName.reg" | Out-Null
 
         if ($LASTEXITCODE) {
-            Write-Verbose "Failed to export the registry hive for: $updatedRegistryPath"
+            throw "Failed to export the registry hive for: $updatedRegistryPath"
         }
         reg save $updatedRegistryPath "$baseSaveName.hiv" | Out-Null
 
         if ($LASTEXITCODE) {
-            Write-Verbose "Failed to save the registry hive for: $updatedRegistryPath"
+            throw "Failed to save the registry hive for: $updatedRegistryPath"
         }
         "To read the registry hive. Run 'reg load HKLM\TempHive $SaveName.hiv'. Then Open your regedit then go to HKLM:\TempHive to view the data." |
             Out-File -FilePath "$baseSaveName`_HowToRead.txt"

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
@@ -90,7 +90,7 @@ function Save-ServerInfoData {
     if (!$Script:localServerObject.Edge) {
 
         $params = @{
-            RegistryPath    = "HKLM:\SOFTWARE\Microsoft\Exchange"
+            RegistryPath    = "HKLM:SOFTWARE\Microsoft\Exchange"
             SaveName        = "Exchange_Registry_Hive"
             SaveToPath      = $copyTo
             UseGetChildItem = $true
@@ -98,7 +98,7 @@ function Save-ServerInfoData {
         Save-RegistryHive @params
 
         $params = @{
-            RegistryPath    = "HKLM:\SOFTWARE\Microsoft\ExchangeServer"
+            RegistryPath    = "HKLM:SOFTWARE\Microsoft\ExchangeServer"
             SaveName        = "ExchangeServer_Registry_Hive"
             SaveToPath      = $copyTo
             UseGetChildItem = $true

--- a/Shared/Write-ErrorInformation.ps1
+++ b/Shared/Write-ErrorInformation.ps1
@@ -8,11 +8,22 @@ function WriteErrorInformationBase {
         [ValidateSet("Write-Host", "Write-Verbose")]
         [string]$Cmdlet
     )
+
+    if ($null -ne $CurrentError.OriginInfo) {
+        & $Cmdlet "Error Origin Info: $($CurrentError.OriginInfo.ToString())"
+    }
+
     & $Cmdlet "$($CurrentError.CategoryInfo.Activity) : $($CurrentError.ToString())"
 
     if ($null -ne $CurrentError.Exception -and
         $null -ne $CurrentError.Exception.StackTrace) {
         & $Cmdlet "Inner Exception: $($CurrentError.Exception.StackTrace)"
+    } elseif ($null -ne $CurrentError.Exception) {
+        & $Cmdlet "Inner Exception: $($CurrentError.Exception)"
+    }
+
+    if ($null -ne $CurrentError.Exception.SerializedRemoteInvocationInfo.PositionMessage) {
+        & $Cmdlet "Position Message: $($CurrentError.Exception.SerializedRemoteInvocationInfo.PositionMessage)"
     }
 
     if ($null -ne $CurrentError.ScriptStackTrace) {


### PR DESCRIPTION
**Issue:**
Discovered an issue within Exchange Log Collector when trying to collect the Server Information remotely. When doing `Invoke-Command` it would return an error due to the `reg.exe` failing to export out the path `HKEY_LOCAL_MACHINE\\SOFTWARE\Microsoft\ExchangeServer`. This occurred because of the double slash. This was difficult to determine the cause from the debug logs by default. 

**Reason:**
Due to the problem debugging the issue quickly, ended up improving the error output to handle the display of information better. 

**Fix:**
Removed the slash `\` that was causing the failure. 

**Validation:**
Lab tested

