### PR TITLE
Get-InternalTransportCertificate causes unhandled exception on Edge Transport servers

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -76,13 +76,8 @@ function Get-ExchangeServerCertificates {
             Write-Verbose "Trying to receive certificates from Exchange server: $($Server)"
             $exchangeServerCertificates = Get-ExchangeCertificate -Server $Server -ErrorAction Stop
 
-            try {
-                Write-Verbose "Trying to query internal transport certificate from AD for this server"
-                $internalTransportCertificate = Get-InternalTransportCertificateFromServer -ComputerName $Server
-            } catch {
-                Write-Verbose "Unable to query the internal transport certificate from AD - call is expected to fail on Edge Transport Servers"
-                Invoke-CatchActions
-            }
+            Write-Verbose "Trying to query internal transport certificate from AD for this server"
+            $internalTransportCertificate = Get-InternalTransportCertificateFromServer -ComputerName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
 
             if ($null -ne $exchangeServerCertificates) {
                 try {

--- a/Shared/ActiveDirectoryFunctions/Get-InternalTransportCertificateFromServer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-InternalTransportCertificateFromServer.ps1
@@ -10,7 +10,7 @@ function Get-InternalTransportCertificateFromServer {
     param (
         [string]$ComputerName = $env:COMPUTERNAME,
         [Parameter(Mandatory = $false)]
-        [scriptblock]$CatchActionFunction
+        [ScriptBlock]$CatchActionFunction
     )
 
     <#

--- a/Shared/ActiveDirectoryFunctions/Get-InternalTransportCertificateFromServer.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-InternalTransportCertificateFromServer.ps1
@@ -2,12 +2,15 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Get-OrganizationContainer.ps1
+. $PSScriptRoot\..\Invoke-CatchActionError.ps1
 
 function Get-InternalTransportCertificateFromServer {
     [CmdletBinding()]
     [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
     param (
-        [string]$ComputerName = $env:COMPUTERNAME
+        [string]$ComputerName = $env:COMPUTERNAME,
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$CatchActionFunction
     )
 
     <#
@@ -29,6 +32,7 @@ function Get-InternalTransportCertificateFromServer {
         }
     } catch {
         Write-Verbose ("Unable to query the internal transport certificate - Exception: $($Error[0].Exception.Message)")
+        Invoke-CatchActionError $CatchActionFunction
     }
 
     return $certObject


### PR DESCRIPTION
**Issue:**
We didn't handle the following failing call which is expected to fail on Edge Transport servers:

Stack:
```
 : Exception calling "GetComputerDomain" with "0" argument(s): "The local computer is not joined to a domain or the domain cannot be contacted."
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.PSScriptCmdlet.DoEndProcessing()
   at System.Management.Automation.CommandProcessorBase.Complete()
Position Message: At C:\AdminScripts\HealthChecker\HealthChecker.ps1:8864 char:33
+ ... ]("LDAP://$([System.DirectoryServices.ActiveDirectory.Domain]::GetCom ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Get-ExchangeContainer, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 8864
at Get-OrganizationContainer, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 8876
at Get-InternalTransportCertificateFromServer, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 9886
at Get-ExchangeServerCertificates<Process>, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 10011
at Get-ExchangeInformation, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 10511
at Get-HealthCheckerExchangeServer, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 12297
at Get-HealthCheckerData, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 13012
at Invoke-HealthCheckerMainReport, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 13088
at <ScriptBlock><End>, C:\AdminScripts\HealthChecker\HealthChecker.ps1: line 13821
at <ScriptBlock>, <No file>: line 1
```

**Reason:**
`GetComputerDomain` fails on computers which are not domain joined (as Edge Transport servers)

**Fix:**
`CatchActionFunction` added to `Get-InternalTransportCertificateFromServer`

**Validation:**
Customer

