### PR TITLE
Include ErrorAction Stop for Get-SmbServerConfiguration

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
@@ -15,7 +15,7 @@ function Get-Smb1ServerSettings {
     }
     process {
         $smbServerConfiguration = Invoke-ScriptBlockHandler -ComputerName $ServerName `
-            -ScriptBlock { Get-SmbServerConfiguration } `
+            -ScriptBlock { Get-SmbServerConfiguration -ErrorAction Stop } `
             -CatchActionFunction $CatchActionFunction `
             -ScriptBlockDescription "Get-SmbServerConfiguration"
 


### PR DESCRIPTION
**Issue:**
Customer was reporting an error was occurring with `Get-SmbServerConfiguration` because they weren't able to run it in their environment. Health Checker was calling out that there wasn't a handled issue, but still completed just fine.

**Fix:**
Include `-ErrorAction Stop` for `Get-SmbServerConfiguration`

This is required to trigger the catch to occur in the script block handler.


**Validation:**
Customer tested

