### PR TITLE
Use target branch of PR instead of assuming origin/main

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -6,7 +6,10 @@ param(
     $Save,
 
     [Switch]
-    $AllFiles
+    $AllFiles,
+
+    [string]
+    $Branch = "main"
 )
 
 #Requires -Version 7
@@ -38,8 +41,8 @@ $filesFullPath = New-Object 'System.Collections.Generic.HashSet[string]'
 if ($optimizeCodeFormatter) {
 
     Write-Verbose "Checking commits only"
-    # Get all the commits between origin/main and HEAD.
-    $gitlog = git log --format="%H %cd" --date=rfc origin/main..HEAD
+    # Get all the commits between origin/$Branch and HEAD.
+    $gitlog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
     $m = $gitlog | Select-String "^(\S+) (.*)$"
 
     foreach ($commitMatch in $m) {

--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -5,11 +5,8 @@ param(
     [Switch]
     $Save,
 
-    [Switch]
-    $AllFiles,
-
     [string]
-    $Branch = "main"
+    $Branch
 )
 
 #Requires -Version 7
@@ -35,7 +32,7 @@ if (-not (Load-Module -Name EncodingAnalyzer)) {
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
 
-$optimizeCodeFormatter = $AllFiles -eq $false
+$optimizeCodeFormatter = [string]::IsNullOrEmpty($Branch) -eq $false
 $filesFullPath = New-Object 'System.Collections.Generic.HashSet[string]'
 # Get only the files that are changed in this PR
 if ($optimizeCodeFormatter) {

--- a/.build/ValidateMerge.ps1
+++ b/.build/ValidateMerge.ps1
@@ -18,7 +18,9 @@
 #>
 
 [CmdletBinding()]
-param ()
+param (
+    [string]$Branch = "main"
+)
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
 $distFolder = Join-Path $repoRoot "dist"
@@ -38,8 +40,8 @@ $allowMergeFiles = @()
 # Files we already checked. We only want to check each file once.
 $filesAlreadyChecked = New-Object 'System.Collections.Generic.HashSet[string]'
 
-# Get all the commits between origin/main and HEAD.
-$gitlog = git log --format="%H %cd" --date=rfc origin/main..HEAD
+# Get all the commits between origin/$Branch and HEAD.
+$gitlog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
 $m = $gitlog | Select-String "^(\S+) (.*)$"
 
 foreach ($commitMatch in $m) {
@@ -85,7 +87,7 @@ foreach ($commitMatch in $m) {
     }
 
     foreach ($affectedFile in $allAffectedFiles) {
-        $commitTimeOnMainString = git log origin/main -n 1 --format="%cd" --date=rfc -- $affectedFile
+        $commitTimeOnMainString = git log origin/$Branch -n 1 --format="%cd" --date=rfc -- $affectedFile
         $commitTimeOnMain = $null
         if (-not [string]::IsNullOrEmpty($commitTimeOnMainString)) {
             $commitTimeOnMain = [DateTime]::Parse($commitTimeOnMainString).ToUniversalTime()

--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -9,9 +9,11 @@ steps:
 
 - pwsh: |
     cd .\.build
-    .\CodeFormatter.ps1
+    .\CodeFormatter.ps1 -Branch $env:TargetBranchName
   displayName: "Code Formatting Script"
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/release'))
+  env:
+    TargetBranchName: $(System.PullRequest.TargetBranch)
 
 - pwsh: |
     cd .\.build
@@ -25,5 +27,7 @@ steps:
 
 - pwsh: |
     cd .\.build
-    .\ValidateMerge.ps1
+    .\ValidateMerge.ps1 -Branch $env:TargetBranchName
   displayName: "Validate commit times"
+  env:
+    TargetBranchName: $(System.PullRequest.TargetBranch)


### PR DESCRIPTION
**Issue:**
Internal build process was failing because main doesn't exist there. 

**Fix:**
Use variable for pipeline and default to main for local use

**Validation:**
Tested
