### PR TITLE
UX improvements

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -54,7 +54,6 @@ param (
     [switch]$TransportConfig,
     [switch]$TransportRoutingTableLogs,
     [switch]$WindowsSecurityLogs,
-    [switch]$AcceptEULA,
     [switch]$AllPossibleLogs,
     [Alias("CollectAllLogsBasedOnDaysWorth")]
     [bool]$CollectAllLogsBasedOnLogAge = $true,
@@ -162,37 +161,10 @@ function Invoke-RemoteFunctions {
 
 function Main {
 
-    Start-Sleep 1
     Test-PossibleCommonScenarios
     Test-NoSwitchesProvided
 
-    $display = @"
-
-        Exchange Log Collector v{0}
-
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-        BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-        DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        -This script will copy over data based off the switches provided.
-        -We will check for at least {1} GB of free space at the local target directory BEFORE
-            attempting to do the remote execution. It will continue to check to make sure that we have
-            at least {2} GB of free space throughout the data collection. If some data is determined
-            that if we were to copy it over it would place us over that threshold, we will not copy that
-            data set over. The script will continue to run while still constantly check the free space
-            available before doing a copy action.
-        -Please run this script at your own risk.
-
-"@ -f $BuildVersion, ($Script:StandardFreeSpaceInGBCheckSize = 10), $Script:StandardFreeSpaceInGBCheckSize
-
-    Clear-Host
-    Write-Host $display
-
-    if (-not($AcceptEULA)) {
-        Enter-YesNoLoopAction -Question "Do you wish to continue? " -YesAction {} -NoAction { exit }
-    }
+    Write-Host "Exchange Log Collector v$($BuildVersion)"
 
     if ( $PSCmdlet.ParameterSetName -eq "LogPeriod" -and ( $LogAge.CompareTo($LogEndAge) -ne 1 ) ) {
         Write-Host "LogStartDate time should smaller than LogEndDate time." -ForegroundColor "Yellow"

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -25,7 +25,6 @@ You are able to use a config file to load up all the parameters you wish to choo
   ],
   "FilePath": "C:\\MS_Logs",
   "IISLogs": true,
-  "AcceptEULA": true,
   "AppSysLogsToXml": false,
   "ScriptDebug": true
 }
@@ -110,7 +109,6 @@ TransportAgentLogs | Enable to collect the Agent Logs. Location: `(Get-Transport
 TransportConfig | Enable to collect the Transport Configuration files from the Server and `Get-TransportConfig` from the org. Files: `EdgeTransport.exe.config`, `MSExchangeFrontEndTransport.exe.config`, `MSExchangeDelivery.exe.config`, and `MSExchangeSubmission.exe.config`
 TransportRoutingTableLogs | Enable to collect the Routing Table Logs. Location: `(Get-TransportService $server).RoutingTableLogPath`, `(Get-FrontendTransportService $server).RoutingTableLogPath`, and `(Get-MailboxTransportService $server).RoutingTableLogPath`
 WindowsSecurityLogs | Enable to collect the Windows Security Logs. Default Location: `'C:\Windows\System32\WinEvt\Logs\Security.evtx'`
-AcceptEULA | Enable to accept the conditions of the script and not get prompted.
 AllPossibleLogs | Enables the collection of all default logging collection on the Server.
 CollectAllLogsBasedOnLogAge | Boolean to determine if you collect all the logs based off the log's age or all the logs in that directory. Default value `$true`
 ConnectivityLogs | Enables the following switches and their logs to be collected: `FrontEndConnectivityLogs`, `HubConnectivityLogs`, and `MailboxConnectivityLogs`


### PR DESCRIPTION
ExchangeLogCollector does some things that negatively impact the user experience. This PR:

- Removes the 1-second delay. We shouldn't pause for no reason.
- Removes Clear-Host. We shouldn't clear the display for no reason.
- Removes the EULA prompt. Other more invasive scripts do not have EULA prompts, so why does this one?