### PR TITLE
Fix local computer failure with Invoke-Command

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
@@ -26,6 +26,13 @@ function Get-HealthCheckerData {
         )
         try {
             Write-Verbose "Testing $ComputerName"
+
+            # If local computer, we should just assume that it should work.
+            if ($ComputerName -eq $env:COMPUTERNAME) {
+                Write-Verbose "Local computer, returning true"
+                return $true
+            }
+
             Invoke-Command -ComputerName $ComputerName -ScriptBlock { Get-Date } -ErrorAction Stop | Out-Null
             $reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey(“LocalMachine”, $ComputerName)
             $reg.OpenSubKey(“SOFTWARE\Microsoft\Windows NT\CurrentVersion”) | Out-Null


### PR DESCRIPTION
**Issue:**
Unable to run HealthChecker locally on the computer because they are unable to run `Invoke-Command` on the server. 

**Reason:**
There should be logic in place that avoid requiring to run `Invoke-Command` when it is the local server. Same as before.

**Fix:**
In `TestComputerName` make sure that we check to see if the test name is the local computer name and just return `$true` if it is. 

**Validation:**
Pester testing

