### PR TITLE
Updates on SerializedDataSigning feature

### DIFF
--- a/Admin/MonitorExchangeAuthCertificate/MonitorExchangeAuthCertificate.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/MonitorExchangeAuthCertificate.ps1
@@ -159,6 +159,8 @@ function Main {
     $versionsUrl = "https://aka.ms/MEAC-VersionsUrl"
     Write-Host ("Monitor Exchange Auth Certificate script version $($BuildVersion)") -ForegroundColor Green
 
+    $currentErrors = $Error.Count
+
     if ($ScriptUpdateOnly) {
         switch (Test-ScriptVersion -AutoUpdate -VersionsUrl $versionsUrl -Confirm:$false) {
             ($true) { Write-Host ("Script was successfully updated") -ForegroundColor Green }
@@ -173,6 +175,8 @@ function Main {
         Write-Host ("Script was updated. Please rerun the command") -ForegroundColor Yellow
         return
     }
+
+    Invoke-ErrorCatchActionLoopFromIndex $currentErrors
 
     if ($PrepareADForAutomationOnly) {
         Write-Host ("Mode: Prepare AD account to run the script as scheduled task")

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerKnownBuildIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerKnownBuildIssues.ps1
@@ -186,6 +186,15 @@ function Invoke-AnalyzerKnownBuildIssues {
             -InformationUrl (GetKnownIssueInformation `
                 "Exchange Service Host service fails after installing March 2022 security update (KB5013118)" `
                 "https://support.microsoft.com/kb/5013118")
+
+        Write-Verbose "Working on January 2023 Security Updates - Management issues after SerializedDataSigning is enabled on Exchange Server 2013"
+        TestForKnownBuildIssues -CurrentVersion $currentVersion `
+            -KnownBuildIssuesToFixes @(
+            (GetKnownIssueBuildInformation "15.0.1497.45" $null)
+        ) `
+            -InformationUrl (GetKnownIssueInformation `
+                "Management issues after SerializedDataSigning is enabled on Exchange Server 2013" `
+                "https://techcommunity.microsoft.com/t5/exchange-team-blog/released-january-2023-exchange-server-security-updates/ba-p/3711808")
     } catch {
         Write-Verbose "Failed to run TestForKnownBuildIssues"
         Invoke-CatchActions

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
@@ -115,10 +115,10 @@ function Invoke-AnalyzerSecuritySerializedDataSigningState {
             Write-Verbose "Checking Registry Value for SerializedDataSigning configuration state"
             if ($serializedDataSigningInformation -eq 1) {
                 Write-Verbose "SerializedDataSigning enabled via Registry Value"
-                $serializedDataSigningWriteType = "Green"
-                $serializedDataSigningState = $true
+                $serializedDataSigningState = ("$($true) - We recommend not to turn on this feature on Exchange 2013 for now")
             } else {
                 Write-Verbose "SerializedDataSigning not configured or explicitly disabled via Registry Value"
+                $serializedDataSigningWriteType = "Grey"
                 $serializedDataSigningState = $false
             }
         }

--- a/docs/Diagnostics/HealthChecker/SerializedDataSigningCheck.md
+++ b/docs/Diagnostics/HealthChecker/SerializedDataSigningCheck.md
@@ -12,6 +12,8 @@ The HealthChecker check validates that the feature is enabled on supported Excha
 
 ### Important
 
+ > :warning: **If you have an Exchange Server 2013 in your environment**: Turning on the signing of serialization payload feature might lead to several issues impacting management in your organization. We recommend not to turn on this feature for now. We will address this in the future update. Customers with Exchange Server 2016 / 2019 only can proceed with using the certificate signing of PowerShell serialization payload feature.
+
 Ensure all the Exchange Servers (Exchange Server 2019, 2016 and 2013) in the environment are running the January 2023 (or later) SU before turning the feature on. Enabling the feature before all servers are updated might lead to failures and errors when managing your organization.
 
 This features uses the `Exchange Server Auth Certificate` to sign the serialized data. Therefore, it's very important that the certificate which is configured as Auth Certificate is valid (not expired) and available on all Exchange Servers (except Edge Transport role and Exchange Management Tools role) within the organization.


### PR DESCRIPTION
**Issue:**
There are known issues when SerializedDataSigning is enabled on Exchange Server 2013 (https://techcommunity.microsoft.com/t5/exchange-team-blog/released-january-2023-exchange-server-security-updates/ba-p/3711808). Therefore, we do not recommend turning this feature on when running E15 in your enviornment. 

**Reason:**
As per note: https://techcommunity.microsoft.com/t5/exchange-team-blog/released-january-2023-exchange-server-security-updates/ba-p/3711808

**Fix:**
Check adjusted and known issue added

**Validation:**
E15 lab
