### PR TITLE
HealthChecker Loadbalancer report shows 100 % load if no requests are available

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-LoadBalancingReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-LoadBalancingReport.ps1
@@ -198,8 +198,9 @@ function Get-LoadBalancingReport {
             } else {
                 $serverValue = 0
             }
-            if ( $totalRequests -eq 0 -or $null -eq $totalRequests) {
-                $percentageLoad = 100
+            if (($totalRequests -eq 0) -or
+                ($null -eq $totalRequests)) {
+                $percentageLoad = 0
             } else {
                 $percentageLoad = [math]::Round((($serverValue / $totalRequests) * 100))
             }
@@ -252,8 +253,9 @@ function Get-LoadBalancingReport {
             } else {
                 $serverValue = 0
             }
-            if ( $totalRequests -eq 0 -or $null -eq $totalRequests) {
-                $percentageLoad = 100
+            if (($totalRequests -eq 0) -or
+                ($null -eq $totalRequests)) {
+                $percentageLoad = 0
             } else {
                 $percentageLoad = [math]::Round((($serverValue / $totalRequests) * 100))
             }


### PR DESCRIPTION
**Issue:**
Customer reported that we show 100% load in HealthChecker Loadbalancing report if `$totalRequests` was `0` or `$null`.

**Reason:**
I think this was a copy/paste issue.

**Fix:**
Changed value to 0 instead of 100.

**Validation:**
Lab

