### PR TITLE
Handle convert to XML for applicationHostConfig

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -194,7 +194,16 @@ function Get-ExchangeInformation {
                 CatchActionFunction = ${Function:Invoke-CatchActions}
             }
 
-            $exchangeInformation.ExtendedProtectionConfig = Get-ExtendedProtectionConfiguration @getExtendedProtectionConfigurationParams
+            if ($null -ne $exchangeInformation.IISSettings.ApplicationHostConfig) {
+                $getExtendedProtectionConfigurationParams.ApplicationHostConfig = $exchangeInformation.IISSettings.ApplicationHostConfig
+            }
+
+            try {
+                $exchangeInformation.ExtendedProtectionConfig = Get-ExtendedProtectionConfiguration @getExtendedProtectionConfigurationParams
+            } catch {
+                Write-Verbose "Failed to get the ExtendedProtectionConfig"
+                Invoke-CatchActions
+            }
         }
 
         $exchangeInformation.ApplicationConfigFileStatus = Get-ExchangeApplicationConfigurationFileValidation -ComputerName $Server -ConfigFileLocation ("{0}EdgeTransport.exe.config" -f $serverExchangeBinDirectory)

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
@@ -57,8 +57,16 @@ function Get-ExchangeServerIISSettings {
 
         if ($null -ne $applicationHostConfig) {
             Write-Verbose "Trying to query the modules which are loaded by IIS"
+            try {
+                [xml]$xmlApplicationHostConfig = [xml]$applicationHostConfig
+            } catch {
+                Write-Verbose "Failed to convert the Application Host Config to XML"
+                Invoke-CatchActions
+                # Don't attempt to run Get-IISModules
+                return
+            }
             $iisModulesParams = @{
-                ApplicationHostConfig    = ([xml]$applicationHostConfig)
+                ApplicationHostConfig    = $xmlApplicationHostConfig
                 SkipLegacyOSModulesCheck = $IsLegacyOS
                 CatchActionFunction      = $CatchActionFunction
             }


### PR DESCRIPTION
**Issue:**
Unable to run Health Checker on some machines due to `applicationHost.config` not being able to convert to `xml`. 

**Fix:**
Placed the convert to `xml` in a `try` `catch` block allowing the script to continue to work. 

**Validation:**
None
Resolved #1387 
