### PR TITLE
Create custom Rule for Read-Host

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -61,7 +61,13 @@ $maxRetries = 5
 foreach ($fileInfo in $filesToCheck) {
     for ($i = 0; $i -lt $maxRetries; $i++) {
         try {
-            $analyzerResults = Invoke-ScriptAnalyzer -Path $FileInfo.FullName -Settings $repoRoot\PSScriptAnalyzerSettings.psd1 -ErrorAction Stop
+            $params = @{
+                Path                = ($fileInfo.FullName)
+                Settings            = "$repoRoot\PSScriptAnalyzerSettings.psd1"
+                CustomRulePath      = "$repoRoot\.build\CodeFormatterChecks\CustomRules.psm1"
+                IncludeDefaultRules = $true
+            }
+            $analyzerResults = Invoke-ScriptAnalyzer @params
             if ($null -ne $analyzerResults) {
                 $errorCount++
                 $analyzerResults | Format-Table -AutoSize

--- a/.build/CodeFormatterChecks/CustomRules.psm1
+++ b/.build/CodeFormatterChecks/CustomRules.psm1
@@ -1,0 +1,36 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function AvoidUsingReadHost {
+
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]$ScriptBlockAst
+    )
+
+    process {
+
+        try {
+            $functions = $ScriptBlockAst.FindAll(
+                {
+                    $args[0] -is [System.Management.Automation.Language.CommandAst]
+                }, $true )
+            foreach ( $function in $functions ) {
+
+                if (($function.GetCommandName()) -eq "Read-Host") {
+                    [PSCustomObject]@{
+                        Message  = "Avoid using Read-Host. Use parameters to get information from the user. Use ShouldProcess to get Y/N confirmation on whether to proceed."
+                        Extent   = $function.Extent
+                        RuleName = $PSCmdlet.MyInvocation.InvocationName
+                        Severity = "Warning"
+                    }
+                }
+            }
+        } catch {
+            $PSCmdlet.ThrowTerminatingError( $_ )
+        }
+    }
+}

--- a/Admin/CrossTenantMailboxMigrationValidation.ps1
+++ b/Admin/CrossTenantMailboxMigrationValidation.ps1
@@ -95,6 +95,7 @@
         This will connect to the Source tenant against AAD and EXO, and will collect all the relevant information (config and user wise) so it can be used passed to the Target tenant admin for the Target validation to be done without the need to connect to the source tenant at the same time.
 .#>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
 param (
     [Parameter(Mandatory = $True, ParameterSetName = "ObjectsValidation", HelpMessage = "Validate source Mailbox and Target MailUser objects. If used alone you will be prompted to introduce the identities you want to validate")]
     [Parameter(Mandatory = $False, ParameterSetName = "OfflineMode", HelpMessage = "Validate source Mailbox and Target MailUser objects. If used alone you will be prompted to introduce the identities you want to validate")]

--- a/Databases/VSSTester/DiskShadow/Invoke-CreateDiskShadowFile.ps1
+++ b/Databases/VSSTester/DiskShadow/Invoke-CreateDiskShadowFile.ps1
@@ -3,6 +3,7 @@
 
 function Invoke-CreateDiskShadowFile {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Required to get drives on old systems')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
     param()
 
     function Out-DHSFile {

--- a/Databases/VSSTester/DiskShadow/Invoke-RemoveExposedDrives.ps1
+++ b/Databases/VSSTester/DiskShadow/Invoke-RemoveExposedDrives.ps1
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 function Invoke-RemoveExposedDrives {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
+    param()
 
     function Out-removeDHSFile {
         param ([string]$fileline)

--- a/Databases/VSSTester/ExchangeInformation/Get-DbToBackup.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-DbToBackup.ps1
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 function Get-DBtoBackup {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
+    param()
     $maxDbIndexRange = $script:databases.length - 1
     $matchCondition = "^([0-9]|[1-9][0-9])$"
     Write-Debug "matchCondition: $matchCondition"

--- a/Databases/VSSTester/VSSTester.ps1
+++ b/Databases/VSSTester/VSSTester.ps1
@@ -16,6 +16,7 @@
 #
 #################################################################################
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '', Justification = 'Allowing empty catch blocks for now as we need to be able to handle the exceptions.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
 [CmdletBinding()]
 param(
 )

--- a/Diagnostics/ExTRA/ExTRA.ps1
+++ b/Diagnostics/ExTRA/ExTRA.ps1
@@ -156,9 +156,3 @@ try {
 if (Test-Path $outputPath) {
     ShowCommandToHost
 }
-
-if ($MyInvocation.InvocationName -eq "&") {
-    # This was most likely run with right-click on the script.
-    # Pause so the user can read the output.
-    Read-Host "Hit Enter to exit"
-}

--- a/Diagnostics/ExTRA/ui.html
+++ b/Diagnostics/ExTRA/ui.html
@@ -40,12 +40,16 @@
         .btn {
             margin-top: 15px;
         }
+
+        .code {
+            padding: 20px;
+        }
     </style>
 </head>
 
 <body onload="showTags()">
     <div class="container">
-        <div class="row toolbar">
+        <div class="row toolbar tagSelectionElement">
             <div class="input-field col s3">
                 <input id="categoryFilter" onchange="categoryFilterChanged(event)"
                     onkeyup="categoryFilterChanged(event)" />
@@ -67,18 +71,46 @@
             <button class="btn waves-effect waves-light col s3" onclick="save()">Save</button>
         </div>
 
-        <div class="row">
-            <div class="col s12"><h5>Scenarios</h5></div>
+        <div class="row tagSelectionElement">
+            <div class="col s12">
+                <h5>Scenarios</h5>
+            </div>
         </div>
-        <div class="row" id="scenariosDiv">
+        <div class="row tagSelectionElement" id="scenariosDiv">
 
         </div>
 
-        <div class="row">
-            <div class="col s12"><h5>Tags</h5></div>
+        <div class="row tagSelectionElement">
+            <div class="col s12">
+                <h5>Tags</h5>
+            </div>
         </div>
-        <div id="checkboxesDiv">
+        <div class="tagSelectionElement" id="checkboxesDiv">
 
+        </div>
+        <div class="row hidden" id="syntaxDiv">
+            <p>The trace can be created, started, and stopped from the command line or PowerShell.</p>
+            <p>To create a data collector which is non-circular and stops at 1 GB:</p>
+            <p class="black green-text code">
+                <code>logman create trace ExchangeDebugTraces -p "{79bb49e6-2a2c-46e4-9167-fa122525d540}" -o c:\tracing\trace.etl -ow -f bin -max 1024 -mode globalsequence</code>
+            </p>
+            <p>To create a data collector which is circular and stops at 2 GB:</p>
+            <p class="black green-text code">
+                <code>logman create trace ExchangeDebugTraces -p "{79bb49e6-2a2c-46e4-9167-fa122525d540}" -o c:\tracing\trace.etl -ow -f bincirc -max 2048 -mode globalsequence</code>
+            </p>
+            <p>To create a data collector which is non-circular and creates a new file every 512 MB until you stop it manually:</p>
+            <p class="black green-text code">
+                <code>logman create trace ExchangeDebugTraces -p `"{79bb49e6-2a2c-46e4-9167-fa122525d540}`" -o c:\tracing\trace.etl -ow -f bin -max 512 -cnf 0 -mode globalsequence</code>
+            </p>
+            <p>To start the trace:</p>
+            <p class="black green-text code">
+                <code>logman start ExchangeDebugTraces</code>
+            </p>
+            <p>To stop the trace:</p>
+            <p class="black green-text code">
+                <code>logman stop ExchangeDebugTraces</code>
+            </p>
+            <p>The collector can also be started and stopped from Perfmon.</p>
         </div>
         <script>
             var selectionTable = [];
@@ -113,7 +145,11 @@
                     body: JSON.stringify(selectionTable, ['name', 'isSelected', 'tags'])
                 });
 
-                window.close();
+                [...document.getElementsByClassName('tagSelectionElement')].forEach(e => {
+                    e.classList.add('hidden');
+                });
+
+                document.getElementById('syntaxDiv').classList.remove('hidden');
             }
 
             function getScenarioNames() {

--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Value is used')]
-[CmdletBinding(DefaultParameterSetName = "LogAge")]
+[CmdletBinding(DefaultParameterSetName = "LogAge", SupportsShouldProcess, ConfirmImpact = "High")]
 param (
     [string]$FilePath = "C:\MS_Logs_Collection",
     [array]$Servers = @($env:COMPUTERNAME),

--- a/Diagnostics/ExchangeLogCollector/Helpers/Enter-YesNoLoopAction.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Enter-YesNoLoopAction.ps1
@@ -2,24 +2,27 @@
 # Licensed under the MIT License.
 
 function Enter-YesNoLoopAction {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
     param(
-        [Parameter(Mandatory = $true)][string]$Question,
-        [Parameter(Mandatory = $true)][scriptblock]$YesAction,
-        [Parameter(Mandatory = $true)][scriptblock]$NoAction
+        [Parameter(Mandatory = $true)]
+        [string]$Question,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Target = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$YesAction,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$NoAction
     )
 
     Write-Verbose "Calling: Enter-YesNoLoopAction"
     Write-Verbose "Passed: [string]Question: $Question"
 
-    do {
-        $answer = Read-Host ("{0} ('y' or 'n')" -f $Question)
-        Write-Verbose "Read-Host answer: $answer"
-    }while ($answer -ne 'n' -and $answer -ne 'y')
-
-    if ($answer -eq 'y') {
-        &$YesAction
+    if ($PSCmdlet.ShouldProcess($Target, $Question)) {
+        & $YesAction
     } else {
-        &$NoAction
+        & $NoAction
     }
 }

--- a/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
+++ b/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
@@ -6,6 +6,7 @@
 
 #  Provide your feedback to ExToolsFeedback@microsoft.com
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Override for now')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
 [cmdletbinding()]
 param([string]$pathforlogs, [switch]$Collect , [switch] $AllServers , [switch] $OnlyThisServer , [switch]$Help)
 

--- a/M365/src/DLT365Groupsupgrade.ps1
+++ b/M365/src/DLT365Groupsupgrade.ps1
@@ -1,5 +1,10 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('CustomRules\AvoidUsingReadHost', '', Justification = 'Do not want to change logic of script as of now')]
+[CmdletBiding()]
+param()
+
 #Create working folder on the logged user desktop
 $ts = Get-Date -Format yyyyMMdd_HHmmss
 $ExportPath = "$env:USERPROFILE\Desktop\PowershellDGUpgrade\DlToO365GroupUpgradeChecks_$ts"

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -45,7 +45,7 @@
         https://aka.ms/privacy
 #>
 
-[Cmdletbinding()]
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
 param (
     [switch]$RunFullScan,
     [switch]$RollbackMitigation,
@@ -362,6 +362,7 @@ function Run-Mitigate {
 
 function Run-MSERT {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Invalid rule result')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
     param(
         [switch]$RunFullScan,
         [switch]$DoNotRemediate
@@ -496,16 +497,9 @@ function Run-MSERT {
     $ScanMode = ""
     if ($RunFullScan) {
         Write-Warning -Message "Running a full scan can take hours or days to complete."
-        Write-Warning -Message "Would you like to continue with the Full MSERT Scan?"
 
-        while ($true) {
-            $Confirm = Read-Host "(Y/N)"
-            if ($Confirm -like "N") {
-                return
-            }
-            if ($Confirm -like "Y") {
-                break
-            }
+        if (-not ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, "Would you like to continue with the Full MSERT Scan?"))) {
+            return
         }
 
         $ScanMode = "Full Scan"


### PR DESCRIPTION
**Reason:**
Created a starter rule to help customize code formatting. We want to prevent `Read-Host` within our script as much as possible. 


Script that currently fail this are: 

CrossTenantMailboxMigrationValidation.ps1

- [x] VSSTester.ps1
  Get-DbToBackup.ps1
  Invoke-RemoveExposedDrives.ps1
  Invoke-CreateDiskShadowFile.ps1

- [x] ExchangeLogCollector/Enter-YesNoLoopAction.ps1

- [x] ExTRA.ps1

- [x] ManagedAvailabilityTroubleshooter.ps1

- [x] DLT365Groupsupgrade.ps1

- [x] EOMT.ps1
