### PR TITLE
Fixed issue with supported version getting set to true

### DIFF
--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -89,6 +89,7 @@ function Get-ExchangeBuildVersionInformation {
                     $cuReleaseDate = "06/29/2021"
                     $mesoValue = 13241
                     $orgValue = 16758
+                    $supportedBuildNumber = $false
                 }
                 { $_ -lt "15.2.922.7" } {
                     $cuLevel = "CU9"
@@ -186,6 +187,7 @@ function Get-ExchangeBuildVersionInformation {
                     $cuReleaseDate = "06/29/2021"
                     $mesoValue = 13241
                     $orgValue = 16221
+                    $supportedBuildNumber = $false
                 }
                 { $_ -lt "15.1.2308.8" } {
                     $cuLevel = "CU20"
@@ -322,6 +324,7 @@ function Get-ExchangeBuildVersionInformation {
                     $cuReleaseDate = "02/12/2019"
                     $mesoValue = 13236
                     $orgValue = 16131
+                    $supportedBuildNumber = $false
                 }
                 { $_ -lt "15.0.1473.3" } {
                     $cuLevel = "CU21"

--- a/Shared/Tests/Get-ExchangeBuildVersionInformation.Tests.ps1
+++ b/Shared/Tests/Get-ExchangeBuildVersionInformation.Tests.ps1
@@ -74,4 +74,25 @@ Describe "Testing Get-ExchangeBuildVersionInformation.ps1" {
             $results.ADLevel.OrgValue | Should -Be 16760
         }
     }
+
+    Context "Testing Unsupported CU Exchange 2019 CU 10 Jul21SU" {
+        BeforeAll {
+            [string]$fileVersion = "15.02.0922.013"
+            $Script:results = Get-ExchangeBuildVersionInformation -FileVersion $fileVersion
+        }
+
+        It "Return the final E19CU12 Oct22SU version object" {
+            $results.MajorVersion | Should -Be "Exchange2019"
+            $results.FriendlyName = "Exchange 2019 CU10 Jul21SU"
+            $results.BuildVersion.ToString() | Should -Be "15.2.922.13"
+            $results.CU | Should -Be "CU10"
+            $results.ReleaseDate | Should -Be ([System.Convert]::ToDateTime([DateTime]"06/29/2021", [System.Globalization.DateTimeFormatInfo]::InvariantInfo))
+            $results.ExtendedSupportDate | Should -Be ([System.Convert]::ToDateTime([DateTime]"10/14/2025", [System.Globalization.DateTimeFormatInfo]::InvariantInfo))
+            $results.Supported | Should -Be $false
+            $results.LatestSU | Should -Be $false
+            $results.ADLevel.SchemaValue | Should -Be 17003
+            $results.ADLevel.MESOValue | Should -Be 13241
+            $results.ADLevel.OrgValue | Should -Be 16758
+        }
+    }
 }


### PR DESCRIPTION
**Issue:**
Health Checker was no longer providing if a CU was out of support any longer due to the new logic. 

**Reason:**
Switched over a `switch` statement to avoid needing to repeat information for the AD Levels for each CU.

**Fix:**
Need set the `$supportedBuildNumber` back to `$false` once we hit a CU level that is no longer supported.

**Validation:**
Pester test created. 

Resolved #1374

