### PR TITLE
Syntax for orphaned folder fix must specify FolderIdentity

### DIFF
--- a/PublicFolders/SourceSideValidations/Tests/MailEnabledFolder/Write-TestMailEnabledFolderResult.ps1
+++ b/PublicFolders/SourceSideValidations/Tests/MailEnabledFolder/Write-TestMailEnabledFolderResult.ps1
@@ -70,7 +70,7 @@ function Write-TestMailEnabledFolderResult {
                 "Import-Csv .\ValidationResults.csv |`n" +
                 " ? ResultType -eq OrphanedMPF |`n" +
                 " % {`n" +
-                "  `$folder = ([ADSI](`"LDAP://`$_`"))`n" +
+                "  `$folder = ([ADSI](`"LDAP://`$(`$_.FolderIdentity)`"))`n" +
                 "  `$parent = ([ADSI]`"`$(`$folder.Parent)`")`n" +
                 "  `$parent.Children.Remove(`$folder)`n" +
                 " }")


### PR DESCRIPTION
Issue:

This syntax doesn't work:

![image](https://user-images.githubusercontent.com/4518572/200415136-ba516475-c961-4dc4-ba3c-4d611d9ed52c.png)

This looks like a missed case. All the other fixes specify $_.FolderIdentity. It's only the OrphanedMPF fix that was missing this piece.

Fix:

![image](https://user-images.githubusercontent.com/4518572/200415283-9fc9ac99-ed9c-4c27-a675-9fa8eb40d222.png)
