### PR TITLE
CVE-2022-21978 check doesn't work well when running AD split permissions

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -251,3 +251,6 @@ function Get-ExchangeProtocolContainer {
 function Get-ExchangeWebSitesFromAd {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeWebSitesFromAd.xml"
 }
+function Get-ExchangeADSplitPermissionsEnabled {
+    return $false
+}

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeADSplitPermissionsEnabled.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeADSplitPermissionsEnabled.ps1
@@ -1,0 +1,41 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\ErrorMonitorFunctions.ps1
+
+function Get-ExchangeADSplitPermissionsEnabled {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param ()
+
+    <#
+        The following bullets are AD split permissions indicators:
+        - An organizational unit (OU) named Microsoft 'Exchange Protected Groups' is created
+        - The 'Exchange Windows Permissions' security group is created/moved in/to the 'Microsoft Exchange Protected Groups' OU
+        - The 'Exchange Trusted Subsystem' security group isn't member of the 'Exchange Windows Permissions' security group
+        - ACEs that would have been assigned to the 'Exchange Windows Permissions' security group aren't added to the Active Directory domain object
+        See: https://learn.microsoft.com/exchange/permissions/split-permissions/split-permissions?view=exchserver-2019#active-directory-split-permissions
+    #>
+
+    $isADSplitPermissionsEnabled = $false
+    try {
+        $rootDSE = [ADSI]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name)/RootDSE")
+        $exchangeTrustedSubsystemDN = ("CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups," + $rootDSE.rootDomainNamingContext)
+        $adSearcher = New-Object DirectoryServices.DirectorySearcher
+        $adSearcher.Filter = '(&(objectCategory=group)(cn=Exchange Windows Permissions))'
+        $adSearcher.SearchRoot = ("LDAP://OU=Microsoft Exchange Protected Groups," + $rootDSE.rootDomainNamingContext)
+        $adSearcherResult = $adSearcher.FindOne()
+
+        if ($null -ne $adSearcherResult) {
+            Write-Verbose "'Exchange Windows Permissions' in 'Microsoft Exchange Protected Groups' OU detected"
+            # AD split permissions is enabled if 'Exchange Trusted Subsystem' isn't a member of the 'Exchange Windows Permissions' security group
+            $isADSplitPermissionsEnabled = (($null -eq $adSearcherResult.Properties.member) -or
+            (-not($adSearcherResult.Properties.member).ToLower().Contains($exchangeTrustedSubsystemDN.ToLower())))
+        }
+    } catch {
+        Write-Verbose "OU 'Microsoft Exchange Protected Groups' was not found - AD split permissions not enabled"
+        Invoke-CatchActions
+    }
+
+    return $isADSplitPermissionsEnabled
+}


### PR DESCRIPTION
**Issue:**
Multiple customers reported that the `CVE-2022-21978` isn't working and reported that the environment is vulnerable to this CVE. 

**Reason:**
All of these customers have AD split permissions in use. The following ACE check was marked as failed for each of those customers:

```
Trying to find the entry GUID: 0296c120-40da-11d1-a9c0-0000f80367c1
ObjectDN: DC=ad,DC=domain,DC=dom
Ace Result Check Passed: False
```

I assume it's expected to not have this ACE in place in AD split permissions scenarios:
_All ACEs assigned to the Exchange Windows Permissions security group are removed from the domain object._

https://learn.microsoft.com/en-us/exchange/permissions/split-permissions/split-permissions?view=exchserver-2019#active-directory-split-permissions

**Fix:**
Added a new function (`Get-ExchangeADSplitPermissionsEnabled`) to detect if customers are running AD split permissions mode. If they do so, initiate a fallback to check for the 'objectVersion (Default)' instead of the ACE.

**Validation:**
Lab & affected customer

