### PR TITLE
Improved Confirm-ExchangeShell to use Get-EventLogLevel instead

### DIFF
--- a/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
+++ b/Admin/SetUnifiedContentPath/SetUnifiedContentPath.ps1
@@ -52,7 +52,7 @@ end {
             exit
         }
 
-        $exchangeSession = Confirm-ExchangeShell -Identity $computerNames[0]
+        $exchangeSession = Confirm-ExchangeShell
 
         if (-not ($exchangeSession.ShellLoaded)) {
             Write-Warning "Failed to load Exchange Management Shell."

--- a/Databases/VSSTester/VSSTester.ps1
+++ b/Databases/VSSTester/VSSTester.ps1
@@ -59,7 +59,7 @@ function Main {
     Write-Host "****************************************************************************************"
     Write-Host "****************************************************************************************"
 
-    $Script:LocalExchangeShell = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+    $Script:LocalExchangeShell = Confirm-ExchangeShell
 
     if (!$Script:LocalExchangeShell.ShellLoaded) {
         Write-Host "Failed to load Exchange Shell. Stopping the script."

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -98,7 +98,7 @@ if ( -not ( $($serverExchangeInstallDirectory.MsiProductMajor) -eq 15 -and `
 $ExchangePath = $serverExchangeInstallDirectory.MsiInstallPath
 
 # Check Exchange Shell and Exchange instalation
-$exchangeShell = Confirm-ExchangeShell -Identity $env:computerName
+$exchangeShell = Confirm-ExchangeShell
 if (-not($exchangeShell.ShellLoaded)) {
     Write-Warning "Failed to load Exchange Shell Module..."
     exit

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -185,7 +185,7 @@ function Main {
         exit
     }
 
-    $Script:LocalExchangeShell = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+    $Script:LocalExchangeShell = Confirm-ExchangeShell
 
     if (!($Script:LocalExchangeShell.ShellLoaded)) {
         Write-Host "It appears that you are not on an Exchange 2010 or newer server. Sorry I am going to quit."

--- a/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ScriptLogFileLocation.ps1
@@ -22,7 +22,7 @@ function Invoke-ScriptLogFileLocation {
         return
     }
 
-    $Script:ExchangeShellComputer = Confirm-ExchangeShell -Identity $Script:Server `
+    $Script:ExchangeShellComputer = Confirm-ExchangeShell `
         -CatchActionFunction ${Function:Invoke-CatchActions}
 
     if (!($Script:ExchangeShellComputer.ShellLoaded)) {

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -208,7 +208,7 @@ begin {
     }
 
     try {
-        $exchangeShell = Confirm-ExchangeShell -Identity $env:COMPUTERNAME
+        $exchangeShell = Confirm-ExchangeShell
         if (-not($exchangeShell.ShellLoaded)) {
             Write-Warning "Failed to load the Exchange Management Shell. Start the script using the Exchange Management Shell."
             exit

--- a/Setup/SetExchAVExclusions/Set-ExchAVExclusions.ps1
+++ b/Setup/SetExchAVExclusions/Set-ExchAVExclusions.ps1
@@ -143,7 +143,7 @@ if ($FileName -like '*\*') {
 $ExchangePath = $serverExchangeInstallDirectory.MsiInstallPath
 
 # Check Exchange Shell and Exchange instalation
-$exchangeShell = Confirm-ExchangeShell -Identity $env:computerName
+$exchangeShell = Confirm-ExchangeShell
 if (-not($exchangeShell.ShellLoaded)) {
     Write-Warning "Failed to load Exchange Shell Module..."
     exit


### PR DESCRIPTION
**Reason:**
It is a problem to have `Confirm-ExchangeShell` require a parameter of `Identity` when dealing with a script that can pass in a list of Exchange Servers. The original point of having the `Identity` parameter was to reduce the time it would take to run the cmdlet `Get-ExchangeServer`. However, this made it complicated to call the function when it shouldn't be required to use an `Identity` to check to see if EMS is loaded and working and initial the possible idle session. 


**Fix:**
Change `Confirm-ExchangeShell` to use `Get-EventLogLevel` and remove the `Identity` parameter. 

**Validation:**
Lab tested with `HealthChecker` and `ExchangeLogCollector`

