### PR TITLE
SetupAssist to use Get-ExchangeBuildVersionInformation

### DIFF
--- a/Setup/SetupAssist/Checks/LocalServer/Test-InstallWatermark.ps1
+++ b/Setup/SetupAssist/Checks/LocalServer/Test-InstallWatermark.ps1
@@ -1,0 +1,38 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\New-TestResult.ps1
+
+function Test-InstallWatermark {
+    [CmdletBinding()]
+    param()
+    begin {
+        $resultParams = @{
+            TestName      = "Install Watermark"
+            Result        = "Passed"
+            Details       = [string]::Empty
+            ReferenceInfo = "More Information: https://aka.ms/SA-InstallWatermark"
+        }
+    }
+    process {
+        $waterMarks = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15' -Recurse |
+            Where-Object { $null -ne $_.Property -and $_.Property.Contains("Watermark") }
+
+        if ($null -ne $waterMarks) {
+            Write-Verbose "Watermark detected"
+
+            foreach ($waterMark in $waterMarks) {
+
+                if ($waterMark.GetValue("Action") -eq "Install") {
+                    $resultParams.Result = "Failed"
+                    $resultParams.Details += $waterMark.GetValue("Watermark") + [System.Environment]::NewLine
+                } else {
+                    Write-Verbose "Watermark didn't contain action of install"
+                }
+            }
+        }
+    }
+    end {
+        New-TestResult @resultParams
+    }
+}

