### PR TITLE
Analyze the whole dependency tree for a script

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -56,7 +56,22 @@ $allScriptFiles = Get-ChildItem -Path $repoRoot -Directory |
 
 $dependencyHashtable = Get-ScriptDependencyHashtable -FileNames $allScriptFiles
 
+# In this file, the key is the script, and the value is the list of files that it imports.
 $dependencyHashtable | Export-Clixml -Path "$distFolder\dependencyHashtable.xml"
+
+$dependentHashtable = @{}
+foreach ($k in $dependencyHashtable.Keys) {
+    foreach ($script in $dependencyHashtable[$k]) {
+        if ($dependentHashtable.ContainsKey($script)) {
+            $dependentHashtable[$script] += $k
+        } else {
+            $dependentHashtable[$script] = @($k)
+        }
+    }
+}
+
+# In this file, the key is the script, and the value is the list of files that import it.
+$dependentHashtable | Export-Clixml -Path "$distFolder\dependentHashtable.xml"
 
 $commitTimeHashtable = Get-FileTimestampHashtable -DependencyHashtable $dependencyHashtable
 


### PR DESCRIPTION
ValidateMerge needs to consider all files included in a script, not just the branch of the tree that includes that script.

Before:

![image](https://user-images.githubusercontent.com/4518572/211635702-212a3785-a4dc-488a-931d-460fff7faee3.png)

After:

![image](https://user-images.githubusercontent.com/4518572/211676456-5779d0dd-7d2a-4fe9-8a4d-00755a4486a5.png)
...
![image](https://user-images.githubusercontent.com/4518572/211676354-8844547d-3149-4c8a-93cc-1dc20a60632c.png)

