### PR TITLE
Update Get-HealthCheckFilesItemsFromLocation.ps1

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
@@ -4,7 +4,7 @@
 function Get-HealthCheckFilesItemsFromLocation {
     ##This notation will break things if you have other xml files from runs with different parameters like exchangedccoreratio
     ##Filenames to exclude: *ExchangeDCCoreRatio* , all other reports generate txt-reports only
-    $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthChecker-*-*.xml" -and $_.Name -notlike "HealthChecker-ExchangeDCCoreRatio-*.xml"}
+    $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthChecker-*-*.xml" -and $_.Name -notlike "HealthChecker-ExchangeDCCoreRatio-*.xml" }
 
     if ($null -eq $items) {
         Write-Host("Doesn't appear to be any Health Check XML files here....stopping the script")

--- a/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-HealthCheckFilesItemsFromLocation.ps1
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 function Get-HealthCheckFilesItemsFromLocation {
-    $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthChecker-*-*.xml" }
+    ##This notation will break things if you have other xml files from runs with different parameters like exchangedccoreratio
+    ##Filenames to exclude: *ExchangeDCCoreRatio* , all other reports generate txt-reports only
+    $items = Get-ChildItem $XMLDirectoryPath | Where-Object { $_.Name -like "HealthChecker-*-*.xml" -and $_.Name -notlike "HealthChecker-ExchangeDCCoreRatio-*.xml"}
 
     if ($null -eq $items) {
         Write-Host("Doesn't appear to be any Health Check XML files here....stopping the script")


### PR DESCRIPTION
A single xml report from a ExchangeDCCoreRatio broke the html report for me
This could be achieved with another $endname for the ExchangeDC-file like _{0}.txt so that -*-*.xml does not match anymore

**Issue:**
A single xml report from a ExchangeDCCoreRatio run broke the html report for me
But that really could also be happened with a misnamed xml file, really

**Reason:**
Exempt the ExchangeDCCoreRatio xml files explicitely from being selected. We dont have any guess what other files are in there. But at least the files generated from our very own healthchecker should be taken care of.

**Fix:**
Short description of the fix
Narrowed down the selection of files,, probably doable otherwise if you guys have other preferences for exclusions.

**Validation:**
I manually tracked down what broke the creation and it came down to having 3 files for my 2 exchange boxes here. Excluded the ExchangeDCCoreRatio-File and everything was good again.

**ExactErrorMessage**
Cannot bind argument to parameter 'AnalyzeHtmlServerValues' because it is null.
... -AnalyzedHtmlServerValues $importData.HtmlServerValues

