### PR TITLE
Add Rule to prevent Clear-Host from being used in Scripts

### DIFF
--- a/.build/CodeFormatterChecks/CustomRules.psm1
+++ b/.build/CodeFormatterChecks/CustomRules.psm1
@@ -34,3 +34,37 @@ function AvoidUsingReadHost {
         }
     }
 }
+
+function AvoidUsingClearHost {
+
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]$ScriptBlockAst
+    )
+
+    process {
+
+        try {
+            $functions = $ScriptBlockAst.FindAll(
+                {
+                    $args[0] -is [System.Management.Automation.Language.CommandAst]
+                }, $true )
+            foreach ( $function in $functions ) {
+
+                if (($function.GetCommandName()) -eq "Clear-Host") {
+                    [PSCustomObject]@{
+                        Message  = "Avoid using Clear-Host. The screen should not be cleared when running the script."
+                        Extent   = $function.Extent
+                        RuleName = $PSCmdlet.MyInvocation.InvocationName
+                        Severity = "Error"
+                    }
+                }
+            }
+        } catch {
+            $PSCmdlet.ThrowTerminatingError( $_ )
+        }
+    }
+}

--- a/Admin/Get-EASMailboxLogs.ps1
+++ b/Admin/Get-EASMailboxLogs.ps1
@@ -46,12 +46,6 @@ if ($null -ne $EnableVerboseLogging) {
     }
 }
 
-Clear-Host
-Write-Host "Do not close this window until you are ready to collect the logs." -ForegroundColor Black -BackgroundColor Yellow
-Write-Host "Press any key to continue ..." -ForegroundColor Yellow
-$host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown") | Out-Null
-Clear-Host
-
 # Convert the interval into seconds
 $Interval = $Interval * 60
 

--- a/Databases/VSSTester/VSSTester.ps1
+++ b/Databases/VSSTester/VSSTester.ps1
@@ -202,6 +202,5 @@ function Main {
 }
 
 try {
-    Clear-Host
     Main
 } catch { } finally { }


### PR DESCRIPTION
**Reason:**
Prevent scripts from using `Clear-Host` within CSS-Exchange. 




