### PR TITLE
Domain Prep Required, found duplicate MESO Containers

### DIFF
--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
@@ -1,7 +1,9 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\..\New-ActionPlan.ps1
 . $PSScriptRoot\..\New-WriteObject.ps1
+. $PSScriptRoot\..\Test-SetupAssist.ps1
 function Test-PrerequisiteCheck {
     [CmdletBinding()]
     param(
@@ -72,6 +74,16 @@ function Test-PrerequisiteCheck {
 
         if (($SetupLogReviewer | TestEvaluatedSettingOrRule -SettingName "IISURLRewriteNotInstalled" -SettingOrRule "Rule") -eq "True") {
             New-WriteObject "IIS URL Rewrite is not installed on the computer. Install it before running setup again." -ForegroundColor "Red"
+        }
+
+        if ((($SetupLogReviewer | TestEvaluatedSettingOrRule -SettingName "LocalDomainIsPrepped") -eq "False") -and
+            (($SetupLogReviewer |  TestEvaluatedSettingOrRule -SettingName "DomainPrepRequired" -SettingOrRule "Rule") -eq "True")) {
+            New-WriteObject "Local Domain Is Not Prepped or might have duplicate MESO Containers" -ForegroundColor "Red"
+            if (Test-SetupAssist) {
+                New-ActionPlan @("Address the problem MESO Containers in 'Exchange AD Latest Level' test above")
+            } else {
+                New-ActionPlan @("Run SetupAssist on the server to determine the problem and correct action plan.")
+            }
         }
 
         if ($returnNow) {

--- a/Setup/Tests/PrerequisiteCheck/ExchangeSetup_DomainPrepRequired.log
+++ b/Setup/Tests/PrerequisiteCheck/ExchangeSetup_DomainPrepRequired.log
@@ -1,0 +1,563 @@
+[12/01/2022 00:49:12.0073] [0] **********************************************
+[12/01/2022 00:49:12.0073] [0] Starting Microsoft Exchange Server 2019 Setup
+[12/01/2022 00:49:12.0073] [0] **********************************************
+[12/01/2022 00:49:12.0088] [0] Local time zone: (UTC-05:00) Eastern Time (US & Canada).
+[12/01/2022 00:49:12.0088] [0] Operating system version: Microsoft Windows NT 6.2.9200.0.
+[12/01/2022 00:49:12.0088] [0] Setup version: 15.2.922.7.
+[12/01/2022 00:49:12.0088] [0] Logged on user: SOLO\Han.
+[12/01/2022 00:49:12.0088] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\V15\Setup, wasn't found.
+[12/01/2022 00:49:12.0291] [0] Command Line Parameter Name='mode', Value='Install'.
+[12/01/2022 00:49:12.0291] [0] Command Line Parameter Name='roles', Value='Microsoft.Exchange.Management.Deployment.RoleCollection'.
+[12/01/2022 00:49:12.0291] [0] Command Line Parameter Name='iacceptexchangeserverlicenseterms', Value=''.
+[12/01/2022 00:49:12.0291] [0] Command Line Parameter Name='sourcedir', Value='D:\'.
+[12/01/2022 00:49:12.0291] [0] RuntimeAssembly was started with the following command: '/mode:install /role:mailbox /IAcceptExchangeServerLicenseTerms /sourcedir:D:"'.
+[12/01/2022 00:49:12.0291] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Exchange\v8.0, wasn't found.
+[12/01/2022 00:49:12.0291] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v14, wasn't found.
+[12/01/2022 00:49:12.0291] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\V15\Setup, wasn't found.
+[12/01/2022 00:49:12.0291] [0] Copying Files...
+[12/01/2022 00:49:12.0307] [0] Starting copy from D:\Setup\ServerRoles\Common to C:\Windows\Temp\ExchangeSetup.
+[12/01/2022 00:49:15.0439] [0] Finished copy from D:\Setup\ServerRoles\Common to C:\Windows\Temp\ExchangeSetup.
+[12/01/2022 00:49:15.0439] [0] File copy complete.  Setup will now collect additional information needed for installation.
+
+[12/01/2022 00:49:15.0455] [0] Assembly dll file location is C:\Windows\Temp\ExchangeSetup\Microsoft.Exchange.Setup.Console.dll
+[12/01/2022 00:49:18.0314] [0] Setup is choosing the domain controller to use
+[12/01/2022 00:49:24.0672] [0] Setup is choosing a local domain controller...
+[12/01/2022 00:49:28.0469] [0] Setup has chosen the local domain controller DC2.Solo.local for initial queries
+[12/01/2022 00:49:28.0875] [0] PrepareAD has been run, and has replicated to this domain controller; so setup will use DC2.Solo.local
+[12/01/2022 00:49:28.0875] [0] Setup is choosing a global catalog...
+[12/01/2022 00:49:28.0891] [0] Setup has chosen the global catalog server DC2.Solo.local.
+[12/01/2022 00:49:28.0922] [0] Setup will use the domain controller 'DC2.Solo.local'.
+[12/01/2022 00:49:28.0922] [0] Setup will use the global catalog 'DC2.Solo.local'.
+[12/01/2022 00:49:28.0922] [0] Exchange configuration container for the organization is 'CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/01/2022 00:49:28.0937] [0] Exchange organization container for the organization is 'CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local'.
+[12/01/2022 00:49:28.0953] [0] Setup will search for an Exchange Server object for the local machine with name 'ExSvr1'.
+[12/01/2022 00:49:28.0984] [0] No Exchange Server with identity 'ExSvr1' was found.
+[12/01/2022 00:49:29.0062] [0] The following roles have been unpacked: 
+[12/01/2022 00:49:29.0062] [0] The following datacenter roles are unpacked: 
+[12/01/2022 00:49:29.0062] [0] The following roles are installed: 
+[12/01/2022 00:49:29.0062] [0] The local server does not have any Exchange files installed.
+[12/01/2022 00:49:29.0078] [0] Server Name=ExSvr1
+[12/01/2022 00:49:29.0078] [0] Setup will use the path 'D:\' for installing Exchange.
+[12/01/2022 00:49:29.0094] [0] The installation mode is set to: 'Install'.
+[12/01/2022 00:49:35.0500] [0] An Exchange organization with name 'SoloORG' was found in this forest.
+[12/01/2022 00:49:35.0500] [0] Active Directory Initialization status : 'True'.
+[12/01/2022 00:49:35.0500] [0] Schema Update Required Status : 'False'.
+[12/01/2022 00:49:35.0500] [0] Organization Configuration Update Required Status : 'False'.
+[12/01/2022 00:49:35.0500] [0] Domain Configuration Update Required Status : 'False'.
+[12/01/2022 00:49:35.0703] [0] Applying default role selection state
+[12/01/2022 00:49:35.0735] [0] Setup is determining what organization-level operations to perform.
+[12/01/2022 00:49:35.0735] [0] Because the value was specified, setup is setting the argument OrganizationName to the value SoloORG.
+[12/01/2022 00:49:35.0735] [0] Setup will run from path 'C:\Windows\Temp\ExchangeSetup'.
+[12/01/2022 00:49:35.0766] [0] InstallModeDataHandler has 13 DataHandlers
+[12/01/2022 00:49:35.0766] [0] RootDataHandler has 1 DataHandlers
+[12/01/2022 00:49:35.0766] [0]      Languages
+[12/01/2022 00:49:35.0766] [0]      Management tools
+[12/01/2022 00:49:35.0766] [0]      Mailbox role: Transport service
+[12/01/2022 00:49:35.0766] [0]      Mailbox role: Client Access service
+[12/01/2022 00:49:35.0782] [0]      Mailbox role: Mailbox service
+[12/01/2022 00:49:35.0782] [0]      Mailbox role: Front End Transport service
+[12/01/2022 00:49:35.0782] [0]      Mailbox role: Client Access Front End service
+[12/01/2022 00:49:35.0798] [0] Validating options for the 5 requested roles
+[12/01/2022 00:49:35.0844] [0] Performing Microsoft Exchange Server Prerequisite Check
+[12/01/2022 00:49:35.0953] [0] **************
+[12/01/2022 00:49:41.0727] [1] Evaluated [Setting:ComputerNameDnsFullyQualified] [HasException:False] [Value:"ExSvr1.Solo.local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0524] [1] Finished [Rule:E16E15CoexistenceMinVersionRequirementForDC] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Started [Rule:MsDSBehaviorVersionRequirement] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0524] [1] Started [Setting:MsDSBehaviorVersion] [Parent:RootAnalysisMember] [ValueType:Int32]
+[12/01/2022 00:49:41.0524] [1] Evaluated [Setting:MicrosoftExchAdminGroupsMailboxRoleConfig] [HasException:False] [Value:"System.DirectoryServices.ResultPropertyCollection"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Finished [Setting:MicrosoftExchAdminGroupsMailboxRoleConfig] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Evaluated [Setting:MailboxRoleOfEqualOrHigherVersion] [HasException:False] [Value:"SOLO-E19A"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Finished [Setting:MailboxRoleOfEqualOrHigherVersion] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Evaluated [Rule:DelegatedMailboxFirstInstall] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Finished [Rule:DelegatedMailboxFirstInstall] [Duration:00:00:00.0156279]
+[12/01/2022 00:49:41.0524] [1] Started [Rule:DelegatedClientAccessFirstInstall] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0524] [1] Started [Setting:ClientAccessRoleOfEqualOrHigherVersion] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0524] [1] Evaluated [Setting:MsDSBehaviorVersion] [HasException:False] [Value:"7"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00]
+[12/01/2022 00:49:41.0524] [1] Finished [Setting:MsDSBehaviorVersion] [Duration:00:00:00]
+[12/01/2022 00:49:41.0524] [1] Started [Setting:MsDSBehaviorVersionDomain] [Parent:RootAnalysisMember] [ValueType:Int32]
+[12/01/2022 00:49:41.0524] [1] Started [Setting:MicrosoftExchAdminGroupsClientAccessRoleConfig] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Setting:MsDSBehaviorVersionDomain] [HasException:True] [Value:
+System.DirectoryServices.DirectoryServicesCOMException (0x80072030): There is no such object on the server.
+
+   at System.DirectoryServices.DirectoryEntry.Bind(Boolean throwIfFail)
+   at System.DirectoryServices.DirectoryEntry.Bind()
+   at System.DirectoryServices.DirectoryEntry.get_AdsObject()
+   at System.DirectoryServices.DirectorySearcher.FindAll(Boolean findMoreThanOne)
+   at Microsoft.Exchange.Management.Deployment.ADProvider.Run(Boolean useGC, String directoryEntry, String[] listOfPropertiesToCollect, String filter, SearchScope searchScope)
+   at Microsoft.Exchange.Management.Analysis.PrereqAnalysis.<CreateActiveDirectoryPrereqProperties>b__2381_116(Result`1 x)
+   at Microsoft.Exchange.Management.Analysis.Builders.SettingBuilder`2.<>c__DisplayClass2_0.<SetValue>b__0(Result x)
+] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Finished [Setting:MsDSBehaviorVersionDomain] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Rule:MsDSBehaviorVersionRequirement] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Finished [Rule:MsDSBehaviorVersionRequirement] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Started [Rule:WindowsServer2008CoreServerEdition] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Rule:WindowsServer2008CoreServerEdition] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00]
+[12/01/2022 00:49:41.0539] [1] Finished [Rule:WindowsServer2008CoreServerEdition] [Duration:00:00:00]
+[12/01/2022 00:49:41.0539] [1] Started [Rule:ValidOSVersion] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0539] [1] Started [Setting:hostFQDNCheck] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Setting:MicrosoftExchAdminGroupsClientAccessRoleConfig] [HasException:False] [Value:"System.DirectoryServices.ResultPropertyCollection"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Finished [Setting:MicrosoftExchAdminGroupsClientAccessRoleConfig] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Setting:hostFQDNCheck] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00]
+[12/01/2022 00:49:41.0539] [1] Finished [Setting:hostFQDNCheck] [Duration:00:00:00]
+[12/01/2022 00:49:41.0539] [1] Started [Setting:WindowsServer2019Version] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Setting:ClientAccessRoleOfEqualOrHigherVersion] [HasException:False] [Value:"SOLO-E19A"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Finished [Setting:ClientAccessRoleOfEqualOrHigherVersion] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Evaluated [Rule:DelegatedClientAccessFirstInstall] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Finished [Rule:DelegatedClientAccessFirstInstall] [Duration:00:00:00.0156261]
+[12/01/2022 00:49:41.0539] [1] Started [Rule:SchemaFSMONotWin2003SPn] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0539] [1] Started [Setting:Win2003FSMOSchemaServer] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0539] [1] Started [Setting:SmoOperatingSystemVersion] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0555] [1] Started [Setting:SmoRoleSchemaRef] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0555] [1] Started [Setting:ServerReference] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0555] [1] Evaluated [Setting:ServerReference] [HasException:False] [Value:"CN=SOLO-DC2,OU=Domain Controllers,DC=Solo,DC=local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0555] [1] Finished [Setting:ServerReference] [Duration:00:00:00]
+[12/01/2022 00:49:41.0602] [1] Evaluated [Setting:SmoRoleSchemaRef] [HasException:False] [Value:"System.DirectoryServices.ResultPropertyCollection"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0468774]
+[12/01/2022 00:49:41.0602] [1] Finished [Setting:SmoRoleSchemaRef] [Duration:00:00:00.0468774]
+[12/01/2022 00:49:41.0602] [1] Evaluated [Setting:SmoOperatingSystemVersion] [HasException:False] [Value:"10.0 (17763)"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Finished [Setting:SmoOperatingSystemVersion] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Evaluated [Setting:Win2003FSMOSchemaServer] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Finished [Setting:Win2003FSMOSchemaServer] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Evaluated [Rule:SchemaFSMONotWin2003SPn] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Finished [Rule:SchemaFSMONotWin2003SPn] [Duration:00:00:00.0624969]
+[12/01/2022 00:49:41.0602] [1] Started [Rule:DomainControllerIsOutOfSite] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0602] [1] Started [Setting:DomainControllerSiteName] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0602] [1] Started [Setting:DomainController] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Setting:DomainController] [HasException:False] [Value:"DC2.Solo.local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Finished [Setting:DomainController] [Duration:00:00:00.0156374]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Setting:DomainControllerSiteName] [HasException:False] [Value:"Default-First-Site-Name"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156374]
+[12/01/2022 00:49:41.0618] [1] Finished [Setting:DomainControllerSiteName] [Duration:00:00:00.0156374]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Rule:DomainControllerIsOutOfSite] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156374]
+[12/01/2022 00:49:41.0618] [1] Finished [Rule:DomainControllerIsOutOfSite] [Duration:00:00:00.0156374]
+[12/01/2022 00:49:41.0618] [1] Started [Rule:ComputerNameDiscrepancy] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0618] [1] Started [Setting:ComputerNameDnsHostname] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Setting:ComputerNameDnsHostname] [HasException:False] [Value:"ExSvr1"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Finished [Setting:ComputerNameDnsHostname] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Started [Setting:ComputerNameNetBIOS] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Setting:ComputerNameNetBIOS] [HasException:False] [Value:"ExSvr1"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Finished [Setting:ComputerNameNetBIOS] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Rule:ComputerNameDiscrepancy] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Finished [Rule:ComputerNameDiscrepancy] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Started [Rule:DNSDomainNameNotValid] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0618] [1] Started [Setting:ComputerNameDnsDomain] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0618] [1] Evaluated [Setting:ComputerNameDnsDomain] [HasException:False] [Value:"Skywalker.local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0618] [1] Finished [Setting:ComputerNameDnsDomain] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Evaluated [Rule:DNSDomainNameNotValid] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Finished [Rule:DNSDomainNameNotValid] [Duration:00:00:00.0156113]
+[12/01/2022 00:49:41.0633] [1] Started [Rule:AdInitErrorRule] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0633] [1] Started [Setting:AdInitError] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0633] [1] Evaluated [Setting:AdInitError] [HasException:False] [Value:""] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Finished [Setting:AdInitError] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Evaluated [Rule:AdInitErrorRule] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Finished [Rule:AdInitErrorRule] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Started [Rule:NoConnectorToStar] [Parent:RootAnalysisMember] [RuleType:Warning]
+[12/01/2022 00:49:41.0633] [1] Started [Setting:E15orHigherHubAlreadyExists] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0633] [1] Started [Setting:MicrosoftExchServicesConfigBridgeheadRoleInTopology] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0633] [1] Evaluated [Setting:MicrosoftExchServicesConfigBridgeheadRoleInTopology] [HasException:False] [Value:"System.DirectoryServices.ResultPropertyCollection"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Finished [Setting:MicrosoftExchServicesConfigBridgeheadRoleInTopology] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Evaluated [Setting:E15orHigherHubAlreadyExists] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Finished [Setting:E15orHigherHubAlreadyExists] [Duration:00:00:00]
+[12/01/2022 00:49:41.0633] [1] Started [Setting:ConnectorToStar] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0649] [1] Evaluated [Setting:ConnectorToStar] [HasException:False] [Value:""] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156271]
+[12/01/2022 00:49:41.0649] [1] Finished [Setting:ConnectorToStar] [Duration:00:00:00.0156271]
+[12/01/2022 00:49:41.0649] [1] Evaluated [Rule:NoConnectorToStar] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156271]
+[12/01/2022 00:49:41.0649] [1] Finished [Rule:NoConnectorToStar] [Duration:00:00:00.0156271]
+[12/01/2022 00:49:41.0649] [1] Started [Rule:DuplicateShortProvisionedName] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0649] [1] Evaluated [Rule:DuplicateShortProvisionedName] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0649] [1] Finished [Rule:DuplicateShortProvisionedName] [Duration:00:00:00]
+[12/01/2022 00:49:41.0649] [1] Started [Rule:InhBlockPublicFolderTree] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0649] [1] Started [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersNtSecurityDescriptor] [Parent:RootAnalysisMember] [ValueType:Byte[]]
+[12/01/2022 00:49:41.0649] [1] Started [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersConfig] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0649] [1] Started [Setting:MicrosoftExchServicesConfigAdminGroupDistinguishedName] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0665] [1] Evaluated [Setting:MicrosoftExchServicesConfigAdminGroupDistinguishedName] [HasException:False] [Value:"CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=SoloORG,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=Solo,DC=local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Finished [Setting:MicrosoftExchServicesConfigAdminGroupDistinguishedName] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Evaluated [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersConfig] [HasException:True] [Value:
+System.DirectoryServices.DirectoryServicesCOMException (0x80072030): There is no such object on the server.
+
+   at System.DirectoryServices.DirectoryEntry.Bind(Boolean throwIfFail)
+   at System.DirectoryServices.DirectoryEntry.Bind()
+   at System.DirectoryServices.DirectoryEntry.get_AdsObject()
+   at System.DirectoryServices.DirectorySearcher.FindAll(Boolean findMoreThanOne)
+   at Microsoft.Exchange.Management.Deployment.ADProvider.Run(Boolean useGC, String directoryEntry, String[] listOfPropertiesToCollect, String filter, SearchScope searchScope)
+   at Microsoft.Exchange.Management.Analysis.PrereqAnalysis.<CreateActiveDirectoryPrereqProperties>b__2381_120(Result`1 x)
+   at Microsoft.Exchange.Management.Analysis.Builders.SettingBuilder`2.<>c__DisplayClass2_0.<SetValue>b__0(Result x)
+] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Finished [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersConfig] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Evaluated [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersNtSecurityDescriptor] [HasException:False] [Value:"System.Byte[]"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Finished [Setting:MicrosoftExchServicesConfigAdminGroupPublicFoldersNtSecurityDescriptor] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Evaluated [Rule:InhBlockPublicFolderTree] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Finished [Rule:InhBlockPublicFolderTree] [Duration:00:00:00.0157279]
+[12/01/2022 00:49:41.0665] [1] Started [Rule:RusMissing] [Parent:RootAnalysisMember] [RuleType:Warning]
+[12/01/2022 00:49:41.0665] [1] Started [Setting:RusName] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0680] [1] Started [Setting:MicrosoftExchangeSystemObjectsCN] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0680] [1] Started [Setting:DomainNCName] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0680] [1] Evaluated [Setting:DomainNCName] [HasException:False] [Value:"DC=Child,DC=Solo,DC=local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0680] [1] Finished [Setting:DomainNCName] [Duration:00:00:00]
+[12/01/2022 00:49:41.0696] [1] Evaluated [Setting:FileVersionUrefs] [HasException:False] [Value:"10.0.17763.2090"] [ParentValue:"<NULL>"] [Thread:52] [Duration:00:00:00.7970557]
+[12/01/2022 00:49:41.0696] [1] Finished [Setting:FileVersionUrefs] [Duration:00:00:00.7970557]
+[12/01/2022 00:49:41.0696] [1] Started [Setting:WindowsBuild] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0696] [1] Evaluated [Setting:WindowsBuild] [HasException:False] [Value:"17763"] [ParentValue:"<NULL>"] [Thread:52] [Duration:00:00:00]
+[12/01/2022 00:49:41.0696] [1] Finished [Setting:WindowsBuild] [Duration:00:00:00]
+[12/01/2022 00:49:41.0696] [1] Evaluated [Rule:Win2k12UrefsUpdateNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:52] [Duration:00:00:00.7970557]
+[12/01/2022 00:49:41.0696] [1] Finished [Rule:Win2k12UrefsUpdateNotInstalled] [Duration:00:00:00.7970557]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:MicrosoftExchangeSystemObjectsCN] [HasException:False] [Value:"Microsoft Exchange System Objects"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0312525]
+[12/01/2022 00:49:41.0711] [1] Finished [Setting:MicrosoftExchangeSystemObjectsCN] [Duration:00:00:00.0312525]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:RusName] [HasException:False] [Value:""] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0467689]
+[12/01/2022 00:49:41.0711] [1] Finished [Setting:RusName] [Duration:00:00:00.0467689]
+[12/01/2022 00:49:41.0711] [1] Started [Setting:Exchange200x] [Parent:ExchangeSerialNumber] [ValueType:Boolean]
+[12/01/2022 00:49:41.0711] [1] Started [Setting:ExchangeSerialNumber] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:ExchangeSerialNumber] [HasException:False] [Value:"Version 15.2 (Build 30922.7)"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:Exchange200x] [HasException:False] [Value:"False"] [ParentValue:"Version 15.2 (Build 30922.7)"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:ExchangeSerialNumber] [HasException:False] [Value:"Version 15.2 (Build 30922.7)"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:Exchange200x] [HasException:False] [Value:"False"] [ParentValue:"Version 15.2 (Build 30922.7)"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:ExchangeSerialNumber] [HasException:False] [Value:"Version 15.2 (Build 30922.7)"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Setting:Exchange200x] [HasException:False] [Value:"False"] [ParentValue:"Version 15.2 (Build 30922.7)"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Finished [Setting:ExchangeSerialNumber] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Finished [Setting:Exchange200x] [Duration:00:00:00]
+[12/01/2022 00:49:41.0711] [1] Evaluated [Rule:RusMissing] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0467689]
+[12/01/2022 00:49:41.0711] [1] Finished [Rule:RusMissing] [Duration:00:00:00.0467689]
+[12/01/2022 00:49:41.0711] [1] Started [Rule:ServerFQDNMatchesSMTPPolicy] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0727] [1] Started [Setting:GatewayProxy] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0727] [1] Started [Setting:ExchangeRecipientPolicyConfiguration] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0727] [1] Evaluated [Setting:ExchangeRecipientPolicyConfiguration] [HasException:False] [Value:"System.DirectoryServices.ResultPropertyCollection"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Finished [Setting:ExchangeRecipientPolicyConfiguration] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Evaluated [Setting:GatewayProxy] [HasException:False] [Value:"solo.local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Finished [Setting:GatewayProxy] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Started [Setting:ComputerNameDnsFullyQualified] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0727] [1] Evaluated [Setting:ComputerNameDnsFullyQualified] [HasException:False] [Value:"ExSvr1.Solo.local"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Finished [Setting:ComputerNameDnsFullyQualified] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Evaluated [Rule:ServerFQDNMatchesSMTPPolicy] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156252]
+[12/01/2022 00:49:41.0727] [1] Finished [Rule:ServerFQDNMatchesSMTPPolicy] [Duration:00:00:00.0156252]
+[12/01/2022 00:49:41.0727] [1] Started [Rule:SmtpAddressLiteral] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0727] [1] Evaluated [Rule:SmtpAddressLiteral] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Finished [Rule:SmtpAddressLiteral] [Duration:00:00:00]
+[12/01/2022 00:49:41.0727] [1] Started [Rule:OffLineABServerDeleted] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0743] [1] Started [Setting:OffLineABServer] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0743] [1] Started [Setting:ExchOab] [Parent:RootAnalysisMember] [ValueType:ResultPropertyCollection]
+[12/01/2022 00:49:41.0743] [1] Evaluated [Setting:ExchOab] [HasException:True] [Value:
+System.DirectoryServices.DirectoryServicesCOMException (0x80072030): There is no such object on the server.
+
+   at System.DirectoryServices.DirectoryEntry.Bind(Boolean throwIfFail)
+   at System.DirectoryServices.DirectoryEntry.Bind()
+   at System.DirectoryServices.DirectoryEntry.get_AdsObject()
+   at System.DirectoryServices.DirectorySearcher.FindAll(Boolean findMoreThanOne)
+   at Microsoft.Exchange.Management.Deployment.ADProvider.Run(Boolean useGC, String directoryEntry, String[] listOfPropertiesToCollect, String filter, SearchScope searchScope)
+   at Microsoft.Exchange.Management.Analysis.PrereqAnalysis.<CreateActiveDirectoryPrereqProperties>b__2381_123(Result`1 x)
+   at Microsoft.Exchange.Management.Analysis.Builders.SettingBuilder`2.<>c__DisplayClass2_0.<SetValue>b__0(Result x)
+] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0743] [1] Finished [Setting:ExchOab] [Duration:00:00:00]
+[12/01/2022 00:49:41.0743] [1] Finished [Setting:OffLineABServer] [Duration:00:00:00]
+[12/01/2022 00:49:41.0743] [1] Evaluated [Rule:OffLineABServerDeleted] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156218]
+[12/01/2022 00:49:41.0743] [1] Finished [Rule:OffLineABServerDeleted] [Duration:00:00:00.0156218]
+[12/01/2022 00:49:41.0743] [1] Started [Rule:ExchangeAlreadyInstalled] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0743] [1] Evaluated [Setting:FileVersionRefs] [HasException:False] [Value:"10.0.17763.2090"] [ParentValue:"<NULL>"] [Thread:53] [Duration:00:00:00.8281125]
+[12/01/2022 00:49:41.0743] [1] Finished [Setting:FileVersionRefs] [Duration:00:00:00.8281125]
+[12/01/2022 00:49:41.0743] [1] Evaluated [Rule:Win2k12RefsUpdateNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:53] [Duration:00:00:00.8281125]
+[12/01/2022 00:49:41.0743] [1] Finished [Rule:Win2k12RefsUpdateNotInstalled] [Duration:00:00:00.8281125]
+[12/01/2022 00:49:41.0758] [1] Started [Setting:MsiProductMajor] [Parent:RootAnalysisMember] [ValueType:Nullable`1]
+[12/01/2022 00:49:41.0758] [1] Evaluated [Setting:MsiProductMajor] [HasException:True] [Value:
+Expected failure for MsiProductMajor:The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\Setup, wasn't found.
+] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0758] [1] Finished [Setting:MsiProductMajor] [Duration:00:00:00]
+[12/01/2022 00:49:41.0758] [1] Started [Setting:NewestBuild] [Parent:RootAnalysisMember] [ValueType:Nullable`1]
+[12/01/2022 00:49:41.0758] [1] Evaluated [Setting:NewestBuild] [HasException:True] [Value:
+Expected failure for NewestBuild:The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\Setup, wasn't found.
+] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:41.0758] [1] Finished [Setting:NewestBuild] [Duration:00:00:00]
+[12/01/2022 00:49:41.0758] [1] Evaluated [Rule:ExchangeAlreadyInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.0156255]
+[12/01/2022 00:49:41.0758] [1] Finished [Rule:ExchangeAlreadyInstalled] [Duration:00:00:00.0156255]
+[12/01/2022 00:49:41.0758] [1] Started [Rule:ComputerRODC] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0758] [1] Started [Setting:ReadOnlyDC] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0758] [1] Evaluated [Setting:FileVersionRpcHttp] [HasException:False] [Value:"10.0.17763.1"] [ParentValue:"<NULL>"] [Thread:50] [Duration:00:00:00.8906039]
+[12/01/2022 00:49:41.0758] [1] Finished [Setting:FileVersionRpcHttp] [Duration:00:00:00.8906039]
+[12/01/2022 00:49:41.0758] [1] Evaluated [Rule:Win7RpcHttpAssocCookieGuidUpdateNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:50] [Duration:00:00:00.8906039]
+[12/01/2022 00:49:41.0758] [1] Finished [Rule:Win7RpcHttpAssocCookieGuidUpdateNotInstalled] [Duration:00:00:00.8906039]
+[12/01/2022 00:49:41.0774] [1] Evaluated [Setting:FileVersionKernel32] [HasException:False] [Value:"10.0.17763.2145"] [ParentValue:"<NULL>"] [Thread:51] [Duration:00:00:00.8906115]
+[12/01/2022 00:49:41.0774] [1] Finished [Setting:FileVersionKernel32] [Duration:00:00:00.8906115]
+[12/01/2022 00:49:41.0774] [1] Evaluated [Rule:SearchFoundationAssemblyLoaderKBNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:51] [Duration:00:00:00.8906115]
+[12/01/2022 00:49:41.0774] [1] Finished [Rule:SearchFoundationAssemblyLoaderKBNotInstalled] [Duration:00:00:00.8906115]
+[12/01/2022 00:49:41.0789] [1] Evaluated [Setting:FileVersionSspicli] [HasException:False] [Value:"10.0.17763.1490"] [ParentValue:"<NULL>"] [Thread:55] [Duration:00:00:00.8593588]
+[12/01/2022 00:49:41.0789] [1] Finished [Setting:FileVersionSspicli] [Duration:00:00:00.8593588]
+[12/01/2022 00:49:41.0789] [1] Started [Setting:Windows10Version] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0789] [1] Evaluated [Setting:FileVersionDiscan] [HasException:False] [Value:"10.0.17763.1697"] [ParentValue:"<NULL>"] [Thread:54] [Duration:00:00:00.8749859]
+[12/01/2022 00:49:41.0789] [1] Finished [Setting:FileVersionDiscan] [Duration:00:00:00.8749859]
+[12/01/2022 00:49:41.0789] [1] Evaluated [Rule:Win2k12RollupUpdateNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:54] [Duration:00:00:00.8749859]
+[12/01/2022 00:49:41.0789] [1] Finished [Rule:Win2k12RollupUpdateNotInstalled] [Duration:00:00:00.8749859]
+[12/01/2022 00:49:41.0821] [1] Evaluated [Rule:RemoteRegException] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:57] [Duration:00:00:00.8906069]
+[12/01/2022 00:49:41.0821] [1] Finished [Rule:RemoteRegException] [Duration:00:00:00.8906069]
+[12/01/2022 00:49:41.0836] [1] Evaluated [Setting:DebugVersion] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:13] [Duration:00:00:01.0156070]
+[12/01/2022 00:49:41.0836] [1] Finished [Setting:DebugVersion] [Duration:00:00:01.0312324]
+[12/01/2022 00:49:41.0836] [1] Evaluated [Rule:OSCheckedBuild] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:13] [Duration:00:00:01.0468510]
+[12/01/2022 00:49:41.0836] [1] Finished [Rule:OSCheckedBuild] [Duration:00:00:01.0468510]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Setting:OSProductSuite] [HasException:False] [Value:"400"] [ParentValue:"<NULL>"] [Thread:46] [Duration:00:00:01.0155865]
+[12/01/2022 00:49:41.0868] [1] Finished [Setting:OSProductSuite] [Duration:00:00:01.0155865]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Rule:ServerWinWebEdition] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:46] [Duration:00:00:01.0312289]
+[12/01/2022 00:49:41.0868] [1] Finished [Rule:ServerWinWebEdition] [Duration:00:00:01.0312289]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Setting:OSProductType] [HasException:False] [Value:"3"] [ParentValue:"<NULL>"] [Thread:60] [Duration:00:00:00.9218592]
+[12/01/2022 00:49:41.0868] [1] Finished [Setting:OSProductType] [Duration:00:00:00.9218592]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Setting:WindowsServer2019Version] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.3281180]
+[12/01/2022 00:49:41.0868] [1] Finished [Setting:WindowsServer2019Version] [Duration:00:00:00.3281180]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Rule:ValidOSVersion] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.3281180]
+[12/01/2022 00:49:41.0868] [1] Finished [Rule:ValidOSVersion] [Duration:00:00:00.3281180]
+[12/01/2022 00:49:41.0868] [1] Started [Rule:Exchange2013AnyOnExchange2010Server] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Setting:Windows10Version] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:55] [Duration:00:00:00.0781281]
+[12/01/2022 00:49:41.0868] [1] Finished [Setting:Windows10Version] [Duration:00:00:00.0781281]
+[12/01/2022 00:49:41.0868] [1] Evaluated [Rule:Win2k16LSARollupUpdateNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:55] [Duration:00:00:00.9374869]
+[12/01/2022 00:49:41.0868] [1] Finished [Rule:Win2k16LSARollupUpdateNotInstalled] [Duration:00:00:00.9374869]
+[12/01/2022 00:49:41.0883] [1] Evaluated [Rule:Exchange2013AnyOnExchange2010Server] [HasException:True] [Value:
+Expected failure for Exchange2013AnyOnExchange2010Server:The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v14, wasn't found.
+] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0156231]
+[12/01/2022 00:49:41.0883] [1] Finished [Rule:Exchange2013AnyOnExchange2010Server] [Duration:00:00:00.0156231]
+[12/01/2022 00:49:41.0883] [1] Started [Rule:ServicesAreMarkedForDeletion] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:41.0883] [1] Started [Setting:ServiceMarkedForDeletion] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:41.0883] [1] Started [Setting:ValidOSSuite] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0883] [1] Evaluated [Setting:Windows8Version] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:60] [Duration:00:00:00.9374823]
+[12/01/2022 00:49:41.0883] [1] Finished [Setting:Windows8Version] [Duration:00:00:00.9374823]
+[12/01/2022 00:49:41.0883] [1] Evaluated [Rule:ServerGuiMgmtInfraNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:73] [Duration:00:00:00.9062362]
+[12/01/2022 00:49:41.0883] [1] Finished [Rule:ServerGuiMgmtInfraNotInstalled] [Duration:00:00:00.9062362]
+[12/01/2022 00:49:41.0883] [1] Started [Setting:IsWcfHttpActivation45Installed] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0883] [1] Started [Setting:SuiteMask] [Parent:RootAnalysisMember] [ValueType:UInt32]
+[12/01/2022 00:49:41.0883] [1] Started [Setting:IsWebASPNET45Installed] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0899] [1] Started [Setting:IsRsatClusteringMgmtInstalled] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0899] [1] Started [Setting:IsRsatClusteringPowerShellInstalled] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0899] [1] Started [Setting:IsRsatClusteringCmdInterfaceInstalled] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0899] [1] Started [Setting:IsNETFramework45FeaturesInstalled] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:41.0899] [1] Started [Setting:IsWebNetExt45Installed] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Setting:ShortServerName] [HasException:False] [Value:"ExSvr1"] [ParentValue:"<NULL>"] [Thread:43] [Duration:00:00:01.4218547]
+[12/01/2022 00:49:42.0336] [1] Finished [Setting:ShortServerName] [Duration:00:00:01.4218547]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Setting:ReadOnlyDC] [HasException:True] [Value:
+System.DirectoryServices.DirectoryServicesCOMException (0x80072030): There is no such object on the server.
+
+   at System.DirectoryServices.DirectoryEntry.Bind(Boolean throwIfFail)
+   at System.DirectoryServices.DirectoryEntry.Bind()
+   at System.DirectoryServices.DirectoryEntry.get_AdsObject()
+   at System.DirectoryServices.DirectorySearcher.FindAll(Boolean findMoreThanOne)
+   at Microsoft.Exchange.Management.Deployment.ADProvider.Run(Boolean useGC, String directoryEntry, String[] listOfPropertiesToCollect, String filter, SearchScope searchScope)
+   at Microsoft.Exchange.Management.Analysis.PrereqAnalysis.<CreateWmiPrereqProperties>b__2388_155(Result`1 x)
+   at Microsoft.Exchange.Management.Analysis.Builders.SettingBuilder`2.<>c__DisplayClass2_0.<SetValue>b__0(Result x)
+] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.5781167]
+[12/01/2022 00:49:42.0336] [1] Finished [Setting:ReadOnlyDC] [Duration:00:00:00.5781167]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Rule:ComputerRODC] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00.5781167]
+[12/01/2022 00:49:42.0336] [1] Finished [Rule:ComputerRODC] [Duration:00:00:00.5781167]
+[12/01/2022 00:49:42.0336] [1] Started [Rule:InvalidADSite] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Rule:InvalidADSite] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:42.0336] [1] Finished [Rule:InvalidADSite] [Duration:00:00:00]
+[12/01/2022 00:49:42.0336] [1] Started [Rule:MinimumFrameworkNotInstalled] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0336] [1] Started [Setting:ClrReleaseNumber] [Parent:RootAnalysisMember] [ValueType:Nullable`1]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Setting:ClrReleaseNumber] [HasException:False] [Value:"528049"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:42.0336] [1] Finished [Setting:ClrReleaseNumber] [Duration:00:00:00]
+[12/01/2022 00:49:42.0336] [1] Evaluated [Rule:MinimumFrameworkNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:6] [Duration:00:00:00]
+[12/01/2022 00:49:42.0336] [1] Finished [Rule:MinimumFrameworkNotInstalled] [Duration:00:00:00]
+[12/01/2022 00:49:42.0352] [1] Evaluated [Setting:MicrosoftExchServicesAdminGroupsConfig] [HasException:False] [Value:"<NULL>"] [ParentValue:"<NULL>"] [Thread:43] [Duration:00:00:01.5312271]
+[12/01/2022 00:49:42.0352] [1] Finished [Setting:MicrosoftExchServicesAdminGroupsConfig] [Duration:00:00:01.5312271]
+[12/01/2022 00:49:42.0352] [1] Evaluated [Setting:ExchangeCurrentServerRoles] [HasException:False] [Value:"0"] [ParentValue:"<NULL>"] [Thread:77] [Duration:00:00:01.3593585]
+[12/01/2022 00:49:42.0352] [1] Finished [Setting:ExchangeCurrentServerRoles] [Duration:00:00:01.3593585]
+[12/01/2022 00:49:42.0352] [1] Evaluated [Setting:ServerIsProvisioned] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:84] [Duration:00:00:01.2499821]
+[12/01/2022 00:49:42.0352] [1] Finished [Setting:ServerIsProvisioned] [Duration:00:00:01.2499821]
+[12/01/2022 00:49:42.0368] [1] Evaluated [Setting:ServerAlreadyExists] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:43] [Duration:00:00:01.5624749]
+[12/01/2022 00:49:42.0368] [1] Finished [Setting:ServerAlreadyExists] [Duration:00:00:01.5624749]
+[12/01/2022 00:49:42.0368] [1] Evaluated [Rule:CafeRoleAlreadyExists] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:45] [Duration:00:00:01.5468495]
+[12/01/2022 00:49:42.0368] [1] Finished [Rule:CafeRoleAlreadyExists] [Duration:00:00:01.5468495]
+[12/01/2022 00:49:42.0368] [1] Evaluated [Rule:ClientAccessRoleAlreadyExists] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:43] [Duration:00:00:01.5780935]
+[12/01/2022 00:49:42.0368] [1] Finished [Rule:ClientAccessRoleAlreadyExists] [Duration:00:00:01.5780935]
+[12/01/2022 00:49:42.0368] [1] Evaluated [Setting:BridgeheadRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:82] [Duration:00:00:01.3281056]
+[12/01/2022 00:49:42.0368] [1] Finished [Setting:BridgeheadRoleInstalled] [Duration:00:00:01.3281056]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:GatewayRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:83] [Duration:00:00:01.3593549]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:GatewayRoleInstalled] [Duration:00:00:01.3593549]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:DomainRole] [HasException:False] [Value:"3"] [ParentValue:"<NULL>"] [Thread:14] [Duration:00:00:01.6249740]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:DomainRole] [Duration:00:00:01.6249740]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:LocalComputerIsDomainController] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:39] [Duration:00:00:01.6093486]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:LocalComputerIsDomainController] [Duration:00:00:01.6249740]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Rule:InstallOnDCInADSplitPermissionMode] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:01.2031087]
+[12/01/2022 00:49:42.0430] [1] Finished [Rule:InstallOnDCInADSplitPermissionMode] [Duration:00:00:01.2031087]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Rule:WarningInstallExchangeRolesOnDomainController] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:39] [Duration:00:00:01.6405926]
+[12/01/2022 00:49:42.0430] [1] Started [Rule:ServerNameNotValid] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0430] [1] Finished [Rule:WarningInstallExchangeRolesOnDomainController] [Duration:00:00:01.6405926]
+[12/01/2022 00:49:42.0430] [1] Started [Setting:LocalServerName] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:SuiteMask] [HasException:False] [Value:"400"] [ParentValue:"<NULL>"] [Thread:65] [Duration:00:00:00.5312428]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:SuiteMask] [Duration:00:00:00.5468664]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:ValidOSSuite] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:65] [Duration:00:00:00.5468664]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:ValidOSSuite] [Duration:00:00:00.5468664]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:Windows2K8R2Version] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:65] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:Windows2K8R2Version] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Rule:NETFrameworkNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:66] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Rule:RSATWebServerNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:65] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Finished [Rule:NETFrameworkNotInstalled] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Finished [Rule:RSATWebServerNotInstalled] [Duration:00:00:01.4687291]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:UnifiedMessagingRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:81] [Duration:00:00:01.4062310]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:UnifiedMessagingRoleInstalled] [Duration:00:00:01.4062310]
+[12/01/2022 00:49:42.0430] [1] Evaluated [Setting:FrontendTransportRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:80] [Duration:00:00:01.4374800]
+[12/01/2022 00:49:42.0430] [1] Finished [Setting:FrontendTransportRoleInstalled] [Duration:00:00:01.4374800]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Setting:CafeRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:79] [Duration:00:00:01.4531038]
+[12/01/2022 00:49:42.0446] [1] Finished [Setting:CafeRoleInstalled] [Duration:00:00:01.4531038]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Setting:ClientAccessRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:78] [Duration:00:00:01.4531038]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Setting:MailboxRoleInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:77] [Duration:00:00:01.4687264]
+[12/01/2022 00:49:42.0446] [1] Finished [Setting:MailboxRoleInstalled] [Duration:00:00:01.4687264]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Rule:BridgeheadRoleAlreadyExists] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:44] [Duration:00:00:01.6093486]
+[12/01/2022 00:49:42.0446] [1] Finished [Rule:BridgeheadRoleAlreadyExists] [Duration:00:00:01.6249724]
+[12/01/2022 00:49:42.0446] [1] Finished [Setting:ClientAccessRoleInstalled] [Duration:00:00:01.4531038]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Rule:MailboxRoleAlreadyExists] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:42] [Duration:00:00:01.6562164]
+[12/01/2022 00:49:42.0446] [1] Finished [Rule:MailboxRoleAlreadyExists] [Duration:00:00:01.6562164]
+[12/01/2022 00:49:42.0446] [1] Evaluated [Rule:ComputerNotPartofDomain] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:14] [Duration:00:00:01.6562164]
+[12/01/2022 00:49:42.0446] [1] Finished [Rule:ComputerNotPartofDomain] [Duration:00:00:01.6562164]
+[12/01/2022 00:49:42.0680] [1] Evaluated [Setting:NicCaption] [HasException:False] [Value:"[00000001] Microsoft Hyper-V Network Adapter"] [ParentValue:"<NULL>"] [Thread:41] [Duration:00:00:01.8593502]
+[12/01/2022 00:49:42.0883] [1] Evaluated [Setting:NicConfiguration] [HasException:False] [Value:"System.Collections.Generic.Dictionary`2[System.String,System.Object]"] [ParentValue:"[00000001] Microsoft Hyper-V Network Adapter"] [Thread:41] [Duration:00:00:02.0624700]
+[12/01/2022 00:49:42.0883] [1] Evaluated [Setting:DnsAddress] [HasException:False] [Value:"192.168.12.10"] [ParentValue:"System.Collections.Generic.Dictionary`2[System.String,System.Object]"] [Thread:41] [Duration:00:00:02.0624700]
+[12/01/2022 00:49:42.0883] [1] Evaluated [Setting:PrimaryDns] [HasException:False] [Value:"192.168.12.10"] [ParentValue:"<NULL>"] [Thread:41] [Duration:00:00:02.0780954]
+[12/01/2022 00:49:42.0883] [1] Finished [Setting:PrimaryDns] [Duration:00:00:02.0780954]
+[12/01/2022 00:49:42.0899] [1] Evaluated [Setting:HostRecord] [HasException:False] [Value:"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]"] [ParentValue:"<NULL>"] [Thread:41] [Duration:00:00:02.0937250]
+[12/01/2022 00:49:42.0899] [1] Finished [Setting:HostRecord] [Duration:00:00:02.0937250]
+[12/01/2022 00:49:42.0899] [1] Evaluated [Rule:HostRecordMissing] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:41] [Duration:00:00:02.1093436]
+[12/01/2022 00:49:42.0899] [1] Finished [Rule:HostRecordMissing] [Duration:00:00:02.1093436]
+[12/01/2022 00:49:42.0914] [1] Evaluated [Setting:LocalServerName] [HasException:False] [Value:"ExSvr1"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.4844201]
+[12/01/2022 00:49:42.0914] [1] Finished [Setting:LocalServerName] [Duration:00:00:00.4844201]
+[12/01/2022 00:49:42.0914] [1] Evaluated [Rule:ServerNameNotValid] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.4844201]
+[12/01/2022 00:49:42.0914] [1] Finished [Rule:ServerNameNotValid] [Duration:00:00:00.4844201]
+[12/01/2022 00:49:42.0914] [1] Started [Rule:LocalComputerIsDCInChildDomain] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0914] [1] Evaluated [Rule:LocalComputerIsDCInChildDomain] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00]
+[12/01/2022 00:49:42.0914] [1] Finished [Rule:LocalComputerIsDCInChildDomain] [Duration:00:00:00]
+[12/01/2022 00:49:42.0930] [1] Started [Rule:LoggedOntoDomain] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0930] [1] Started [Setting:CurrentLogOn] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:42.0930] [1] Evaluated [Setting:CurrentLogOn] [HasException:False] [Value:"SOLO\Han"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00]
+[12/01/2022 00:49:42.0930] [1] Finished [Setting:CurrentLogOn] [Duration:00:00:00]
+[12/01/2022 00:49:42.0930] [1] Evaluated [Rule:LoggedOntoDomain] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00]
+[12/01/2022 00:49:42.0930] [1] Finished [Rule:LoggedOntoDomain] [Duration:00:00:00]
+[12/01/2022 00:49:42.0930] [1] Started [Rule:DomainPrepRequired] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:42.0930] [1] Started [Setting:LocalDomainIsPrepped] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:42.0946] [1] Started [Setting:ComputerDomainDN] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:42.0961] [1] Started [Setting:ComputerDomain] [Parent:RootAnalysisMember] [ValueType:String]
+[12/01/2022 00:49:43.0289] [1] Evaluated [Setting:ComputerDomain] [HasException:False] [Value:"Skywalker.local"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.3281174]
+[12/01/2022 00:49:43.0289] [1] Finished [Setting:ComputerDomain] [Duration:00:00:00.3281174]
+[12/01/2022 00:49:43.0305] [1] Evaluated [Setting:ComputerDomainDN] [HasException:False] [Value:"DC=Skywalker,DC=local"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.3593702]
+[12/01/2022 00:49:43.0305] [1] Finished [Setting:ComputerDomainDN] [Duration:00:00:00.3593702]
+[12/01/2022 00:49:43.0305] [1] Evaluated [Setting:LocalDomainIsPrepped] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.3749934]
+[12/01/2022 00:49:43.0305] [1] Finished [Setting:LocalDomainIsPrepped] [Duration:00:00:00.3749934]
+[12/01/2022 00:49:43.0305] [1] Evaluated [Rule:DomainPrepRequired] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:9] [Duration:00:00:00.3749934]
+[12/01/2022 00:49:43.0305] [1] Finished [Rule:DomainPrepRequired] [Duration:00:00:00.3749934]
+[12/01/2022 00:49:43.0586] [1] Evaluated [Setting:NetTcpPortSharingStartMode] [HasException:False] [Value:"Auto"] [ParentValue:"<NULL>"] [Thread:15] [Duration:00:00:02.7812078]
+[12/01/2022 00:49:43.0586] [1] Finished [Setting:NetTcpPortSharingStartMode] [Duration:00:00:02.7812078]
+[12/01/2022 00:49:43.0586] [1] Evaluated [Rule:NetTcpPortSharingSvcNotAuto] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:15] [Duration:00:00:02.7968264]
+[12/01/2022 00:49:43.0586] [1] Finished [Rule:NetTcpPortSharingSvcNotAuto] [Duration:00:00:02.7968264]
+[12/01/2022 00:49:43.0602] [1] Evaluated [Setting:EventSystemStarted] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:18] [Duration:00:00:02.7812052]
+[12/01/2022 00:49:43.0602] [1] Finished [Setting:EventSystemStarted] [Duration:00:00:02.7968306]
+[12/01/2022 00:49:43.0602] [1] Evaluated [Rule:EventSystemStopped] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:18] [Duration:00:00:02.8124492]
+[12/01/2022 00:49:43.0602] [1] Finished [Rule:EventSystemStopped] [Duration:00:00:02.8124492]
+[12/01/2022 00:49:43.0602] [1] Evaluated [Setting:MpsSvcStarted] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:16] [Duration:00:00:02.7968306]
+[12/01/2022 00:49:43.0602] [1] Finished [Setting:MpsSvcStarted] [Duration:00:00:02.7968306]
+[12/01/2022 00:49:43.0602] [1] Evaluated [Rule:MpsSvcStopped] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:16] [Duration:00:00:02.8124492]
+[12/01/2022 00:49:43.0602] [1] Finished [Rule:MpsSvcStopped] [Duration:00:00:02.8124492]
+[12/01/2022 00:49:43.0649] [1] Evaluated [Setting:MSDTCStarted] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:17] [Duration:00:00:02.8437050]
+[12/01/2022 00:49:43.0649] [1] Finished [Setting:MSDTCStarted] [Duration:00:00:02.8437050]
+[12/01/2022 00:49:43.0649] [1] Evaluated [Rule:MSDTCStopped] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:17] [Duration:00:00:02.8593236]
+[12/01/2022 00:49:43.0649] [1] Finished [Rule:MSDTCStopped] [Duration:00:00:02.8593236]
+[12/01/2022 00:49:43.0883] [1] Evaluated [Setting:ServiceMarkedForDeletion] [HasException:False] [Value:""] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:01.9999740]
+[12/01/2022 00:49:43.0883] [1] Finished [Setting:ServiceMarkedForDeletion] [Duration:00:00:01.9999740]
+[12/01/2022 00:49:43.0883] [1] Evaluated [Rule:ServicesAreMarkedForDeletion] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:01.9999740]
+[12/01/2022 00:49:43.0883] [1] Finished [Rule:ServicesAreMarkedForDeletion] [Duration:00:00:01.9999740]
+[12/01/2022 00:49:43.0883] [1] Started [Rule:WarnMapiHttpNotEnabled] [Parent:RootAnalysisMember] [RuleType:Warning]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:InstalledWindowsFeatures] [HasException:False] [Value:"System.Object[]"] [ParentValue:"<NULL>"] [Thread:58] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:InstalledWindowsFeatures] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsNETFramework45FeaturesInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:68] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsNETFramework45FeaturesInstalled] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsRsatClusteringCmdInterfaceInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:64] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsRsatClusteringCmdInterfaceInstalled] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:RsatClusteringCmdInterfaceInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:64] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:RsatClusteringCmdInterfaceInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:NETFramework45FeaturesNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:68] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:NETFramework45FeaturesNotInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsRsatClusteringPowerShellInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:63] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsRsatClusteringPowerShellInstalled] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsWinRMIISExtensionInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:58] [Duration:00:00:08.4838082]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsWinRMIISExtensionInstalled] [Duration:00:00:08.4838082]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:WinRMIISExtensionInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:58] [Duration:00:00:08.4838082]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:WinRMIISExtensionInstalled] [Duration:00:00:08.4838082]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsRsatClusteringInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:61] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsRsatClusteringInstalled] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:RsatClusteringPowerShellInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:63] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:RsatClusteringPowerShellInstalled] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsWebISAPIExtInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:70] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsWebISAPIExtInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:WebISAPIExtNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:70] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:WebISAPIExtNotInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:RsatClusteringInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:61] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:RsatClusteringInstalled] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsRPCOverHTTPproxyInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:72] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsRPCOverHTTPproxyInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:RPCOverHTTPproxyNotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:72] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:RPCOverHTTPproxyNotInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsWebASPNET45Installed] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:71] [Duration:00:00:07.5306982]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsWebASPNET45Installed] [Duration:00:00:07.5306982]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:WebASPNET45NotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:71] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsRsatClusteringMgmtInstalled] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:62] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:WebASPNET45NotInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsRsatClusteringMgmtInstalled] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:RsatClusteringMgmtInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:62] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:RsatClusteringMgmtInstalled] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsWcfHttpActivation45Installed] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:60] [Duration:00:00:07.5306982]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsWcfHttpActivation45Installed] [Duration:00:00:07.5306982]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:WcfHttpActivation45Installed] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:60] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:WcfHttpActivation45Installed] [Duration:00:00:08.4681805]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Setting:IsWebNetExt45Installed] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:69] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Finished [Setting:IsWebNetExt45Installed] [Duration:00:00:07.5150740]
+[12/01/2022 00:49:49.0414] [1] Evaluated [Rule:WebNetExt45NotInstalled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:69] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0414] [1] Finished [Rule:WebNetExt45NotInstalled] [Duration:00:00:08.4525609]
+[12/01/2022 00:49:49.0445] [1] Active Directory session settings for 'Get-OrganizationConfig' are: View Entire Forest: 'True', Configuration Domain Controller: 'DC2.Solo.local', Preferred Global Catalog: 'DC2.Solo.local', Preferred Domain Controllers: '{ DC2.Solo.local }'
+[12/01/2022 00:49:49.0445] [1] User specified parameters: 
+[12/01/2022 00:49:49.0445] [1] Beginning processing Get-OrganizationConfig
+[12/01/2022 00:49:49.0461] [1] Searching objects of type "ADOrganizationConfig" with filter "$null", scope "SubTree" under the root "$null".
+[12/01/2022 00:49:49.0461] [1] Request filter in Get Task: (&(|(objectCategory=msExchOrganizationContainer)(objectCategory=msExchConfigurationUnitContainer))(|(&(msExchVersion<=3377699720527872)(!(msExchVersion=3377699720527872)))(!(msExchVersion=*)))).
+[12/01/2022 00:49:49.0476] [1] Previous operation run on domain controller 'DC2.Solo.local'.
+[12/01/2022 00:49:49.0476] [1] Preparing to output objects. The maximum size of the result set is "Unlimited".
+[12/01/2022 00:49:49.0758] [1] Ending processing Get-OrganizationConfig
+[12/01/2022 00:49:49.0758] [1] Evaluated [Rule:WarnMapiHttpNotEnabled] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:05.8744843]
+[12/01/2022 00:49:49.0758] [1] Finished [Rule:WarnMapiHttpNotEnabled] [Duration:00:00:05.8744843]
+[12/01/2022 00:49:49.0758] [1] Started [Rule:VC2013RedistDependencyRequirement] [Parent:RootAnalysisMember] [RuleType:Error]
+[12/01/2022 00:49:49.0758] [1] Started [Setting:VCRedist2013Installed] [Parent:RootAnalysisMember] [ValueType:Boolean]
+[12/01/2022 00:49:49.0758] [1] Started [Setting:FileVersionMsvcr120] [Parent:RootAnalysisMember] [ValueType:Version]
+[12/01/2022 00:49:49.0789] [1] Evaluated [Setting:PowerShellExecutionPolicy] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:74] [Duration:00:00:08.8119208]
+[12/01/2022 00:49:49.0789] [1] Finished [Setting:PowerShellExecutionPolicy] [Duration:00:00:08.8119208]
+[12/01/2022 00:49:49.0789] [1] Evaluated [Rule:PowerShellExecutionPolicyCheckSet] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:74] [Duration:00:00:08.8119208]
+[12/01/2022 00:49:49.0789] [1] Finished [Rule:PowerShellExecutionPolicyCheckSet] [Duration:00:00:08.8119208]
+[12/01/2022 00:49:49.0820] [1] Evaluated [Setting:FileVersionMsvcr120] [HasException:False] [Value:"12.0.21005.1"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:49.0820] [1] Finished [Setting:FileVersionMsvcr120] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:49.0820] [1] Evaluated [Setting:VCRedist2013Installed] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:49.0820] [1] Finished [Setting:VCRedist2013Installed] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:49.0820] [1] Evaluated [Rule:VC2013RedistDependencyRequirement] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:8] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:49.0820] [1] Finished [Rule:VC2013RedistDependencyRequirement] [Duration:00:00:00.0624941]
+[12/01/2022 00:49:52.0191] [1] Evaluated [Setting:PrimaryDNSPortAvailable] [HasException:False] [Value:"True"] [ParentValue:"<NULL>"] [Thread:40] [Duration:00:00:11.3860970]
+[12/01/2022 00:49:52.0191] [1] Finished [Setting:PrimaryDNSPortAvailable] [Duration:00:00:11.3860970]
+[12/01/2022 00:49:52.0191] [1] Evaluated [Rule:PrimaryDNSTestFailed] [HasException:False] [Value:"False"] [ParentValue:"<NULL>"] [Thread:40] [Duration:00:00:11.3860970]
+[12/01/2022 00:49:52.0191] [1] Finished [Rule:PrimaryDNSTestFailed] [Duration:00:00:11.4017156]
+[12/01/2022 00:49:52.0191] [1] Finished [Analysis:Prereq] [Duration:00:00:11.4798432]
+[12/01/2022 00:49:52.0191] [1] Failed [Rule:DomainPrepRequired] [Message:The local domain needs to be prepared using Setup /PrepareDomain before server roles can be installed.]
+[12/01/2022 00:49:52.0207] [1] [REQUIRED] The local domain needs to be prepared using Setup /PrepareDomain before server roles can be installed.
+[12/01/2022 00:49:52.0207] [1] Help URL: http://technet.microsoft.com/library(EXCHG.150)/ms.exch.setupreadiness.DomainPrepRequired.aspx
+[12/01/2022 00:49:52.0222] [1] [RECOMENDED] Setup can't detect a Send connector with an address space of '*'. Mail flow to the Internet may not work properly.
+[12/01/2022 00:49:52.0238] [1] Ending processing test-SetupPrerequisites
+[12/01/2022 00:49:52.0254] [0] CurrentResult console.ProcessRunInternal:136: 1
+[12/01/2022 00:49:52.0254] [0] Exchange Server installation failed during prereq check. Trying to restore the server state back to active.
+[12/01/2022 00:49:52.0254] [0] RestoreServer Script Path: C:\Windows\Temp\ExchangeSetup\RestoreServerOnPrereqFailure.ps1
+[12/01/2022 00:49:52.0301] [0] Beginning processing Write-ExchangeSetupLog
+[12/01/2022 00:49:52.0316] [0] Trying to restore server state.
+[12/01/2022 00:49:52.0316] [0] Ending processing Write-ExchangeSetupLog
+[12/01/2022 00:49:52.0316] [0] Active Directory session settings for 'Get-ExchangeServer' are: View Entire Forest: 'True', Configuration Domain Controller: 'DC2.Solo.local', Preferred Global Catalog: 'DC2.Solo.local', Preferred Domain Controllers: '{ DC2.Solo.local }'
+[12/01/2022 00:49:52.0316] [0] User specified parameters:  -ErrorAction:'SilentlyContinue' -Identity:'ExSvr1'
+[12/01/2022 00:49:52.0316] [0] Beginning processing get-ExchangeServer
+[12/01/2022 00:49:52.0332] [0] Searching objects "ExSvr1" of type "Server" under the root "$null".
+[12/01/2022 00:49:52.0426] [0] Previous operation run on domain controller 'DC2.Solo.local'.
+[12/01/2022 00:49:52.0426] [0] Previous operation run on domain controller 'DC2.Solo.local'.
+[12/01/2022 00:49:52.0426] [0] Preparing to output objects. The maximum size of the result set is "Unlimited".
+[12/01/2022 00:49:52.0426] [0] The operation couldn't be performed because object 'ExSvr1' couldn't be found on 'DC2.Solo.local'.
+[12/01/2022 00:49:52.0441] [0] The operation couldn't be performed because object 'ExSvr1' couldn't be found on 'DC2.Solo.local'.
+[12/01/2022 00:49:52.0441] [0] Ending processing get-ExchangeServer
+[12/01/2022 00:49:52.0441] [0] Beginning processing Write-ExchangeSetupLog
+[12/01/2022 00:49:52.0441] [0] [WARNING] ExSvr1 is not an Exchange Server. Unable to set monitoring and server state to active.
+[12/01/2022 00:49:52.0441] [0] Ending processing Write-ExchangeSetupLog
+[12/01/2022 00:49:52.0457] [0] CurrentResult launcherbase.maincore:90: 1
+[12/01/2022 00:49:52.0457] [0] CurrentResult console.startmain:52: 1
+[12/01/2022 00:49:52.0457] [0] CurrentResult SetupLauncherHelper.loadassembly:452: 1
+[12/01/2022 00:49:52.0457] [0] The Exchange Server setup operation didn't complete.  More details can be found in ExchangeSetup.log located in the <SystemDrive>:\ExchangeSetupLogs folder.
+[12/01/2022 00:49:52.0457] [0] CurrentResult main.run:235: 1
+[12/01/2022 00:49:52.0457] [0] The registry key, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\V15\Setup, wasn't found.
+[12/01/2022 00:49:52.0457] [0] CurrentResult setupbase.maincore:396: 1
+[12/01/2022 00:49:52.0457] [0] End of Setup
+[12/01/2022 00:49:52.0457] [0] **********************************************

