### PR TITLE
Always use computer domain to bind to RootDSE

### DIFF
--- a/.build/ValidateMerge.ps1
+++ b/.build/ValidateMerge.ps1
@@ -59,6 +59,7 @@ foreach ($commitMatch in $m) {
         if ($filesAlreadyChecked.Contains($fullPath)) {
             # If we have several commits that modify the same file, we only need to check it once,
             # on the latest commit.
+            Write-Host "  $fileChanged was modified in a later commit."
             continue
         }
 
@@ -81,7 +82,7 @@ foreach ($commitMatch in $m) {
             }
         }
 
-        Write-Host "$fileChanged is included directly or transitively in $($filesAffectedByThisChange.Count - 1) files."
+        Write-Host "  $fileChanged is included directly or transitively in $($filesAffectedByThisChange.Count - 1) files."
     }
 
     foreach ($affectedFile in $allAffectedFiles) {
@@ -108,6 +109,8 @@ foreach ($commitMatch in $m) {
         }
     }
 }
+
+Write-Host
 
 if ($preventMergeFiles.Count -gt 0) {
     Write-Host "The following files have a commit time earlier than main branch. Please rebase your branch to update the commit times."

--- a/.build/ValidateMerge.ps1
+++ b/.build/ValidateMerge.ps1
@@ -54,7 +54,7 @@ foreach ($commitMatch in $m) {
 
     $filesChangedInCommit = git diff-tree --no-commit-id --name-only -r $commitHash
     foreach ($fileChanged in $filesChangedInCommit) {
-        $filesAffectedByThisChange = 0
+        $filesAffectedByThisChange = New-Object 'System.Collections.Generic.HashSet[string]'
         $fullPath = Join-Path $repoRoot $fileChanged
         if ($filesAlreadyChecked.Contains($fullPath)) {
             # If we have several commits that modify the same file, we only need to check it once,
@@ -73,7 +73,7 @@ foreach ($commitMatch in $m) {
         while ($stack.Count -gt 0) {
             $currentFile = $stack.Pop()
             [void]$allAffectedFiles.Add($currentFile)
-            $filesAffectedByThisChange++
+            [void]$filesAffectedByThisChange.Add($currentFile)
             foreach ($k in $deps.Keys) {
                 if ($deps[$k].Contains($currentFile)) {
                     $stack.Push($k)
@@ -81,7 +81,7 @@ foreach ($commitMatch in $m) {
             }
         }
 
-        Write-Host "$fileChanged is included directly or transitively in $($filesAffectedByThisChange - 1) files."
+        Write-Host "$fileChanged is included directly or transitively in $($filesAffectedByThisChange.Count - 1) files."
     }
 
     foreach ($affectedFile in $allAffectedFiles) {

--- a/Admin/Find-AmbiguousSids.ps1
+++ b/Admin/Find-AmbiguousSids.ps1
@@ -4,7 +4,7 @@
 [CmdletBinding()]
 param (
     [string]
-    $GCName = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().FindGlobalCatalog().Name,
+    $GCName = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest.FindGlobalCatalog().Name,
 
     [bool]
     $IgnoreWellKnown = $true

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdPermissions.ps1
@@ -73,7 +73,7 @@ function Get-ExchangeAdPermissions {
 
     try {
         Write-Verbose "Getting the domain information"
-        $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+        $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
         Write-Verbose ("Detected: $($forest.Domains.Count) domain(s)")
         $otherWellKnownObjects = Get-ExchangeOtherWellKnownObjects
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdSchemaClass.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeAdSchemaClass.ps1
@@ -8,7 +8,7 @@ function Get-ExchangeAdSchemaClass {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand) to query $SchemaClassName schema class"
 
-    $rootDSE = [ADSI]("LDAP://RootDSE")
+    $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
 
     if ([string]::IsNullOrEmpty($rootDSE.schemaNamingContext)) {
         return $null

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeDomainConfigVersion.ps1
@@ -19,7 +19,7 @@ function Get-ExchangeDomainConfigVersion {
     }
 
     Write-Verbose "Getting domain information for domain: $Domain"
-    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+    $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
 
     Write-Verbose "Checking if domain is present"
     if ($forest.Domains.Name.Contains($Domain)) {

--- a/Security/src/Test-CVE-2021-34470.ps1
+++ b/Security/src/Test-CVE-2021-34470.ps1
@@ -29,7 +29,7 @@ param (
 
 $ErrorActionPreference = "Stop"
 
-$schemaMaster = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().SchemaRoleOwner
+$schemaMaster = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest.SchemaRoleOwner
 
 $schemaDN = ([ADSI]"LDAP://$($schemaMaster)/RootDSE").schemaNamingContext
 

--- a/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ComputersContainerExists.ps1
@@ -5,7 +5,7 @@
 
 function Test-ComputersContainerExists {
     try {
-        $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+        $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
         foreach ($domain in $forest.Domains) {
             try {
                 $domainDN = $domain.GetDirectoryEntry().distinguishedName

--- a/Setup/SetupAssist/Checks/Domain/Test-DomainControllerDnsHostName.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-DomainControllerDnsHostName.ps1
@@ -3,7 +3,7 @@
 
 . $PSScriptRoot\..\New-TestResult.ps1
 function Test-DomainControllerDnsHostName {
-    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+    $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
     foreach ($domain in $forest.Domains) {
         foreach ($dc in $domain.DomainControllers) {
             $firstDotIndex = $dc.Name.IndexOf(".")

--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -19,7 +19,7 @@ function Test-ExchangeADSetupLevel {
         $localDomainPrep = $null -ne $ADSetupLevel -and $ADSetupLevel.MESO.DN -eq "Unknown"
         Test-UserGroupMemberOf -PrepareAdRequired $true -PrepareSchemaRequired ($latestExchangeVersion.$ExchangeVersion.UpperRange -ne $currentSchemaValue) # -PrepareDomainOnly $localDomainPrep
 
-        $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+        $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
         $params = @{
             TestName = "Prepare AD Requirements"
             Result   = "Failed"

--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -134,7 +134,7 @@ function Test-ExchangeADSetupLevel {
     }
 
     function GetExchangeADSetupLevel {
-        $rootDSE = [ADSI]("LDAP://RootDSE")
+        $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
         $directorySearcher = New-Object System.DirectoryServices.DirectorySearcher
         $directorySearcher.SearchScope = "Subtree"
         $directorySearcher.SearchRoot = [ADSI]("LDAP://" + $rootDSE.configurationNamingContext.ToString())

--- a/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ExchangeADSetupLevel.ps1
@@ -145,7 +145,6 @@ function Test-ExchangeADSetupLevel {
         $directorySearcher.Filter = "(&(name=ms-Exch-Schema-Version-Pt)(objectCategory=attributeSchema))"
         $schemaFindAll = $directorySearcher.FindAll()
 
-        $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
         $directorySearcher.SearchScope = "OneLevel"
         $directorySearcher.SearchRoot = [ADSI]("LDAP://" + $rootDSE.defaultNamingContext.ToString())
         $directorySearcher.Filter = "(objectCategory=msExchSystemObjectsContainer)"

--- a/Shared/ActiveDirectoryFunctions/Get-ADReplicationStatus.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ADReplicationStatus.ps1
@@ -230,7 +230,7 @@ function Get-ADReplicationStatus {
     }
 
     process {
-        $rootDSE = [ADSI]("LDAP://RootDSE")
+        $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
         $sitesContainerPath = ("CN=Sites," + $rootDSE.configurationNamingContext)
         $sitesContainer = [ADSI]("LDAP://" + $sitesContainerPath)
         $ntdsaSearcher = New-Object System.DirectoryServices.DirectorySearcher($sitesContainer, "(objectClass=nTDSDSA)", @("distinguishedName", "options"))

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeContainer.ps1
@@ -6,7 +6,7 @@ function Get-ExchangeContainer {
     [OutputType([System.DirectoryServices.DirectoryEntry])]
     param ()
 
-    $rootDSE = [ADSI]("LDAP://RootDSE")
+    $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
     $exchangeContainerPath = ("CN=Microsoft Exchange,CN=Services," + $rootDSE.configurationNamingContext)
     $exchangeContainer = [ADSI]("LDAP://" + $exchangeContainerPath)
     Write-Verbose "Exchange Container Path: $($exchangeContainer.path)"

--- a/Shared/ActiveDirectoryFunctions/Get-TokenGroupsGlobalAndUniversal.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-TokenGroupsGlobalAndUniversal.ps1
@@ -26,7 +26,7 @@ function Get-TokenGroupsGlobalAndUniversal {
     process {
         try {
             if ([string]::IsNullOrEmpty($GCName)) {
-                $rootDSE = [ADSI]("GC://RootDSE")
+                $rootDSE = [ADSI]("GC://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
                 $GCName = $rootDSE.dnsHostName
             }
 

--- a/Shared/ActiveDirectoryFunctions/Search-AllActiveDirectoryDomains.ps1
+++ b/Shared/ActiveDirectoryFunctions/Search-AllActiveDirectoryDomains.ps1
@@ -17,7 +17,7 @@ function Search-AllActiveDirectoryDomains {
         $CacheResults = $false
     )
 
-    $rootDSE = [ADSI]("GC://RootDSE")
+    $rootDSE = [ADSI]("GC://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
     $container = [ADSI]("GC://$($rootDSE.dnsHostName)")
     $searcher = $null
     if ($null -ne $PropertiesToLoad) {

--- a/Shared/Get-WellKnownGroupSid.ps1
+++ b/Shared/Get-WellKnownGroupSid.ps1
@@ -29,7 +29,7 @@ function Get-WellKnownGroupSid {
         $GroupType
     )
 
-    $forest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+    $forest = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest
 
     $rootDomainSidBytes = [byte[]] $forest.RootDomain.GetDirectoryEntry().Properties["objectSid"][0]
     $rootDomainSid = New-Object System.Security.Principal.SecurityIdentifier($rootDomainSidBytes, 0)


### PR DESCRIPTION
**Issue:**
If a user is logged in to a machine in the Exchange forest using a user account from a trusted forest, binding to LDAP://RootDSE gives us the user forest.

**Fix:**
Get the computer's domain and explicitly bind to that RootDSE.

