### PR TITLE
TLS 1.0 and 1.1 display output adjusted to recommend TLS 1.2 usage only

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -85,10 +85,8 @@ function Invoke-AnalyzerSecuritySettings {
                 ($tlsKey -eq "1.2" -and $currentTlsVersion.TLSConfiguration -eq "Disabled") -or
                 ($tlsKey -eq "1.3" -and $currentTlsVersion.TLSConfiguration -eq "Enabled")) {
             $displayWriteType = "Red"
-        } elseif ((($tlsKey -eq "1.0") -and
-            ($currentTlsVersion.TLSConfiguration -eq "Enabled")) -or
-            (($tlsKey -eq "1.1") -and
-            ($currentTlsVersion.TLSConfiguration -eq "Enabled"))) {
+        } elseif ($currentTlsVersion.TLSConfiguration -eq "Enabled" -and
+            ($tlsKey -eq "1.1" -or $tlsKey -eq "1.0")) {
             $displayWriteType = "Yellow"
         }
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Tests.ps1
@@ -119,7 +119,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "SMB1 Installed" "True" -WriteType "Red"
             TestObjectMatch "SMB1 Blocked" "False" -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 69
+            $Script:ActiveGrouping.Count | Should -Be 71
         }
 
         It "Display Results - Security Vulnerability" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Tests.ps1
@@ -123,7 +123,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Pattern service" "Unreachable`r`n`t`tMore information: https://aka.ms/HelpConnectivityEEMS" -WriteType "Yellow"
             TestObjectMatch "Telemetry enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 79
+            $Script:ActiveGrouping.Count | Should -Be 81
         }
 
         It "Display Results - Security Vulnerability" {

--- a/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
+++ b/docs/Diagnostics/HealthChecker/TLSConfigurationCheck.md
@@ -2,6 +2,8 @@
 
 We check and validate Exchange servers TLS 1.0 - 1.3 configuration. We can detect mismatches in TLS versions for client and server. This is important because Exchange can be both a client and a server.
 
+We will also show a yellow warning, if TLS 1.0 and/or TLS 1.1 is enabled. Microsoft's TLS 1.0 implementation is free of known security vulnerabilities. Due to the potential for future protocol downgrade attacks and other TLS 1.0 vulnerabilities not specific to Microsoft's implementation, it is recommended that dependencies on all security protocols older than TLS 1.2 be removed where possible (TLS 1.1/1.0/ SSLv3/SSLv2).
+
 At this time TLS 1.3 is **not** supported by Exchange and has been known to cause issues if enabled. If detected to be anything but disabled on Exchange, it will be thrown as an error and needs to be addressed right away.
 
 We also check for the SystemDefaultTlsVersions registry value which controls if .NET Framework will inherit its defaults from the Windows Schannel DisabledByDefault registry values or not.
@@ -50,6 +52,10 @@ Yes
 **Additional resources:**
 
 [Exchange Server TLS configuration best practices](https://aka.ms/HC-TLSGuide)
+
+[Solving the TLS 1.0 Problem, 2nd Edition](https://learn.microsoft.com/security/engineering/solving-tls1-problem)
+
+[TLS 1.2 support at Microsoft](https://www.microsoft.com/security/blog/2017/06/20/tls-1-2-support-at-microsoft/)
 
 [Exchange Server TLS guidance, part 1: Getting Ready for TLS 1.2](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Exchange-Server-TLS-guidance-part-1-Getting-Ready-for-TLS-1-2/ba-p/607649)
 


### PR DESCRIPTION
**Description:**
We (Microsoft) recommend proactively disabling TLS versions older than TLS 1.2 to prevent future protocol downgrade attacks. Note that Microsoft's TLS 1.0 implementation is free of known security vulnerabilities.
See: 
https://www.microsoft.com/en-us/security/blog/2017/06/20/tls-1-2-support-at-microsoft/
https://learn.microsoft.com/en-us/security/engineering/solving-tls1-problem

**Fix:**
Resolve #1301 

**Validation:**
Lab

![image](https://user-images.githubusercontent.com/40993616/199070159-7e992026-83e4-4e00-9071-8125cd4ef5c4.png)
![image](https://user-images.githubusercontent.com/40993616/199070100-bcbc4de7-131e-469f-a64a-125e9f729fc2.png)

