### PR TITLE
Use Custom properties for Vulnerability Report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Add-AnalyzedResultInformation.ps1
@@ -4,22 +4,47 @@
 function Add-AnalyzedResultInformation {
     [CmdletBinding()]
     param(
+        # Main object that we are manipulating and adding entries to
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [HealthChecker.AnalyzedInformation]$AnalyzedInformation,
+
+        # The value of the display entry
         [object]$Details,
-        [string]$Name,
-        [string]$TestingName,
-        [object]$OutColumns,
-        [ScriptBlock[]]$OutColumnsColorTests,
-        [string]$HtmlName,
+
         [object]$DisplayGroupingKey,
+
         [int]$DisplayCustomTabNumber = -1,
-        [object]$DisplayTestingValue,
+
         [string]$DisplayWriteType = "Grey",
-        [bool]$AddDisplayResultsLineInfo = $true,
-        [bool]$AddHtmlDetailRow = $true,
+
+        # The name of the display entry
+        [string]$Name,
+
+        # Used for when the name might have a duplicate and we want it to be unique for logic outside of display
+        [string]$CustomName,
+
+        # Used for when the value might have a duplicate and we want it to be unique for logic outside of display
+        [object]$CustomValue,
+
+        # Used to display an Object in a table
+        [object]$OutColumns,
+
+        [ScriptBlock[]]$OutColumnsColorTests,
+
+        [string]$TestingName,
+
+        [object]$DisplayTestingValue,
+
+        [string]$HtmlName,
+
         [string]$HtmlDetailsCustomValue = "",
+
+        [bool]$AddDisplayResultsLineInfo = $true,
+
+        [bool]$AddHtmlDetailRow = $true,
+
         [bool]$AddHtmlOverviewValues = $false,
+
         [bool]$AddHtmlActionRow = $false
         #[string]$ActionSettingClass = "",
         #[string]$ActionSettingValue,
@@ -95,10 +120,26 @@ function Add-AnalyzedResultInformation {
                     $lineInfo.TestingValue = $Details
                 }
 
+                if ($null -ne $CustomValue) {
+                    $lineInfo.CustomValue = $CustomValue
+                } elseif ($null -ne $DisplayTestingValue) {
+                    $lineInfo.CustomValue = $DisplayTestingValue
+                } else {
+                    $lineInfo.CustomValue = $Details
+                }
+
                 if (-not ([string]::IsNullOrEmpty($TestingName))) {
                     $lineInfo.TestingName = $TestingName
                 } else {
                     $lineInfo.TestingName = $Name
+                }
+
+                if (-not ([string]::IsNullOrEmpty($CustomName))) {
+                    $lineInfo.CustomName = $CustomName
+                } elseif (-not ([string]::IsNullOrEmpty($TestingName))) {
+                    $lineInfo.CustomName = $TestingName
+                } else {
+                    $lineInfo.CustomName = $Name
                 }
 
                 $lineInfo.WriteType = $DisplayWriteType

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -59,6 +59,7 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                     Details             = "CVE-2022-24516, CVE-2022-21979, CVE-2022-21980, CVE-2022-24477, CVE-2022-30134"
                     DisplayWriteType    = "Red"
                     TestingName         = "Extended Protection Vulnerable"
+                    CustomName          = "CVE-2022-24516, CVE-2022-21979, CVE-2022-21980, CVE-2022-24477, CVE-2022-30134"
                     DisplayTestingValue = $true
                 }
                 $epBasicParams = $baseParams + @{

--- a/Diagnostics/HealthChecker/Features/Invoke-VulnerabilityReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Invoke-VulnerabilityReport.ps1
@@ -67,13 +67,13 @@ function Invoke-VulnerabilityReport {
                 $cveName = [string]::Empty
 
                 if ($vulnerability.Name -eq $securityVulnerability) {
-                    if ($vulnerability.TestingName -ne $securityVulnerability) {
-                        $cveName = $vulnerability.TestingName
+                    if ($vulnerability.CustomName -ne $securityVulnerability) {
+                        $cveName = $vulnerability.CustomName
                     } else {
-                        $cveName = $vulnerability.TestingValue
+                        $cveName = $vulnerability.CustomValue
                     }
                 } elseif (($vulnerability.Name -eq $iisModule -and
-                        $vulnerability.TestingValue -eq $true) -or
+                        $vulnerability.CustomValue -eq $true) -or
                     ($null -ne $vulnerability.Name -and
                     $vulnerability.Name -ne $iisModule)) {
                     $cveName = $vulnerability.Name

--- a/Diagnostics/HealthChecker/Helpers/Class.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Class.ps1
@@ -334,8 +334,10 @@ using System.Collections;
             public string DisplayValue;
             public string Name;
             public string TestingName; // Used for pestering testing
+            public string CustomName; // Used for security vulnerability
             public int TabNumber;
             public object TestingValue; //Used for pester testing down the road.
+            public object CustomValue; // Used for security vulnerability
             public object OutColumns; //used for colorized format table option.
             public string WriteType;
 


### PR DESCRIPTION
**Reason:**
Avoid using the testing properties to pull out the name of the CVEs that we want to showcase. 

**Fix:**
Added additional properties to be looking at.

**Validation:**
Lab tested

