### PR TITLE
Fix to display the SDP status in E19

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
@@ -38,8 +38,8 @@ function Invoke-AnalyzerSecuritySerializedDataSigningState {
 
     if ($exchangeMajor -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
         switch ($exchangeCU) {
-            ($_ -eq "CU12") { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.1118.21"); break }
-            ($_ -eq "CU11") { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.986.37"); break }
+            { $_ -eq "CU12" } { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.1118.21"); break }
+            { $_ -eq "CU11" } { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.986.37"); break }
             default { $serializedDataSigningSupportedBuild = $false }
         }
     } elseif ($exchangeMajor -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {


### PR DESCRIPTION
**Issue:**
Customers reporting that the `Serialized Data Protection` status is not displayed in Exchange 2019

**Reason:**
Wrong brackets used in `switch` statment:

Is:
```
        switch ($exchangeCU) {
            ( $_ -eq "CU12" ) { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.1118.21"); break }
            ( $_ -eq "CU11" ) { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.986.37"); break }
            default { $serializedDataSigningSupportedBuild = $false }
        }
```

Should:
```
        switch ($exchangeCU) {
            { $_ -eq "CU12" } { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.1118.21"); break }
            { $_ -eq "CU11" } { $serializedDataSigningSupportedBuild = ($exchangeBuild -ge "15.2.986.37"); break }
            default { $serializedDataSigningSupportedBuild = $false }
        }
```

**Fix:**
Use `{}` brackets.

**Validation:**
Lab

