### PR TITLE
Pipe HashSet to Get-ChildItem so the collection is not treated as one string

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -73,7 +73,7 @@ if ($optimizeCodeFormatter) {
 }
 
 if ($optimizeCodeFormatter) {
-    $filesToCheck = Get-ChildItem -Path $filesFullPath -Include "*.ps1", "*.psm1", "*.md"
+    $filesToCheck = $filesFullPath | Get-ChildItem -Include "*.ps1", "*.psm1", "*.md"
     Write-Host "Files that we are looking at for code formatting:"
     $filesToCheck.FullName | Write-Host
 } else {


### PR DESCRIPTION
Build is failing because Get-ChlidItem is doing a weird thing with the HashSet:

![image](https://user-images.githubusercontent.com/4518572/211322095-3a178c35-bf4e-445c-94de-8bed8d968d45.png)
