### PR TITLE
Add edit icon back to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ theme:
   name: 'material'
   features:
     - navigation.indexes
+    - content.action.edit
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences:


### PR DESCRIPTION
**Issue:**
No longer have the edit icon on the docs page.

**Fix:**
Based off this doc, we need to have this feature enabled. 

Looks like this was just recently added to material in version 9.0.0. which was released last week.

https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/?h=edit#edit-this-page

**Validation:**
None.