--- a/Setup/SetupAssist/Checks/UserContext/Test-UserIsAdministrator.ps1
+++ b/Setup/SetupAssist/Checks/UserContext/Test-UserIsAdministrator.ps1
@@ -1,0 +1,19 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\..\..\..\Shared\Confirm-Administrator.ps1
+. $PSScriptRoot\..\New-TestResult.ps1
+function Test-UserIsAdministrator {
+    $windowsIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+
+    $params = @{
+        TestName = "User Administrator"
+        Details  = "$($windowsIdentity.Name) $($windowsIdentity.User.Value)"
+    }
+
+    if (Confirm-Administrator) {
+        New-TestResult @params -Result "Passed"
+    } else {
+        New-TestResult @params -Result "Failed"
+    }
+}

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -24,6 +24,7 @@ param(
 . $PSScriptRoot\Checks\LocalServer\Test-PendingReboot.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-PrerequisiteInstalled.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-VirtualDirectoryConfiguration.ps1
+. $PSScriptRoot\Checks\UserContext\Test-UserGroupMemberOf.ps1
 . $PSScriptRoot\..\Shared\SetupLogReviewerLogic.ps1
 . $PSScriptRoot\..\..\Shared\LoggerFunctions.ps1
 . $PSScriptRoot\..\..\Shared\Write-ErrorInformation.ps1
@@ -41,7 +42,8 @@ function WriteCatchInfo {
 }
 
 function RunAllTests {
-    $tests = @("Test-ExchangeADSetupLevel",
+    $tests = @("Test-UserIsAdministrator",
+        "Test-ExchangeADSetupLevel",
         "Test-ExecutionPolicy",
         "Test-ExchangeServices",
         "Test-ComputersContainerExists",

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -19,6 +19,7 @@ param(
 . $PSScriptRoot\Checks\Domain\Test-ValidHomeMdb.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-ExecutionPolicy.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-ExchangeServices.ps1
+. $PSScriptRoot\Checks\LocalServer\Test-InstallWatermark.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-MissingDirectory.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-MsiCacheFiles.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-PendingReboot.ps1
@@ -49,6 +50,7 @@ function RunAllTests {
         "Test-ComputersContainerExists",
         "Test-DomainControllerDnsHostName",
         "Test-DomainMultiActiveSyncVirtualDirectories",
+        "Test-InstallWatermark",
         "Test-MissingDirectory",
         "Test-MsiCacheFiles",
         "Test-PrerequisiteInstalled",

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -25,7 +25,7 @@ param(
 . $PSScriptRoot\Checks\LocalServer\Test-PendingReboot.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-PrerequisiteInstalled.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-VirtualDirectoryConfiguration.ps1
-. $PSScriptRoot\Checks\UserContext\Test-UserGroupMemberOf.ps1
+. $PSScriptRoot\Checks\UserContext\Test-UserIsAdministrator.ps1
 . $PSScriptRoot\..\Shared\SetupLogReviewerLogic.ps1
 . $PSScriptRoot\..\..\Shared\LoggerFunctions.ps1
 . $PSScriptRoot\..\..\Shared\Write-ErrorInformation.ps1

--- a/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
+++ b/Setup/SetupLogReviewer/Checks/FindContext/Test-PrerequisiteCheck.ps1
@@ -77,13 +77,18 @@ function Test-PrerequisiteCheck {
         }
 
         if ((($SetupLogReviewer | TestEvaluatedSettingOrRule -SettingName "LocalDomainIsPrepped") -eq "False") -and
-            (($SetupLogReviewer |  TestEvaluatedSettingOrRule -SettingName "DomainPrepRequired" -SettingOrRule "Rule") -eq "True")) {
+            (($SetupLogReviewer | TestEvaluatedSettingOrRule -SettingName "DomainPrepRequired" -SettingOrRule "Rule") -eq "True")) {
             New-WriteObject "Local Domain Is Not Prepped or might have duplicate MESO Containers" -ForegroundColor "Red"
             if (Test-SetupAssist) {
                 New-ActionPlan @("Address the problem MESO Containers in 'Exchange AD Latest Level' test above")
             } else {
                 New-ActionPlan @("Run SetupAssist on the server to determine the problem and correct action plan.")
             }
+        }
+
+        if (($SetupLogReviewer | TestMultiEvaluatedSettingOrRule -SettingName "InstallWatermark" -SettingOrRule "Rule" -TestValue "True")) {
+            New-WriteObject "Exchange Setup failure was detected for install or recovery causing a watermark" -ForegroundColor "Red"
+            New-ActionPlan @("More Information: https://aka.ms/SA-InstallWatermark")
         }
 
         if ($returnNow) {

--- a/Setup/Tests/SetupAssist.Tests.ps1
+++ b/Setup/Tests/SetupAssist.Tests.ps1
@@ -24,9 +24,10 @@ Describe "Testing SetupAssist" {
         BeforeEach {
 
             Mock GetExchangeADSetupLevel { return $Script:GetExchangeADSetupLevel }
-            Mock TestMismatchLevel {}
+            Mock Get-SetupLogReviewer { return $Script:GetSetupLogReviewer }
             Mock TestPrepareAD {}
-            Mock Test-UserGroupMemberOf {}
+            Mock Test-Path { return $true }
+            Mock Test-UserGroupMemberOf { return $null }
 
             function SetGetExchangeADSetupLevel {
                 param(
@@ -50,168 +51,78 @@ Describe "Testing SetupAssist" {
                     }
                 }
             }
+
+            function SetGetSetupLogReviewer {
+                param(
+                    [string]$BuildNumber,
+                    [string]$User
+                )
+
+                $Script:GetSetupLogReviewer = [PSCustomObject]@{
+                    SetupBuildNumber = $BuildNumber
+                    User             = $User
+                }
+            }
         }
 
         It "Unknown Exchange 2013 Schema Value" {
             SetGetExchangeADSetupLevel -OrgValue 15130 -SchemaValue 15130 -MESOValue 15130
+            SetGetSetupLogReviewer "15.00.1473.003" "contoso\user"
             $results = Test-ExchangeADSetupLevel
+            Assert-MockCalled -CommandName Test-UserGroupMemberOf -ParameterFilter { $PrepareAdRequired -eq $true -and $PrepareSchemaRequired -eq $true } -Exactly 1
             $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "Unknown Exchange Schema Version"
-        }
-
-        It "Exchange 2013 CU23 Not Ready" {
-            SetGetExchangeADSetupLevel -OrgValue 16133 -SchemaValue 15312 -MESOValue 13236
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "Exchange 2013 CU23 Not Ready"
+            $results.Details | Should -Be "Exchange 2013 CU22"
         }
 
         It "Exchange 2013 CU23 Ready" {
             SetGetExchangeADSetupLevel -OrgValue 16133 -SchemaValue 15312 -MESOValue 13237
+            SetGetSetupLogReviewer "15.00.1497.002" "contoso\user"
+            $results = Test-ExchangeADSetupLevel
+            Assert-MockCalled -CommandName Test-UserGroupMemberOf -Exactly 0
+            $results.Result | Should -Be "Passed"
+            $results.Details | Should -Be "Exchange 2013 CU23"
+        }
+
+        It "Exchange 2016 CU10 - Last attempt CU10" {
+            SetGetExchangeADSetupLevel -OrgValue 16213 -SchemaValue 15332 -MESOValue 13236
+            SetGetSetupLogReviewer "15.01.1531.003" "contoso\user"
             $results = Test-ExchangeADSetupLevel
             $results.Result | Should -Be "Passed"
-            $results.Details | Should -Be "Exchange 2013 CU23 Ready"
+            $results.Details | Should -Be "Exchange 2016 CU10"
         }
 
-        It "Exchange 2016 Mismatch MESO 13236 Schema 15332" {
-            SetGetExchangeADSetupLevel -OrgValue 16133 -SchemaValue 15332 -MESOValue 13236
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
-        }
-
-        It "Exchange 2016 Mismatch MESO 13235 Schema 15332" {
-            SetGetExchangeADSetupLevel -OrgValue 16133 -SchemaValue 15332 -MESOValue 13235
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
-        }
-
-        It "Exchange 2016 CU10" {
+        It "Exchange 2016 CU10 AD - Last attempt CU11" {
             SetGetExchangeADSetupLevel -OrgValue 16213 -SchemaValue 15332 -MESOValue 13236
+            SetGetSetupLogReviewer "15.01.1591.010" "contoso\user"
             $results = Test-ExchangeADSetupLevel
+            Assert-MockCalled -CommandName Test-UserGroupMemberOf -ParameterFilter { $PrepareAdRequired -eq $true } -Exactly 1
             $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU10"
-        }
-
-        It "Exchange 2016 CU11" {
-            SetGetExchangeADSetupLevel -OrgValue 16214 -SchemaValue 15332 -MESOValue 13236
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU11"
-        }
-
-        It "Exchange 2016 CU12" {
-            SetGetExchangeADSetupLevel -OrgValue 16215 -SchemaValue 15332 -MESOValue 13236
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU12"
-        }
-
-        It "Exchange 2016 CU17" {
-            SetGetExchangeADSetupLevel -OrgValue 16217 -SchemaValue 15332 -MESOValue 13237
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU17"
-        }
-
-        It "Exchange 2016 CU18" {
-            SetGetExchangeADSetupLevel -OrgValue 16218 -SchemaValue 15332 -MESOValue 13238
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU18"
-        }
-
-        It "Exchange 2016 CU19" {
-            SetGetExchangeADSetupLevel -OrgValue 16219 -SchemaValue 15333 -MESOValue 13239
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU19"
-        }
-
-        It "Exchange 2016 CU20" {
-            SetGetExchangeADSetupLevel -OrgValue 16220 -SchemaValue 15333 -MESOValue 13240
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU20"
-        }
-
-        It "Exchange 2016 Mismatch Schema 15333" {
-            SetGetExchangeADSetupLevel -OrgValue 16221 -SchemaValue 15333 -MESOValue 13240
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
-        }
-
-        It "Exchange 2016 CU21" {
-            SetGetExchangeADSetupLevel -OrgValue 16221 -SchemaValue 15334 -MESOValue 13241
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU21"
-        }
-
-        It "Exchange 2016 CU22" {
-            SetGetExchangeADSetupLevel -OrgValue 16222 -SchemaValue 15334 -MESOValue 13242
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2016 CU22"
+            $results.Details | Should -Be "Exchange 2016 CU11"
         }
 
         It "Exchange 2016 CU23" {
             SetGetExchangeADSetupLevel -OrgValue 16223 -SchemaValue 15334 -MESOValue 13243
+            SetGetSetupLogReviewer "15.1.2507.6" "contoso\user"
             $results = Test-ExchangeADSetupLevel
+            Assert-MockCalled -CommandName Test-UserGroupMemberOf -Exactly 0
             $results.Result | Should -Be "Passed"
-            $results.Details | Should -Be "At Exchange 2016 CU23"
-        }
-
-        It "Exchange 2016 Mismatch Schema 15334" {
-            SetGetExchangeADSetupLevel -OrgValue 16221 -SchemaValue 15334 -MESOValue 13240
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
+            $results.Details | Should -Be "Exchange 2016 CU23"
         }
 
         It "Exchange 2019 CU8" {
             SetGetExchangeADSetupLevel -OrgValue 16756 -SchemaValue 17002 -MESOValue 13239
+            SetGetSetupLogReviewer "15.2.464.5" "contoso\user"
             $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2019 CU8"
-        }
-
-        It "Exchange 2019 CU9" {
-            SetGetExchangeADSetupLevel -OrgValue 16757 -SchemaValue 17002 -MESOValue 13240
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2019 CU9"
-        }
-
-        It "Exchange 2019 Mismatch Schema 17002" {
-            SetGetExchangeADSetupLevel -OrgValue 16221 -SchemaValue 17002 -MESOValue 13240
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
-        }
-
-        It "Exchange 2019 CU10" {
-            SetGetExchangeADSetupLevel -OrgValue 16758 -SchemaValue 17003 -MESOValue 13241
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2019 CU10"
-        }
-
-        It "Exchange 2019 CU11" {
-            SetGetExchangeADSetupLevel -OrgValue 16759 -SchemaValue 17003 -MESOValue 13242
-            $results = Test-ExchangeADSetupLevel
-            $results.Result | Should -Be "Failed"
-            $results.Details | Should -Be "At Exchange 2019 CU11"
+            $results.Result | Should -Be "Passed"
+            $results.Details | Should -Be "Exchange 2019 CU3"
         }
 
         It "Exchange 2019 CU12" {
             SetGetExchangeADSetupLevel -OrgValue 16760 -SchemaValue 17003 -MESOValue 13243
+            SetGetSetupLogReviewer "15.2.1118.7" "contoso\user"
             $results = Test-ExchangeADSetupLevel
             $results.Result | Should -Be "Passed"
-            $results.Details | Should -Be "At Exchange 2019 CU12"
-        }
-
-        It "Exchange 2019 Mismatch Schema 17003" {
-            SetGetExchangeADSetupLevel -OrgValue 16757 -SchemaValue 17003 -MESOValue 13241
-            Test-ExchangeADSetupLevel
-            Assert-MockCalled -Exactly 1 -CommandName "TestMismatchLevel"
+            $results.Details | Should -Be "Exchange 2019 CU12"
         }
     }
 }

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -48,6 +48,11 @@ function Get-ExchangeBuildVersionInformation {
             Invoke-CatchActionError $CatchActionFunction
         }
 
+        <#
+            Exchange Build Numbers: https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019
+            Exchange 2016 & 2019 AD Changes: https://learn.microsoft.com/en-us/exchange/plan-and-deploy/prepare-ad-and-domains?view=exchserver-2019
+            Exchange 2013 AD Changes: https://learn.microsoft.com/en-us/exchange/prepare-active-directory-and-domains-exchange-2013-help
+        #>
         if ($exchangeVersion.Major -eq 15 -and $exchangeVersion.Minor -eq 2) {
             Write-Verbose "Exchange 2019 is detected"
             $exchangeMajorVersion = "Exchange2019"

--- a/docs/Setup/SetupAssist/InstallWatermark.md
+++ b/docs/Setup/SetupAssist/InstallWatermark.md
@@ -1,0 +1,3 @@
+# Install Watermark
+
+After a failed install attempt of Exchange, we can leave behind a watermark that then prevents you from trying to run setup again when trying use unattended mode. To get around this issue, run Setup.exe from the GUI and not the command line. From the GUI, it is able to detect that we had a watermark and tries to pick up where we left off. However, unattended mode fails in the prerequisites check section prior to running and the GUI skips over this section.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - ComputersContainer: Setup/SetupAssist/ComputersContainer.md
       - ReadOnlyDomainControllerContainer: Setup/SetupAssist/ReadOnlyDomainControllerContainer.md
       - RebootPending: Setup/SetupAssist/RebootPending.md
+      - InstallWatermark: Setup/SetupAssist/InstallWatermark.md
     - SetupLogReviewer: Setup/SetupLogReviewer.md
   - Transport:
     - Compute-TopExoRecipientsFromMessageTrace: Transport/Compute-TopExoRecipientsFromMessageTrace.md


### PR DESCRIPTION
**Reason:**
This allows for the shared code `Get-ExchangeBuildVersionInformation` that now contains the ORG, MESO, Schema version values in it to be used so we can use the last CU install attempt build number to determine what level of AD we should be at and if we need to run `/PrepareAD`, `/PrepareDomain`, or `/PrepareSchema`

Also included test for install watermark on the server. 


**Validation:**
Lab tested.
Resolved #1314 
Resolved #1355