### PR TITLE
Throw if we can't find in the install path for CopyMissingDlls

### DIFF
--- a/Setup/CopyMissingDlls/CopyMissingDlls.ps1
+++ b/Setup/CopyMissingDlls/CopyMissingDlls.ps1
@@ -19,7 +19,19 @@ $2019mappingsFileContent = [System.Text.Encoding]::UTF8.GetString($2019mappingsF
 
 #Get Version installed on server
 $installPath = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction SilentlyContinue).MsiInstallPath
+
+if ($null -eq $installPath) {
+    throw "Failed to find MsiInstallPath in the registry."
+} elseif (-not (Test-Path $installPath)) {
+    throw "Failed to find proper install path. '$installPath'"
+}
+
 $installedVersion = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\ExchangeServer\v15\AdminTools -ErrorAction SilentlyContinue).ConfiguredVersion
+
+if ($null -eq $installedVersion) {
+    throw "Failed to find ConfiguredVersion in the registry."
+}
+
 #get version of ISO, verify it is the same.
 $isoItemRoot = Get-Item "$IsoRoot\Setup.exe"
 


### PR DESCRIPTION
**Issue:**
Customer ran into a bunch of errors with the script trying to copy files, but this was because we weren't able to find the install path for some reason.

**Reason:**
Avoid attempting to copy the data if the install path doesn't exist. 

**Fix:**
Do a `throw` if we fail to find the install path from registry or path isn't created. 

**Validation:**
N/A

