### PR TITLE
Find all the DCs in the site

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-ExchangeDcCoreRatio.ps1
@@ -57,9 +57,7 @@ function Get-ExchangeDCCoreRatio {
     }
 
     $ADSite = [System.DirectoryServices.ActiveDirectory.ActiveDirectorySite]::GetComputerSite().Name
-    [array]$DomainControllers = (Get-ADForest).Domains |
-        ForEach-Object { Get-ADDomainController -Server $_ } |
-        Where-Object { $_.IsGlobalCatalog -eq $true -and $_.Site -eq $ADSite }
+    [array]$DomainControllers = [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest.FindAllGlobalCatalogs($ADSite)
 
     [System.Collections.Generic.List[System.Object]]$DCList = New-Object System.Collections.Generic.List[System.Object]
     $DCCoresTotal = 0


### PR DESCRIPTION
**Issue:**
With `Get-ADDomainController` without the parameter `-Filter` it was only returning a single server. Therefore, made the check pointless. 

**Fix:**
Use `Forest.FindAllGlobalCatalogs(string)` instead to find all the GCs in the site that we want. 

https://learn.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.forest.findallglobalcatalogs?view=dotnet-plat-ext-7.0

**Validation:**
Lab tested

Resolved #1140 