--- a/Setup/Tests/SetupLogReviewer.Tests.ps1
+++ b/Setup/Tests/SetupLogReviewer.Tests.ps1
@@ -138,6 +138,14 @@ Describe "Testing SetupLogReviewer" {
             Test-GeneralAdditionalContext
         }
 
+        It "Domain Prep Required" {
+            & $sr -SetupLog "$PSScriptRoot\PrerequisiteCheck\ExchangeSetup_DomainPrepRequired.log"
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -eq "Local Domain Is Not Prepped or might have duplicate MESO Containers" -and $ForegroundColor -eq "Red" }
+            Assert-MockCalled -Exactly 1 -CommandName Write-Host `
+                -ParameterFilter { $Object -like "*Run SetupAssist on the server to determine the problem and correct action plan." }
+        }
+
         It "DC Out of Site - 1" {
             & $sr -SetupLog "$PSScriptRoot\PrerequisiteCheck\DCOutOfSite\ExchangeSetup_DC_Site_1.log"
             Assert-MockCalled -Exactly 1 -CommandName Write-Host `


### PR DESCRIPTION
**Issue:**
Setup is failing to install Exchange in a new domain stating that domain isn't prepared, even though the `/PrepareDomain` succeed. SetupAssist was also not detecting any issues.

The cause to the issue is a secondary MESO container existing in the secondary domain that we are trying to install Exchange in has an object value of less than 12433. Because of this, the prerequisites check fails. 

**Fix:**
Detect this issue properly with SetupAssist and SetupLogReviewer. Provide to delete the old MESO container, because it is so old it shouldn't be used any longer anyways. 

**Validation:**
Lab tested. 

Repro Steps:
Created a forest called `Solo.local`
Created a tree domain called `Skywalker.local` in the `Solo.loocal` forest
Created a TestMESO container with the class type of `msExchSystemObjectsContainer` under `LostAndFound`
Set the TestMESO objectVersion to 6923, a value less than 12433
Prepared the domain in `Skywalker.local` normally
Tried to install Exchange, it would fail to do so.

Options to fix are to increase the value to 12433 manually or delete the container (recommended) and setup will continue. 