### PR TITLE
Fix doc link page

### DIFF
--- a/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
+++ b/docs/Diagnostics/HealthChecker/PacketsLossCheck.md
@@ -17,5 +17,6 @@ Yes
 **Additional Information**
 
 [Large packet loss in the guest OS using VMXNET3 in ESXi (2039495)](https://kb.vmware.com/s/article/2039495)
+
 [Disable "adaptive rx ring sizing" to avoid random interface reset (78343)](https://kb.vmware.com/s/article/78343)
 


### PR DESCRIPTION
**Reason:**
The two links look like one

![image](https://user-images.githubusercontent.com/22776718/208129250-5ab6d90a-2075-4311-8025-860e15855cf4.png)


**Fix:**
Break up the lines

**Validation:**
Looks good in VSCode Preview. 

