### PR TITLE
Include known issue for ServiceControl.ps1 with Reverse

### DIFF
--- a/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ServiceControlReverse.ps1
+++ b/Setup/SetupLogReviewer/Checks/ErrorContext/Test-ServiceControlReverse.ps1
@@ -1,0 +1,40 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\New-ActionPlan.ps1
+. $PSScriptRoot\..\New-ErrorContext.ps1
+function Test-ServiceControlReverse {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [object]
+        $ErrorContext
+    )
+    process {
+        $errorContext = $ErrorContext.ErrorContext
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+
+        $selectString = $errorContext | Select-String -Pattern "System.Management.Automation.MethodInvocationException: Exception calling `"Reverse`" with `"1`" argument"
+
+        if ($null -ne $selectString) {
+            Write-Verbose "Found MethodInvocationException with Reverse, making sure we see Service Control as well"
+            $selectString = $errorContext | Select-String -Pattern "ServiceControl.ps1"
+
+            if ($null -ne $selectString) {
+                Write-Verbose "Found known issue with ServiceControl.ps1, provide valid workaround."
+                $errorContext |
+                    New-ErrorContext
+                New-ActionPlan @(
+                    "1. Find the ServiceControl.ps1 in the Exchange Bin Directory",
+                    "2. Find the following line in the script, within the StopServices function:"
+                    "`t`$services = Get-ServiceToControl `$Roles -Active",
+                    "3. Add in the following:",
+                    "`tif (`$services -eq `$null) { return `$true }",
+                    "4. Save the file and try to run Setup again."
+                )
+            } else {
+                Write-Verbose "Didn't see ServiceControl.ps1, so might not be known issue."
+            }
+        }
+    }
+}

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-KnownIssuesByErrors.ps1
@@ -11,6 +11,7 @@
 . $PSScriptRoot\..\ErrorContext\Test-MissingHomeMdb.ps1
 . $PSScriptRoot\..\ErrorContext\Test-MountDatabaseFailure.ps1
 . $PSScriptRoot\..\ErrorContext\Test-MSExchangeSecurityGroupsContainerDeleted.ps1
+. $PSScriptRoot\..\ErrorContext\Test-ServiceControlReverse.ps1
 . $PSScriptRoot\..\ErrorContext\Test-VirtualDirectoryFailure.ps1
 . $PSScriptRoot\..\ErrorReference\Test-FipsUpgradeConfiguration.ps1
 . $PSScriptRoot\..\ErrorReference\Test-InitializePermissionsOfDomain.ps1
@@ -67,6 +68,7 @@ function Test-KnownIssuesByErrors {
             "Test-MissingHomeMdb",
             "Test-MountDatabaseFailure",
             "Test-MSExchangeSecurityGroupsContainerDeleted",
+            "Test-ServiceControlReverse",
             "Test-VirtualDirectoryFailure",
             "Test-InstallFromBin"
         )

