### PR TITLE
Place Get-ExchangeWebSitesFromAd in a try catch block

### DIFF
--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
@@ -9,5 +9,6 @@ function Get-ExchangeContainer {
     $rootDSE = [ADSI]("LDAP://RootDSE")
     $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
     $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
+    Write-Verbose "Exchange Container Path: $($exchangeContainer.path)"
     return $exchangeContainer
 }

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeProtocolContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeProtocolContainer.ps1
@@ -15,5 +15,6 @@ function Get-ExchangeProtocolContainer {
     $organizationContainer = Get-OrganizationContainer
     $protocolContainerPath = ("CN=Protocols,CN=" + $ComputerName + ",CN=Servers,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups," + $organizationContainer.distinguishedName)
     $protocolContainer = [ADSI]("LDAP://" + $protocolContainerPath)
+    Write-Verbose "Protocol Container Path: $($protocolContainer.Path)"
     return $protocolContainer
 }


### PR DESCRIPTION
**Issue:**
A few customers have reported an issue with Health Checker where it was failing to execute. It appears that in their environment there might be some more issues that are occurring.

In a lab environment, I could not replicate the exception `Exception calling "FindOne" with "0" argument(s): "Unknown error (0x80005000)"`. However, I was able to reproduce the second issue that was reported with adding a deny ACE for an Admin at the Exchange ORG container level. This would result in the exception `Exception calling "FindOne" with "0" argument(s): "There is no such object on the server.`

**Reason:**
The caller is responsible for handling an exception that might occur within the AD functions. 

**Fix:**
Within `Get-ExchangeServerIISSettings` placed `Get-ExchangeWebSitesFromAd` within a `try` `catch` block to handle the issue correctly and allow Health Checker to continue. 

**Validation:**
Lab tested. 


Resolved #1338