### PR TITLE
Use Get-Website to query the website id

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-LoadBalancingReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-LoadBalancingReport.ps1
@@ -98,7 +98,7 @@ function Get-LoadBalancingReport {
 
     $currentErrors = $Error.Count
     foreach ( $CASServer in $CASServers) {
-        $DefaultIdSite = Invoke-Command -ComputerName $CASServer -ScriptBlock { (Get-IISSite "Default Web Site").Id }
+        $DefaultIdSite = Invoke-Command -ComputerName $CASServer -ScriptBlock { (Get-Website "Default Web Site").Id }
 
         $FECounters = Get-LocalizedCounterSamples -MachineName $CASServer -Counter @(
             "\ASP.NET Apps v4.0.30319(_lm_w3svc_$($DefaultIdSite)_*)\Requests Executing"
@@ -142,7 +142,7 @@ function Get-LoadBalancingReport {
     $keyOrders = $displayKeys.Keys | Sort-Object
 
     foreach ( $MBXServer in $MBXServers) {
-        $BackendIdSite = Invoke-Command -ComputerName $MBXServer -ScriptBlock { (Get-IISSite "Exchange Back End").Id }
+        $BackendIdSite = Invoke-Command -ComputerName $MBXServer -ScriptBlock { (Get-Website "Exchange Back End").Id }
 
         $BECounters = Get-LocalizedCounterSamples -MachineName $MBXServer -Counter @(
             "\ASP.NET Apps v4.0.30319(_lm_w3svc_$($BackendIdSite)_*)\Requests Executing"


### PR DESCRIPTION
**Issue:**
`LoadBalancingReport` wasn't able to run on Windows Server 2012 R2

**Reason:**
We used the `Get-IISSite` cmdlet which is part of the `IISAdministration` module. This module isn't available on Windows Server 2012 R2.

**Fix:**
As we only use this cmdlet to get the website id, we can use the `Get-Website` cmdlet which is part of the `WebAdministration` module and so available on Windows Server 2012 R2.

**Validation:**
Customer (confirmed)

