### PR TITLE
Temp fix for build pipeline errors

### DIFF
--- a/azure-pipeline-release.yml
+++ b/azure-pipeline-release.yml
@@ -110,7 +110,7 @@ steps:
       dist\*.zip
       dist\*.txt
       dist\*.csv
-    addChangeLog: true
+    addChangeLog: false
     isDraft: true
 
 - task: GitHubRelease@0
@@ -127,5 +127,5 @@ steps:
     releaseNotesSource: 'file'
     releaseNotesFile: dist\ScriptVersions.txt
     assetUploadMode: replace
-    addChangeLog: true
+    addChangeLog: false
     isDraft: false


### PR DESCRIPTION
**Issue:**
```
Getting the following error: ##[error]Error: Server Error: Sorry, this diff is taking too long to generate.
```

**Reason:**
Unable to release scripts with build pipeline. 

**Fix:**
Remove reason for the diff action hopefully. 


