### PR TITLE
SetupAssist Check Token Group

### DIFF
--- a/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserGroupMemberOf.ps1
@@ -1,6 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-TokenGroupsGlobalAndUniversal.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Confirm-Administrator.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-WellKnownGroupSid.ps1
 . $PSScriptRoot\..\New-TestResult.ps1
@@ -19,6 +20,8 @@ function Test-UserGroupMemberOf {
         TestName = "User Administrator"
         Details  = "$whoami $userSid"
     }
+
+    $tokenGroups = Get-TokenGroupsGlobalAndUniversal -UserSid $userSid
 
     if (Confirm-Administrator) {
         New-TestResult @params -Result "Passed"
@@ -64,7 +67,17 @@ function Test-UserGroupMemberOf {
         if ($principal.IsInRole($group.Role)) {
             New-TestResult @params -Result "Passed"
         } else {
-            New-TestResult @params -Result "Failed" -ReferenceInfo $group.Reason
+            # If not running under admin, IsInRole doesn't work properly provide error on this.
+            # Then check to see if they are in a token group, if they are need to sign out to have it applied.
+            # Otherwise, they are not in the group.
+            if (-not (Confirm-Administrator)) {
+                New-TestResult @params -Result "Failed" -ReferenceInfo "Must run as Administrator to properly test"
+            } elseif ($null -ne $tokenGroups -and
+            ($tokenGroups.SID.Contains($group.Role.ToString()))) {
+                New-TestResult @params -Result "Warning" -ReferenceInfo "Need to log off and log back in"
+            } else {
+                New-TestResult @params -Result "Failed" -ReferenceInfo $group.Reason
+            }
         }
     }
 }

--- a/Shared/ActiveDirectoryFunctions/Get-TokenGroupsGlobalAndUniversal.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-TokenGroupsGlobalAndUniversal.ps1
@@ -1,0 +1,81 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\Invoke-CatchActionError.ps1
+function Get-TokenGroupsGlobalAndUniversal {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$GCName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "DistinguishedName")]
+        [string]$DistinguishedName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "SID")]
+        [string]$UserSid,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$CatchActionFunction
+    )
+
+    begin {
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        Write-Verbose "GCName: '$GCName' DistinguishedName: '$DistinguishedName'"
+        $tokenGroups = New-Object System.Collections.Generic.List[object]
+    }
+    process {
+        try {
+            if ([string]::IsNullOrEmpty($GCName)) {
+                $rootDSE = [ADSI]("GC://RootDSE")
+                $GCName = $rootDSE.dnsHostName
+            }
+
+            if ($PsCmdlet.ParameterSetName -eq "SID") {
+                try {
+                    $adObject = ([ADSI]("LDAP://<SID=" + $UserSid.ToString() + ">"))
+                    $DistinguishedName = $adObject.Properties["distinguishedName"][0].ToString()
+                } catch {
+                    Invoke-CatchActionError $CatchActionFunction
+                    throw "Failed to convert $UserSid to DistinguishedName"
+                }
+            }
+
+            $searchRoot = [ADSI]("GC://" + $GCName + "/" + $DistinguishedName)
+            $searcher = New-Object System.DirectoryServices.DirectorySearcher($searchRoot, "(objectClass=*)", @("tokenGroupsGlobalAndUniversal"), [System.DirectoryServices.SearchScope]::Base)
+            $result = $searcher.FindOne()
+
+            if ($null -eq $result) {
+                return
+            }
+
+            foreach ($sidBytes in $result.Properties["tokenGroupsGlobalAndUniversal"]) {
+                $translated = $null
+                $sid = New-Object System.Security.Principal.SecurityIdentifier($sidBytes, 0)
+                try {
+                    $translated = $sid.Translate("System.Security.Principal.NTAccount").ToString()
+                } catch {
+                    try {
+                        Write-Verbose "Failed to do sid.Translate. Doing a lookup instead."
+                        Invoke-CatchActionError $CatchActionFunction
+                        $adObject = ([ADSI]("LDAP://<SID=" + $sid.ToString() + ">"))
+                        $translated = $adObject.Properties["samAccountName"][0].ToString()
+                    } catch {
+                        Write-Verbose "Failed to lookup $sid"
+                        Invoke-CatchActionError $CatchActionFunction
+                    }
+                }
+
+                $tokenGroups.Add([PSCustomObject]@{
+                        SID  = $sid.ToString()
+                        Name = $translated
+                    })
+            }
+        } catch {
+            Write-Verbose "Failed to completely run $($MyInvocation.MyCommand)"
+            Invoke-CatchActionError $CatchActionFunction
+        }
+    }
+    end {
+        return $tokenGroups
+    }
+}


### PR DESCRIPTION
**Issue:**
User can be in the correct groups after having already logged into the machine. However, they still need to log out and back in to get the permissions. 

**Reason:**
Recently had a case where Admin was in the group, but never properly logged off or back into the machine. 

**Fix:**
Collect the token groups as well for the user and then check to see if the required groups are there when the local test fails. If the user is seen as part of the group from the token group, but not locally, they just need to sign out and sign back in. 

Also, if the user isn't running as Administrator, the local test will fail so providing a different error message for that instead. 

![image](https://user-images.githubusercontent.com/22776718/199751992-86a88e5d-6936-42f2-939f-8b564dc40ef7.png)


![image](https://user-images.githubusercontent.com/22776718/199752144-f18ecf43-3bd0-4d2e-97dc-7466f3af906d.png)


**Validation:**
Verified in lab
