### PR TITLE
Handle Localize Counter Failures

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/PerformanceCountersFunctions.ps1
+++ b/Diagnostics/HealthChecker/Helpers/PerformanceCountersFunctions.ps1
@@ -84,7 +84,7 @@ function Get-LocalizedPerformanceCounterName {
 
     if (-not ($Script:EnglishOnlyOSCache.ContainsKey($ComputerName))) {
         $perfLib = Get-RemoteRegistrySubKey -MachineName $ComputerName `
-            -SubKey "SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009" `
+            -SubKey "SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib" `
             -CatchActionFunction ${Function:Invoke-CatchActions}
         $englishOnlyOS = ($perfLib.GetSubKeyNames() |
                 Where-Object { $_ -like "0*" }).Count -eq 1


### PR DESCRIPTION
**Issue:**
Customer reported an issue where HC was trying to localize the performance counters. This ended up failing out the script. 

Within the customer's environment, there was an issue with the `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009` location of the registry that caused this problem. 

**Fix:**
Handle the localization failures
Improve some of the code and debug information

**Validation:**
Lab tested
Customer already fixed the underlying problem with the registry that caused this issue. 

Resolved #1413 