--- a/Setup/Tests/KnownIssues/ExchangeSetup_ServiceControl_Reverse.log
+++ b/Setup/Tests/KnownIssues/ExchangeSetup_ServiceControl_Reverse.log
@@ -1,0 +1,101 @@
+[11/03/2022 20:41:59.0654] [0] **********************************************
+[11/03/2022 20:41:59.0669] [0] Starting Microsoft Exchange Server 2016 Setup
+[11/03/2022 20:41:59.0669] [0] **********************************************
+[11/03/2022 20:41:59.0669] [0] Local time zone: (UTC-05:00) Bogota, Lima, Quito, Rio Branco.
+[11/03/2022 20:41:59.0669] [0] Operating system version: Microsoft Windows NT 6.2.9200.0.
+[11/03/2022 20:41:59.0746] [0] Setup version: 15.1.2507.6.
+[11/03/2022 20:41:59.0749] [0] Logged on user: SOLO\Han.
+[11/03/2022 20:41:59.0810] [0] Command Line Parameter Name='sourcedir', Value='E:\'.
+[11/03/2022 20:41:59.0810] [0] Command Line Parameter Name='mode', Value='Install'.
+[11/03/2022 20:41:59.0826] [0] RuntimeAssembly was started with the following command: '/sourcedir:E: /mode:Install'.
+[11/03/2022 20:42:15.0663] [0] The following roles are installed: AdminToolsRole 
+[11/03/2022 20:42:28.0569] [0] Setup is choosing the domain controller to use
+[11/03/2022 20:42:35.0351] [0] Setup is choosing a local domain controller...
+[11/03/2022 20:42:38.0648] [0] Setup has chosen the local domain controller DC2.Solo.local for initial queries
+[11/03/2022 20:42:38.0790] [0] PrepareAD has been run, and has replicated to this domain controller; so setup will use DC2.Solo.local
+[11/03/2022 20:42:38.0790] [0] Setup is choosing a global catalog...
+[11/03/2022 20:42:38.0838] [0] Setup has chosen the global catalog server DC2.Solo.local.
+[11/03/2022 20:42:38.0901] [0] Setup will use the domain controller 'DC2.Solo.local'.
+[11/03/2022 20:42:38.0901] [0] Setup will use the global catalog 'DC2.Solo.local'.
+[11/03/2022 20:42:38.0901] [0] Exchange configuration container for the organization is 'CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[11/03/2022 20:42:38.0901] [0] Exchange organization container for the organization is 'CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[11/03/2022 20:42:38.0918] [0] Setup will search for an Exchange Server object for the local machine with name 'ExSvr1'.
+[11/03/2022 20:42:39.0091] [0] Exchange Server object found : 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[11/03/2022 20:42:39.0106] [0] The following roles have been unpacked: BridgeheadRole ClientAccessRole MailboxRole UnifiedMessagingRole FrontendTransportRole AdminToolsRole CafeRole 
+[11/03/2022 20:42:39.0106] [0] The following datacenter roles are unpacked: 
+[11/03/2022 20:42:39.0106] [0] The following roles are installed: AdminToolsRole 
+[11/03/2022 20:42:39.0106] [0] The local server has some Exchange files installed.
+[11/03/2022 20:42:39.0233] [0] Server Name=ExSvr1
+[11/03/2022 20:42:39.0248] [0] Setup will use the path 'E:\' for installing Exchange.
+[11/03/2022 20:42:39.0248] [0] Setup will discover the installed roles from server object 'CN=ExSvr1,CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[11/03/2022 20:42:39.0248] [0] 'BridgeheadRole' is installed on the server object.
+[11/03/2022 20:42:39.0248] [0] The installation mode is set to: 'Install'.
+[11/03/2022 20:42:43.0016] [0] An Exchange organization with name 'SoloORG' was found in this forest.
+[11/03/2022 20:42:43.0016] [0] Active Directory Initialization status : 'True'.
+[11/03/2022 20:42:43.0017] [0] Schema Update Required Status : 'False'.
+[11/03/2022 20:42:43.0017] [0] Organization Configuration Update Required Status : 'False'.
+[11/03/2022 20:42:43.0017] [0] Domain Configuration Update Required Status : 'False'.
+[11/03/2022 20:42:43.0018] [0] The locally installed version is 15.1.2507.6.
+[11/03/2022 20:42:43.0018] [0] Exchange Installation Directory : 'D:\Exchange'.
+[11/03/2022 20:42:43.0115] [0] Applying default role selection state
+[11/03/2022 20:42:43.0146] [0] Setup is determining what organization-level operations to perform.
+[11/03/2022 20:42:43.0146] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[11/03/2022 20:42:43.0146] [0] Setup will run from path 'D:\Exchange\'.
+[11/03/2022 20:42:43.0162] [0] InstallModeDataHandler has 13 DataHandlers
+[11/03/2022 20:42:43.0162] [0] RootDataHandler has 1 DataHandlers
+[11/03/2022 20:42:43.0350] [0] CurrentResult launcherbase.maincore:90: 0
+[11/03/2022 20:42:43.0573] [0] Finished loading screen IncompleteInstallationDetectedPage.
+[11/03/2022 20:42:49.0106] [0] Setup is determining what organization-level operations to perform.
+[11/03/2022 20:42:49.0106] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[11/03/2022 20:42:49.0106] [0] Setup will run from path 'D:\Exchange\'.
+[11/03/2022 20:42:49.0106] [0] InstallModeDataHandler has 13 DataHandlers
+[11/03/2022 20:42:49.0106] [0] RootDataHandler has 1 DataHandlers
+[11/03/2022 20:42:49.0123] [0] **************
+[08/02/2022 14:34:41.0558] [1] Evaluated [Setting:ComputerNameDnsFullyQualified] [HasException:False] [Value:"ExSvr1.Solo.local"] [ParentValue:"<NULL>"] [Thread:13] [Duration:00:00:00.0156281]
+[11/03/2022 20:43:20.0669] [2] Ending processing Write-ExchangeSetupLog
+[11/03/2022 20:43:20.0669] [1] The following 1 error(s) occurred during task execution:
+[11/03/2022 20:43:20.0669] [1] 0.  ErrorRecord: Exception calling "Reverse" with "1" argument(s): "Value cannot be null.
+Parameter name: array"
+[11/03/2022 20:43:20.0669] [1] 0.  ErrorRecord: System.Management.Automation.MethodInvocationException: Exception calling "Reverse" with "1" argument(s): "Value cannot be null.
+Parameter name: array" ---> System.ArgumentNullException: Value cannot be null.
+Parameter name: array
+   at System.Array.Reverse(Array array)
+   at CallSite.Target(Closure , CallSite , Type , Object )
+   --- End of inner exception stack trace ---
+   at System.Management.Automation.ExceptionHandlingOps.ConvertToMethodInvocationException(Exception exception, Type typeToThrow, String methodName, Int32 numArgs, MemberInfo memberInfo)
+   at CallSite.Target(Closure , CallSite , Type , Object )
+   at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
+   at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
+[11/03/2022 20:43:20.0669] [1] [ERROR] The following error was generated when "$error.Clear(); 
+          $roleList = $RoleRoles.Replace('Role','').Split(',');
+
+          if($roleList -contains 'LanguagePacks')
+          {
+            & $RoleBinPath\ServiceControl.ps1 Save
+            & $RoleBinPath\ServiceControl.ps1 DisableServices $roleList;
+            & $RoleBinPath\ServiceControl.ps1 Stop $roleList;
+             
+          };
+        " was run: "System.Management.Automation.MethodInvocationException: Exception calling "Reverse" with "1" argument(s): "Value cannot be null.
+Parameter name: array" ---> System.ArgumentNullException: Value cannot be null.
+Parameter name: array
+   at System.Array.Reverse(Array array)
+   at CallSite.Target(Closure , CallSite , Type , Object )
+   --- End of inner exception stack trace ---
+   at System.Management.Automation.ExceptionHandlingOps.ConvertToMethodInvocationException(Exception exception, Type typeToThrow, String methodName, Int32 numArgs, MemberInfo memberInfo)
+   at CallSite.Target(Closure , CallSite , Type , Object )
+   at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
+   at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame)
+   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)".
+[11/03/2022 20:43:20.0669] [1] [ERROR] Exception calling "Reverse" with "1" argument(s): "Value cannot be null.
+Parameter name: array"
+[11/03/2022 20:43:20.0669] [1] [ERROR] Value cannot be null.
+Parameter name: array
+[11/03/2022 20:43:20.0669] [1] [ERROR-REFERENCE] Id=AllRolesPreFileCopyComponent___2f7e3804a2b340c69e930798211fb8fd Component=EXCHANGE14:\Current\Release\Shared\Datacenter\Setup
+[11/03/2022 20:43:20.0669] [1] Setup is stopping now because of one or more critical errors.
+[11/03/2022 20:43:20.0669] [1] Finished executing component tasks.
+[11/03/2022 20:43:20.0717] [1] Ending processing Start-PreFileCopy
+[11/03/2022 20:44:07.0456] [0] CurrentResult setupbase.maincore:396: 0
+[11/03/2022 20:44:07.0456] [0] End of Setup
+[11/03/2022 20:44:07.0456] [0] **********************************************

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -319,6 +319,24 @@ Describe "Testing SetupLogReviewer" {
             Assert-MockCalled -Exactly 1 -CommandName Write-Host `
                 -ParameterFilter { $Object -like "*Do NOT remove the arbitration mailboxes/accounts as they may contain critical information for your environment." }
         }
+
+        It "ServiceControl Reverse Error" {
+            & $sr -SetupLog "$PSScriptRoot\KnownIssues\ExchangeSetup_ServiceControl_Reverse.log"
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*System.Management.Automation.MethodInvocationException*" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*1. Find the ServiceControl.ps1 in the Exchange Bin Directory" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*2. Find the following line in the script, within the StopServices function:" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*`$services = Get-ServiceToControl `$Roles -Active" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*3. Add in the following:" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*if (`$services -eq `$null) { return `$true }" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*4. Save the file and try to run Setup again." }
+        }
     }
 
     Context "Good Test Case" {


### PR DESCRIPTION
**Reason:**
Within the SetupLogReviewer, include the known issue regarding `ServiceControl.ps1` that has services ended up being `null` prior to calling `Reverse`.

**Fix:**
Provide the following output and action plan. 

![image](https://user-images.githubusercontent.com/22776718/200412727-edb93290-035a-4846-b7ec-1ea48228088e.png)


**Validation:**
Tested and included pester testing

