### PR TITLE
Update AD Site Count

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
@@ -63,6 +63,7 @@ function Get-OrganizationInformation {
                 $directorySearcher.SearchScope = "Subtree"
                 $directorySearcher.SearchRoot = [ADSI]("LDAP://" + $rootDSE.configurationNamingContext.ToString())
                 $directorySearcher.Filter = "(objectCategory=site)"
+                $directorySearcher.PageSize = 100
                 $orgInfo.ADSiteCount = ($directorySearcher.FindAll()).Count
             } catch {
                 Write-Verbose "Failed to collect AD Site Count information"

--- a/docs/Diagnostics/HealthChecker/ADSiteCount.md
+++ b/docs/Diagnostics/HealthChecker/ADSiteCount.md
@@ -4,7 +4,7 @@ In large environments that contains a lot of sites, can cause a performance issu
 
 It is recommended to reduce the number of AD Sites within the environment to address this issue. However, there is a workaround that would prevent the issue from occurring every 4-hours and just every 24-hours.
 
-In the `%ExchangeInstallPath%\Bin\Microsoft.Exchange.Directory.TopologyService.exe.config` file, change the `ExchangeTopologyCacheLifetime` value to be `24:00:00,00:20:00` instead to have the cache lifetime increase from 4-hours to 24-hours. It is not recommended to go beyond 24-hours.
+In the `%ExchangeInstallPath%\Bin\Microsoft.Exchange.Directory.TopologyService.exe.config` file, change the `ExchangeTopologyCacheLifetime` value to be `1.00:00:00,00:20:00` instead to have the cache lifetime increase from 4-hours to 24-hours. It is not recommended to go beyond 24-hours.
 
 
 **Included in HTML Report?**


### PR DESCRIPTION
**Issue:**
AD Site Count only returning 1000. Docs have incorrect format for setting to 1 day. 

**Fix:**
Include PageSize for directory searcher, which should return all the sites. 
Address the format of the `ExchangeTopologyCacheLifetime` value.

**Validation:**
NA

