### PR TITLE
No schema test on Edge Server

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-34470.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2021-34470.ps1
@@ -28,7 +28,8 @@ function Invoke-AnalyzerSecurityCve-2021-34470 {
         (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) -and
             ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU21)) -or
         (($SecurityObject.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) -and
-            ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU10))) {
+            ($SecurityObject.CU -lt [HealthChecker.ExchangeCULevel]::CU10)) -and
+        $SecurityObject.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) {
         Write-Verbose "Testing CVE: CVE-2021-34470"
 
         $displayWriteTypeColor = $null


### PR DESCRIPTION
**Issue:**
Customer reported an issue:

```
Errors that occurred that wasn't handled
Error Index: 0
 : You cannot call a method on a null-valued expression.
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.PSScriptCmdlet.DoEndProcessing()
   at System.Management.Automation.CommandProcessorBase.Complete()
Position Message: At C:\\HealthChecker.ps1:4460 char:13
+         if ($SecurityObject.OrgInformation.SecurityResults.CVE2021344 ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Invoke-AnalyzerSecurityCve-2021-34470, C:\\HealthChecker.ps1: line 4460
at Invoke-AnalyzerSecurityCveCheck, C:\\HealthChecker.ps1: line 5349
at Invoke-AnalyzerSecurityVulnerability, C:\\HealthChecker.ps1: line 5375
at Invoke-AnalyzerEngine, C:\\HealthChecker.ps1: line 5488
at Get-HealthCheckerData, C:\\HealthChecker.ps1: line 12544
at Invoke-HealthCheckerMainReport, C:\\HealthChecker.ps1: line 12615
at <ScriptBlock><End>, C:\\HealthChecker.ps1: line 13345
at <ScriptBlock>, <No file>: line 1
-----------------------------------
```


**Fix:**
Make sure we aren't performing this check attempt on an Edge Server.

**Validation:**
Pester testing

