### PR TITLE
Remove unnecessary escape characters

### DIFF
--- a/Diagnostics/ExTRA/ui.html
+++ b/Diagnostics/ExTRA/ui.html
@@ -100,7 +100,7 @@
             </p>
             <p>To create a data collector which is non-circular and creates a new file every 512 MB until you stop it manually:</p>
             <p class="black green-text code">
-                <code>logman create trace ExchangeDebugTraces -p `"{79bb49e6-2a2c-46e4-9167-fa122525d540}`" -o c:\tracing\trace.etl -ow -f bin -max 512 -cnf 0 -mode globalsequence</code>
+                <code>logman create trace ExchangeDebugTraces -p "{79bb49e6-2a2c-46e4-9167-fa122525d540}" -o c:\tracing\trace.etl -ow -f bin -max 512 -cnf 0 -mode globalsequence</code>
             </p>
             <p>To start the trace:</p>
             <p class="black green-text code">


### PR DESCRIPTION
Copy/pasting with these causes a syntax error.