### PR TITLE
Remove NET Core 2 Requirment and use code sign V2

### DIFF
--- a/azure-pipeline-release.yml
+++ b/azure-pipeline-release.yml
@@ -12,12 +12,7 @@ steps:
     .\Build.ps1
   displayName: "Build Script"
 
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    version: '2.1.x'
-
-- task: EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   condition: and(succeeded(), ne (variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release'))
   inputs:
     ConnectedServiceName: 'CSS Exchange Code Sign'


### PR DESCRIPTION
**Reason:**
Use code sign version 2 and remove NET Core 2 requirement that was needed for the version 1.


