### PR TITLE
Exchange 2016 CU22 out of support

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -32,7 +32,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Internet Web Proxy" "Not Set"
             TestObjectMatch "Extended Protection Enabled (Any Vdir)" $false
             TestObjectMatch "Setting Overrides Detected" $false
-            $Script:ActiveGrouping.Count | Should -Be 13
+            $Script:ActiveGrouping.Count | Should -Be 14
         }
 
         It "Display Results - Organization Information" {

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -173,7 +173,7 @@ function Get-ExchangeBuildVersionInformation {
                 { $_ -lt "15.1.2507.6" } {
                     $cuLevel = "CU22"
                     $cuReleaseDate = "09/28/2021"
-                    $supportedBuildNumber = $true
+                    $supportedBuildNumber = $false
                     $mesoValue = 13242
                     $orgValue = 16222
                 }
@@ -190,7 +190,6 @@ function Get-ExchangeBuildVersionInformation {
                     $cuReleaseDate = "06/29/2021"
                     $mesoValue = 13241
                     $orgValue = 16221
-                    $supportedBuildNumber = $false
                 }
                 { $_ -lt "15.1.2308.8" } {
                     $cuLevel = "CU20"


### PR DESCRIPTION
**Reason:**
Exchange 2016 CU22 is no longer in support.

**Fix:**
Set flag on Exchange 2016 CU22 stating that it is no longer supported. 

**Validation:**
Pester
