### PR TITLE
Exclude non-Exchange websites by default

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
@@ -5,6 +5,7 @@
 . $PSScriptRoot\Get-IISWebApplication.ps1
 . $PSScriptRoot\Get-IISWebSite.ps1
 . $PSScriptRoot\..\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
+. $PSScriptRoot\..\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeWebSitesFromAd.ps1
 . $PSScriptRoot\..\..\..\..\..\Shared\IISFunctions\Get-ApplicationHostConfig.ps1
 . $PSScriptRoot\..\..\..\..\..\Shared\IISFunctions\Get-IISModules.ps1
 
@@ -22,7 +23,14 @@ function Get-ExchangeServerIISSettings {
             CatchActionFunction = $CatchActionFunction
         }
 
-        $webSite = Invoke-ScriptBlockHandler @params -ScriptBlock ${Function:Get-IISWebSite}
+        $exchangeWebSites = Get-ExchangeWebSitesFromAd -ComputerName $ComputerName
+        if ($exchangeWebSites.Count -gt 2) {
+            Write-Verbose "Multiple OWA/ECP virtual directories detected"
+        }
+        Write-Verbose "Exchange websites detected: $([string]::Join(", " ,$exchangeWebSites))"
+
+        # We need to wrap the array into another array as the -WebSitesToProcess parameter expects an array object
+        $webSite = Invoke-ScriptBlockHandler @params -ScriptBlock ${Function:Get-IISWebSite} -ArgumentList (, $exchangeWebSites)
         $webApplication = Invoke-ScriptBlockHandler @params -ScriptBlock ${Function:Get-IISWebApplication}
 
         $configurationFiles = @($webSite.PhysicalPath)

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -2,9 +2,22 @@
 # Licensed under the MIT License.
 
 function Get-IISWebSite {
-    $webSites = Get-WebSite
-    $bindings = Get-WebBinding
+    param(
+        [array]$WebSitesToProcess
+    )
+
     $returnList = New-Object 'System.Collections.Generic.List[object]'
+    $webSites = New-Object 'System.Collections.Generic.List[object]'
+
+    if ($null -eq $WebSitesToProcess) {
+        $webSites.AddRange((Get-WebSite))
+    } else {
+        foreach ($iisWebSite in $WebSitesToProcess) {
+            $webSites.Add((Get-WebSite -Name $($iisWebSite)))
+        }
+    }
+
+    $bindings = Get-WebBinding
 
     foreach ($site in $webSites) {
         $siteBindings = $bindings |

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeProtocolContainer.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeProtocolContainer.xml
@@ -1,0 +1,214 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.DirectoryServices.DirectoryEntry</T>
+      <T>System.ComponentModel.Component</T>
+      <T>System.MarshalByRefObject</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.DirectoryServices.DirectoryEntry</ToString>
+    <Props>
+      <Obj N="objectClass" RefId="1">
+        <TN RefId="1">
+          <T>System.DirectoryServices.PropertyValueCollection</T>
+          <T>System.Collections.CollectionBase</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>top</S>
+          <S>protocolCfgShared</S>
+          <S>protocolCfgSharedServer</S>
+        </LST>
+      </Obj>
+      <Obj N="cn" RefId="2">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="distinguishedName" RefId="3">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=Protocols,CN=E1501,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=Exchangelabs,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=exchangelabs,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="instanceType" RefId="4">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>4</I32>
+        </LST>
+      </Obj>
+      <Obj N="whenCreated" RefId="5">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-11-05T08:36:35</DT>
+        </LST>
+      </Obj>
+      <Obj N="whenChanged" RefId="6">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-11-05T08:36:35</DT>
+        </LST>
+      </Obj>
+      <Obj N="uSNCreated" RefId="7">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="8">
+            <TN RefId="2">
+              <T>System.__ComObject</T>
+              <T>System.MarshalByRefObject</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="uSNChanged" RefId="9">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="10">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="showInAdvancedViewOnly" RefId="11">
+        <TNRef RefId="1" />
+        <LST>
+          <B>true</B>
+        </LST>
+      </Obj>
+      <Obj N="adminDisplayName" RefId="12">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="nTSecurityDescriptor" RefId="13">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="14">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="name" RefId="15">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="objectGUID" RefId="16">
+        <TNRef RefId="1" />
+        <LST>
+          <BA>7Gw2GoxsSUeWeeZjy0KjLQ==</BA>
+        </LST>
+      </Obj>
+      <Obj N="systemFlags" RefId="17">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>1073741824</I32>
+        </LST>
+      </Obj>
+      <Obj N="objectCategory" RefId="18">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=ms-Exch-Protocol-Cfg-Shared-Server,CN=Schema,CN=Configuration,DC=exchangelabs,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="dSCorePropagationData" RefId="19">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-11-05T08:43:18</DT>
+          <DT>2021-11-05T08:40:10</DT>
+          <DT>2021-11-05T08:40:09</DT>
+          <DT>2021-11-05T08:36:36</DT>
+          <DT>1601-07-14T22:36:49</DT>
+        </LST>
+      </Obj>
+      <Obj N="availableAuthorizationPackages" RefId="20">
+        <TNRef RefId="1" />
+        <LST>
+          <S>MCIS Membership System using SSL§DPA§DPASSL</S>
+          <S>MCIS Membership System§DPA§DPA</S>
+          <S>Windows Challenge/Response Using SSL§NTLM§NTLMSSL</S>
+          <S>Windows Challenge/Response§NTLM§NTLM</S>
+          <S>Basic (Clear Text) Using SSL§CLEARTEXT§CLEARTEXTSSL</S>
+          <S>Basic (Clear Text)§CLEARTEXT§CLEARTEXT</S>
+        </LST>
+      </Obj>
+      <Obj N="characterSetList" RefId="21">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Thai (Windows 874)§WINDOWS-874</S>
+          <S>Japanese (EUC)§X-EUC</S>
+          <S>Baltic (Windows 1257)§WINDOWS-1257</S>
+          <S>Arabic (Windows 1256)§WINDOWS-1256</S>
+          <S>Hebrew (Windows 1255)§WINDOWS-1255</S>
+          <S>Turkish (Windows 1254)§WINDOWS-1254</S>
+          <S>Greek (Windows 1253)§WINDOWS-1253</S>
+          <S>Latin I (Windows 1252)§WINDOWS-1252</S>
+          <S>Cyrillic (Windows 1251)§WINDOWS-1251</S>
+          <S>Central European (Windows 1250)§WINDOWS-1250</S>
+          <S>Korean (EUC)§EUC-KR</S>
+          <S>US ASCII§US-ASCII</S>
+          <S>Unicode (UTF-8)§utf-8</S>
+          <S>Unicode (UTF-7)§utf-7</S>
+          <S>Japanese (Shift-JIS)§SHIFT-JIS</S>
+          <S>IA5 (Swedish)§SEN_850200_B</S>
+          <S>IA5 (Norwegian)§NS_4551-1</S>
+          <S>Korean§KS_C_5601-1987</S>
+          <S>Russian (KOI8-R)§KOI8-R</S>
+          <S>Latin 9 (ISO-8859-15)§ISO-8859-15</S>
+          <S>Turkish (ISO-8859-9)§ISO-8859-9</S>
+          <S>Hebrew (ISO-8859-8)§ISO-8859-8</S>
+          <S>Greek (ISO-8859-7)§ISO-8859-7</S>
+          <S>Arabic (ISO-8859-6)§ISO-8859-6</S>
+          <S>Cyrillic (ISO-8859-5)§ISO-8859-5</S>
+          <S>Baltic (ISO-8859-4)§ISO-8859-4</S>
+          <S>Turkish (ISO-8859-3)§ISO-8859-3</S>
+          <S>Central European (ISO-8859-2)§ISO-8859-2</S>
+          <S>Western European (ISO-8859-1)§ISO-8859-1</S>
+          <S>Korean (ISO 2022 KR, 7 bit)§ISO-2022-KR</S>
+          <S>Japanese (JIS-SIO)§ISO-2022-JPSIO</S>
+          <S>Japanese (JIS-ESC)§ISO-2022-JPESC</S>
+          <S>Japanese (JIS)§ISO-2022-JPDBCS</S>
+          <S>Chinese Simplified (HZ)§hz-gb-2312</S>
+          <S>Chinese Simplified (GB18030)§GB18030</S>
+          <S>Chinese Simplified (GB2312)§GB2312</S>
+          <S>IA5 (German)§DIN_66003</S>
+          <S>Chinese Traditional (Big5)§BIG5</S>
+          <S>Untranslated ("ANSI")§ANSI</S>
+        </LST>
+      </Obj>
+      <Obj N="useSiteValues" RefId="22">
+        <TNRef RefId="1" />
+        <LST>
+          <B>false</B>
+        </LST>
+      </Obj>
+      <Obj N="msExchMinAdminVersion" RefId="23">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>-2147453113</I32>
+        </LST>
+      </Obj>
+      <Obj N="msExchVersion" RefId="24">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="25">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="connectionListFilterType" RefId="26">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>0</I32>
+        </LST>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeWebSitesFromAd.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetExchangeWebSitesFromAd.xml
@@ -1,0 +1,24 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Object[]</T>
+      <T>System.Array</T>
+      <T>System.Object</T>
+    </TN>
+    <LST>
+      <S>Default Web Site</S>
+    </LST>
+  </Obj>
+  <Obj RefId="1">
+    <TNRef RefId="0" />
+    <LST>
+      <S>Exchange Back End</S>
+    </LST>
+  </Obj>
+  <Obj RefId="2">
+    <TNRef RefId="0" />
+    <LST>
+      <S>OWA_Secondary</S>
+    </LST>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeProtocolContainer.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeProtocolContainer.xml
@@ -1,0 +1,214 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.DirectoryServices.DirectoryEntry</T>
+      <T>System.ComponentModel.Component</T>
+      <T>System.MarshalByRefObject</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.DirectoryServices.DirectoryEntry</ToString>
+    <Props>
+      <Obj N="objectClass" RefId="1">
+        <TN RefId="1">
+          <T>System.DirectoryServices.PropertyValueCollection</T>
+          <T>System.Collections.CollectionBase</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>top</S>
+          <S>protocolCfgShared</S>
+          <S>protocolCfgSharedServer</S>
+        </LST>
+      </Obj>
+      <Obj N="cn" RefId="2">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="distinguishedName" RefId="3">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=Protocols,CN=E2k16-1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=Contoso Labs,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Contoso,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="instanceType" RefId="4">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>4</I32>
+        </LST>
+      </Obj>
+      <Obj N="whenCreated" RefId="5">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:47:28</DT>
+        </LST>
+      </Obj>
+      <Obj N="whenChanged" RefId="6">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:47:29</DT>
+        </LST>
+      </Obj>
+      <Obj N="uSNCreated" RefId="7">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="8">
+            <TN RefId="2">
+              <T>System.__ComObject</T>
+              <T>System.MarshalByRefObject</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="uSNChanged" RefId="9">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="10">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="showInAdvancedViewOnly" RefId="11">
+        <TNRef RefId="1" />
+        <LST>
+          <B>true</B>
+        </LST>
+      </Obj>
+      <Obj N="adminDisplayName" RefId="12">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="nTSecurityDescriptor" RefId="13">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="14">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="name" RefId="15">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="objectGUID" RefId="16">
+        <TNRef RefId="1" />
+        <LST>
+          <BA>DZnF/6MDVkObv+lWWoWUPQ==</BA>
+        </LST>
+      </Obj>
+      <Obj N="systemFlags" RefId="17">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>1073741824</I32>
+        </LST>
+      </Obj>
+      <Obj N="objectCategory" RefId="18">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=ms-Exch-Protocol-Cfg-Shared-Server,CN=Schema,CN=Configuration,DC=Contoso,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="dSCorePropagationData" RefId="19">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:51:48</DT>
+          <DT>2021-07-29T05:48:38</DT>
+          <DT>2021-07-29T05:48:38</DT>
+          <DT>2021-07-29T05:47:31</DT>
+          <DT>1601-07-14T22:36:49</DT>
+        </LST>
+      </Obj>
+      <Obj N="msExchMinAdminVersion" RefId="20">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>-2147453113</I32>
+        </LST>
+      </Obj>
+      <Obj N="msExchVersion" RefId="21">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="22">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="availableAuthorizationPackages" RefId="23">
+        <TNRef RefId="1" />
+        <LST>
+          <S>MCIS Membership System using SSL§DPA§DPASSL</S>
+          <S>MCIS Membership System§DPA§DPA</S>
+          <S>Windows Challenge/Response Using SSL§NTLM§NTLMSSL</S>
+          <S>Windows Challenge/Response§NTLM§NTLM</S>
+          <S>Basic (Clear Text) Using SSL§CLEARTEXT§CLEARTEXTSSL</S>
+          <S>Basic (Clear Text)§CLEARTEXT§CLEARTEXT</S>
+        </LST>
+      </Obj>
+      <Obj N="useSiteValues" RefId="24">
+        <TNRef RefId="1" />
+        <LST>
+          <B>false</B>
+        </LST>
+      </Obj>
+      <Obj N="characterSetList" RefId="25">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Thai (Windows 874)§WINDOWS-874</S>
+          <S>Japanese (EUC)§X-EUC</S>
+          <S>Baltic (Windows 1257)§WINDOWS-1257</S>
+          <S>Arabic (Windows 1256)§WINDOWS-1256</S>
+          <S>Hebrew (Windows 1255)§WINDOWS-1255</S>
+          <S>Turkish (Windows 1254)§WINDOWS-1254</S>
+          <S>Greek (Windows 1253)§WINDOWS-1253</S>
+          <S>Latin I (Windows 1252)§WINDOWS-1252</S>
+          <S>Cyrillic (Windows 1251)§WINDOWS-1251</S>
+          <S>Central European (Windows 1250)§WINDOWS-1250</S>
+          <S>Korean (EUC)§EUC-KR</S>
+          <S>US ASCII§US-ASCII</S>
+          <S>Unicode (UTF-8)§utf-8</S>
+          <S>Unicode (UTF-7)§utf-7</S>
+          <S>Japanese (Shift-JIS)§SHIFT-JIS</S>
+          <S>IA5 (Swedish)§SEN_850200_B</S>
+          <S>IA5 (Norwegian)§NS_4551-1</S>
+          <S>Korean§KS_C_5601-1987</S>
+          <S>Russian (KOI8-R)§KOI8-R</S>
+          <S>Latin 9 (ISO-8859-15)§ISO-8859-15</S>
+          <S>Turkish (ISO-8859-9)§ISO-8859-9</S>
+          <S>Hebrew (ISO-8859-8)§ISO-8859-8</S>
+          <S>Greek (ISO-8859-7)§ISO-8859-7</S>
+          <S>Arabic (ISO-8859-6)§ISO-8859-6</S>
+          <S>Cyrillic (ISO-8859-5)§ISO-8859-5</S>
+          <S>Baltic (ISO-8859-4)§ISO-8859-4</S>
+          <S>Turkish (ISO-8859-3)§ISO-8859-3</S>
+          <S>Central European (ISO-8859-2)§ISO-8859-2</S>
+          <S>Western European (ISO-8859-1)§ISO-8859-1</S>
+          <S>Korean (ISO 2022 KR, 7 bit)§ISO-2022-KR</S>
+          <S>Japanese (JIS-SIO)§ISO-2022-JPSIO</S>
+          <S>Japanese (JIS-ESC)§ISO-2022-JPESC</S>
+          <S>Japanese (JIS)§ISO-2022-JPDBCS</S>
+          <S>Chinese Simplified (HZ)§hz-gb-2312</S>
+          <S>Chinese Simplified (GB18030)§GB18030</S>
+          <S>Chinese Simplified (GB2312)§GB2312</S>
+          <S>IA5 (German)§DIN_66003</S>
+          <S>Chinese Traditional (Big5)§BIG5</S>
+          <S>Untranslated ("ANSI")§ANSI</S>
+        </LST>
+      </Obj>
+      <Obj N="connectionListFilterType" RefId="26">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>0</I32>
+        </LST>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeWebSitesFromAd.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetExchangeWebSitesFromAd.xml
@@ -1,0 +1,24 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Object[]</T>
+      <T>System.Array</T>
+      <T>System.Object</T>
+    </TN>
+    <LST>
+      <S>Default Web Site</S>
+    </LST>
+  </Obj>
+  <Obj RefId="1">
+    <TNRef RefId="0" />
+    <LST>
+      <S>Exchange Back End</S>
+    </LST>
+  </Obj>
+  <Obj RefId="2">
+    <TNRef RefId="0" />
+    <LST>
+      <S>OWA_Secondary</S>
+    </LST>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeProtocolContainer.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeProtocolContainer.xml
@@ -1,0 +1,214 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.DirectoryServices.DirectoryEntry</T>
+      <T>System.ComponentModel.Component</T>
+      <T>System.MarshalByRefObject</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.DirectoryServices.DirectoryEntry</ToString>
+    <Props>
+      <Obj N="objectClass" RefId="1">
+        <TN RefId="1">
+          <T>System.DirectoryServices.PropertyValueCollection</T>
+          <T>System.Collections.CollectionBase</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>top</S>
+          <S>protocolCfgShared</S>
+          <S>protocolCfgSharedServer</S>
+        </LST>
+      </Obj>
+      <Obj N="cn" RefId="2">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="distinguishedName" RefId="3">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=Protocols,CN=E2k16-1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=Contoso Labs,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Contoso,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="instanceType" RefId="4">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>4</I32>
+        </LST>
+      </Obj>
+      <Obj N="whenCreated" RefId="5">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:47:28</DT>
+        </LST>
+      </Obj>
+      <Obj N="whenChanged" RefId="6">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:47:29</DT>
+        </LST>
+      </Obj>
+      <Obj N="uSNCreated" RefId="7">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="8">
+            <TN RefId="2">
+              <T>System.__ComObject</T>
+              <T>System.MarshalByRefObject</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="uSNChanged" RefId="9">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="10">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="showInAdvancedViewOnly" RefId="11">
+        <TNRef RefId="1" />
+        <LST>
+          <B>true</B>
+        </LST>
+      </Obj>
+      <Obj N="adminDisplayName" RefId="12">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="nTSecurityDescriptor" RefId="13">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="14">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="name" RefId="15">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Protocols</S>
+        </LST>
+      </Obj>
+      <Obj N="objectGUID" RefId="16">
+        <TNRef RefId="1" />
+        <LST>
+          <BA>DZnF/6MDVkObv+lWWoWUPQ==</BA>
+        </LST>
+      </Obj>
+      <Obj N="systemFlags" RefId="17">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>1073741824</I32>
+        </LST>
+      </Obj>
+      <Obj N="objectCategory" RefId="18">
+        <TNRef RefId="1" />
+        <LST>
+          <S>CN=ms-Exch-Protocol-Cfg-Shared-Server,CN=Schema,CN=Configuration,DC=Contoso,DC=lab</S>
+        </LST>
+      </Obj>
+      <Obj N="dSCorePropagationData" RefId="19">
+        <TNRef RefId="1" />
+        <LST>
+          <DT>2021-07-29T05:51:48</DT>
+          <DT>2021-07-29T05:48:38</DT>
+          <DT>2021-07-29T05:48:38</DT>
+          <DT>2021-07-29T05:47:31</DT>
+          <DT>1601-07-14T22:36:49</DT>
+        </LST>
+      </Obj>
+      <Obj N="msExchMinAdminVersion" RefId="20">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>-2147453113</I32>
+        </LST>
+      </Obj>
+      <Obj N="msExchVersion" RefId="21">
+        <TNRef RefId="1" />
+        <LST>
+          <Obj RefId="22">
+            <TNRef RefId="2" />
+            <ToString>System.__ComObject</ToString>
+          </Obj>
+        </LST>
+      </Obj>
+      <Obj N="availableAuthorizationPackages" RefId="23">
+        <TNRef RefId="1" />
+        <LST>
+          <S>MCIS Membership System using SSL§DPA§DPASSL</S>
+          <S>MCIS Membership System§DPA§DPA</S>
+          <S>Windows Challenge/Response Using SSL§NTLM§NTLMSSL</S>
+          <S>Windows Challenge/Response§NTLM§NTLM</S>
+          <S>Basic (Clear Text) Using SSL§CLEARTEXT§CLEARTEXTSSL</S>
+          <S>Basic (Clear Text)§CLEARTEXT§CLEARTEXT</S>
+        </LST>
+      </Obj>
+      <Obj N="useSiteValues" RefId="24">
+        <TNRef RefId="1" />
+        <LST>
+          <B>false</B>
+        </LST>
+      </Obj>
+      <Obj N="characterSetList" RefId="25">
+        <TNRef RefId="1" />
+        <LST>
+          <S>Thai (Windows 874)§WINDOWS-874</S>
+          <S>Japanese (EUC)§X-EUC</S>
+          <S>Baltic (Windows 1257)§WINDOWS-1257</S>
+          <S>Arabic (Windows 1256)§WINDOWS-1256</S>
+          <S>Hebrew (Windows 1255)§WINDOWS-1255</S>
+          <S>Turkish (Windows 1254)§WINDOWS-1254</S>
+          <S>Greek (Windows 1253)§WINDOWS-1253</S>
+          <S>Latin I (Windows 1252)§WINDOWS-1252</S>
+          <S>Cyrillic (Windows 1251)§WINDOWS-1251</S>
+          <S>Central European (Windows 1250)§WINDOWS-1250</S>
+          <S>Korean (EUC)§EUC-KR</S>
+          <S>US ASCII§US-ASCII</S>
+          <S>Unicode (UTF-8)§utf-8</S>
+          <S>Unicode (UTF-7)§utf-7</S>
+          <S>Japanese (Shift-JIS)§SHIFT-JIS</S>
+          <S>IA5 (Swedish)§SEN_850200_B</S>
+          <S>IA5 (Norwegian)§NS_4551-1</S>
+          <S>Korean§KS_C_5601-1987</S>
+          <S>Russian (KOI8-R)§KOI8-R</S>
+          <S>Latin 9 (ISO-8859-15)§ISO-8859-15</S>
+          <S>Turkish (ISO-8859-9)§ISO-8859-9</S>
+          <S>Hebrew (ISO-8859-8)§ISO-8859-8</S>
+          <S>Greek (ISO-8859-7)§ISO-8859-7</S>
+          <S>Arabic (ISO-8859-6)§ISO-8859-6</S>
+          <S>Cyrillic (ISO-8859-5)§ISO-8859-5</S>
+          <S>Baltic (ISO-8859-4)§ISO-8859-4</S>
+          <S>Turkish (ISO-8859-3)§ISO-8859-3</S>
+          <S>Central European (ISO-8859-2)§ISO-8859-2</S>
+          <S>Western European (ISO-8859-1)§ISO-8859-1</S>
+          <S>Korean (ISO 2022 KR, 7 bit)§ISO-2022-KR</S>
+          <S>Japanese (JIS-SIO)§ISO-2022-JPSIO</S>
+          <S>Japanese (JIS-ESC)§ISO-2022-JPESC</S>
+          <S>Japanese (JIS)§ISO-2022-JPDBCS</S>
+          <S>Chinese Simplified (HZ)§hz-gb-2312</S>
+          <S>Chinese Simplified (GB18030)§GB18030</S>
+          <S>Chinese Simplified (GB2312)§GB2312</S>
+          <S>IA5 (German)§DIN_66003</S>
+          <S>Chinese Traditional (Big5)§BIG5</S>
+          <S>Untranslated ("ANSI")§ANSI</S>
+        </LST>
+      </Obj>
+      <Obj N="connectionListFilterType" RefId="26">
+        <TNRef RefId="1" />
+        <LST>
+          <I32>0</I32>
+        </LST>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeWebSitesFromAd.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetExchangeWebSitesFromAd.xml
@@ -1,0 +1,24 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Object[]</T>
+      <T>System.Array</T>
+      <T>System.Object</T>
+    </TN>
+    <LST>
+      <S>Default Web Site</S>
+    </LST>
+  </Obj>
+  <Obj RefId="1">
+    <TNRef RefId="0" />
+    <LST>
+      <S>Exchange Back End</S>
+    </LST>
+  </Obj>
+  <Obj RefId="2">
+    <TNRef RefId="0" />
+    <LST>
+      <S>OWA_Secondary</S>
+    </LST>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -245,3 +245,9 @@ function Get-WebBinding {
 function Get-WebApplication {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetWebApplication.xml"
 }
+function Get-ExchangeProtocolContainer {
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeProtocolContainer.xml"
+}
+function Get-ExchangeWebSitesFromAd {
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeWebSitesFromAd.xml"
+}

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeProtocolContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeProtocolContainer.ps1
@@ -1,0 +1,19 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Get-OrganizationContainer.ps1
+
+function Get-ExchangeProtocolContainer {
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.DirectoryEntry])]
+    param (
+        [string]$ComputerName = $env:COMPUTERNAME
+    )
+
+    $ComputerName = $ComputerName.Split(".")[0]
+
+    $organizationContainer = Get-OrganizationContainer
+    $protocolContainerPath = ("CN=Protocols,CN=" + $ComputerName + ",CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups," + $organizationContainer.distinguishedName)
+    $protocolContainer = [ADSI]("LDAP://" + $protocolContainerPath)
+    return $protocolContainer
+}

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeWebSitesFromAd.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeWebSitesFromAd.ps1
@@ -1,0 +1,44 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Get-ExchangeProtocolContainer.ps1
+
+function Get-ExchangeWebSitesFromAd {
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param (
+        [string]$ComputerName = $env:COMPUTERNAME
+    )
+
+    begin {
+        function GetExchangeWebSiteFromCn {
+            param (
+                [string]$Site
+            )
+
+            if ($null -ne $Site) {
+                $index = $Site.IndexOf("(") + 1
+                if ($index -ne 0) {
+                    return ($Site.Substring($index, ($Site.LastIndexOf(")") - $index)))
+                }
+            }
+        }
+
+        $processedExchangeWebSites = New-Object 'System.Collections.Generic.List[array]'
+    }
+    process {
+        $protocolContainer = Get-ExchangeProtocolContainer -ComputerName $ComputerName
+        if ($null -ne $protocolContainer) {
+            $httpProtocol = $protocolContainer.Children | Where-Object {
+                ($_.name -eq "HTTP")
+            }
+
+            foreach ($cn in $httpProtocol.Children.cn) {
+                $processedExchangeWebSites.Add((GetExchangeWebSiteFromCn $cn))
+            }
+        }
+    }
+    end {
+        return ($processedExchangeWebSites | Select-Object -Unique)
+    }
+}


### PR DESCRIPTION
**Issue:**
The change introduced in PR #1286 will cause false positives (FP) if any other website than the Exchange default ones exists (e.g., added by 3rd party solutions). 

**Reason:**
We return all existing websites when `Get-WebSite` is being called and check for existing `web.config` files.

**Fix:**
We query the Exchange websites from AD configuration partition to ensure that we get all the Exchange-related websites (also additional created OWA/ECP ones). We skip any other website which is not related to Exchange.

![image](https://user-images.githubusercontent.com/40993616/199701162-3385ef24-e70c-4d6b-a9c4-88ea484bd019.png)

Resolve #1310 

**Validation:**
Lab & affected customer

