### PR TITLE
SetupAssist address update to latest version of Exchange

### DIFF
--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -160,7 +160,7 @@ function Test-ExchangeADSetupLevel {
 
     $adLevel = GetExchangeADSetupLevel
     $testName = "Exchange AD Latest Level"
-    $setupLog = "C:\ExchangeSetupLogs\ExchangeSetup.log"
+    $setupLog = "$env:SystemDrive\ExchangeSetupLogs\ExchangeSetup.log"
     $currentSchemaValue = $adLevel.Schema.Value
     $currentInstallingExchangeVersion = $null
 

--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -11,6 +11,9 @@ function Test-ExchangeADSetupLevel {
         param(
             [string]$ExchangeVersion
         )
+        # Make sure this gets called first before any other returns can occur
+        Test-UserGroupMemberOf -PrepareAdRequired $true -PrepareSchemaRequired ($latestExchangeVersion.$ExchangeVersion.UpperRange -ne $currentSchemaValue)
+
         $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
         $params = @{
             TestName = "Prepare AD Requirements"
@@ -61,7 +64,6 @@ function Test-ExchangeADSetupLevel {
             "Local Server Site:    $localSite")
 
         New-TestResult @params -Details $details -ReferenceInfo $runPrepareAD
-        Test-UserGroupMemberOf -PrepareAdRequired $true -PrepareSchemaRequired ($latestExchangeVersion.$ExchangeVersion.UpperRange -ne $currentSchemaValue)
     }
 
     function TestMismatchLevel {
@@ -221,8 +223,10 @@ function Test-ExchangeADSetupLevel {
         if ($adLevel.MESO.Value -eq 13237 -and
             $adLevel.Org.Value -eq 16133) {
             New-TestResult -TestName $testName -Result "Passed" -Details "Exchange 2013 CU23 Ready"
+            Test-UserGroupMemberOf
         } else {
             New-TestResult -TestName $testName -Result "Failed" -Details "Exchange 2013 CU23 Not Ready"
+            Test-UserGroupMemberOf
         }
     } elseif ($adLevel.Schema.Value -eq 15332) {
         #Exchange 2016 CU10+

--- a/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
@@ -59,8 +59,9 @@ function Test-UserGroupMemberOf {
     $principal = (New-Object System.Security.Principal.WindowsPrincipal([System.Security.Principal.WindowsIdentity]::GetCurrent()))
 
     foreach ($group in $groupRequirements) {
+        $params.TestName = "User Group - $($group.Name)"
+        $params.Details = "$($group.Role)"
         if ($principal.IsInRole($group.Role)) {
-            $params.Details = "$($group.Name) $($group.Role)"
             New-TestResult @params -Result "Passed"
         } else {
             New-TestResult @params -Result "Failed" -ReferenceInfo $group.Reason

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -132,7 +132,7 @@ function Main {
     Write-Host "Setup Log Reviewer Results"
     Write-Host "--------------------------"
     Write-Host ""
-    $setupLog = "C:\ExchangeSetupLogs\ExchangeSetup.log"
+    $setupLog = "$env:SystemDrive\ExchangeSetupLogs\ExchangeSetup.log"
     if ((Test-Path $setupLog)) {
         Invoke-SetupLogReviewer -SetupLog $SetupLog
     } else {


### PR DESCRIPTION
**Issue:**
Customer was trying to install Exchange 2019 in an Exchange 2013 environment. SetupAssist would determine that we are on Exchange 2013 schema and determine that everything was 'good' due to the fact that Exchange 2013 had a SU that caused the AD environment to be a little off.

However, this then caused the script to not attempt to call the code for `TestPrepareAD` to determine if we can install Exchange from this server due to domain and site in comparison to the schema master. Then we also would need to know about if the user running the script is in the correct groups to be able to run `Setup.exe /PrepareAD` if required.

While addressing this issue, ended up finding a different bug within the `Test-UserGroupMemberOf` that prevented a clear output to know what group we weren't in. 

**Reason:**
Script became unhelpful to track down the issue if the user isn't part of the correct group to be able to install Exchange with `Setup.exe /PrepareAD`.

**Fix:**
Within `Test-ExchangeADSetupLevel` ended up calling `Get-SetupLogReviewer` if the Exchange Setup Log was present on the computer. If it was, then proceed to detect the `SetupBuildNumber` from the returned results to determine which Exchange version we are trying to install. If the schema version in AD doesn't match what we are trying to install, it would just run the `TestMismatchLevel` code which calls everything that is required for the end user to interrupt. 

Broke out the testing within `Test-UserGroupMemberOf` so each test result would show up correctly and be cleaner in the output and useful.

![image](https://user-images.githubusercontent.com/22776718/199496678-ea59e044-6b0f-4bcf-80ba-5cb75e52114d.png)


**Validation:**
Lab tested. 
