### PR TITLE
Reduce size of Health Checker XML Output

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeAppPoolsInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeAppPoolsInformation.ps1
@@ -25,7 +25,7 @@ function Get-ExchangeAppPoolsInformation {
                     $FilePath
                 )
                 if (Test-Path $FilePath) {
-                    return (Get-Content $FilePath)
+                    return (Get-Content $FilePath -Raw)
                 }
                 return [string]::Empty
             } `

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
@@ -47,7 +47,7 @@ function Get-ExchangeServerIISSettings {
                 [PSCustomObject]@{
                     Location = $_
                     Exist    = $(Test-Path $_)
-                    Content  = if (Test-Path $_) { Get-Content $_ } else { $null }
+                    Content  = if (Test-Path $_) { Get-Content $_ -Raw } else { $null }
                 }
             }
         } -ArgumentList (, $sharedWebConfigPaths) -ScriptBlockDescription "Getting Shared Web Config Files"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
@@ -16,7 +16,7 @@ function Get-IISWebApplication {
             $webConfigExists = Test-Path $configurationFilePath
 
             if ($webConfigExists) {
-                $webConfigContent = Get-Content $configurationFilePath
+                $webConfigContent = Get-Content $configurationFilePath -Raw
                 $linkedConfigurationLine = ($webConfigContent | Select-String "linkedConfiguration").Line
 
                 if ($null -ne $linkedConfigurationLine) {

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -27,7 +27,7 @@ function Get-IISWebSite {
         $webConfigContent = $null
 
         if ($webConfigExists) {
-            $webConfigContent = Get-Content $configurationFilePath
+            $webConfigContent = Get-Content $configurationFilePath -Raw
         }
 
         $returnList.Add([PSCustomObject]@{

--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
@@ -126,7 +126,7 @@ function Get-HealthCheckerData {
         Write-Progress @paramWriteProgress
 
         try {
-            $analyzedResults | Export-Clixml -Path $Script:OutXmlFullPath -Encoding UTF8 -Depth 6 -ErrorAction SilentlyContinue
+            $analyzedResults | Export-Clixml -Path $Script:OutXmlFullPath -Encoding UTF8 -Depth 2 -ErrorAction SilentlyContinue
         } catch {
             Write-Verbose "Failed to Export-Clixml. Converting HealthCheckerExchangeServer to json"
             $jsonHealthChecker = $analyzedResults.HealthCheckerExchangeServer | ConvertTo-Json
@@ -137,7 +137,7 @@ function Get-HealthCheckerData {
                 DisplayResults              = $analyzedResults.DisplayResults
             }
 
-            $testOutputXml | Export-Clixml -Path $Script:OutXmlFullPath -Encoding UTF8 -Depth 6 -ErrorAction Stop
+            $testOutputXml | Export-Clixml -Path $Script:OutXmlFullPath -Encoding UTF8 -Depth 2 -ErrorAction Stop
         } finally {
             Invoke-ErrorCatchActionLoopFromIndex $currentErrors
 

--- a/Shared/IISFunctions/Get-ApplicationHostConfig.ps1
+++ b/Shared/IISFunctions/Get-ApplicationHostConfig.ps1
@@ -14,7 +14,7 @@ function Get-ApplicationHostConfig {
     $params = @{
         ComputerName           = $ComputerName
         ScriptBlockDescription = "Getting applicationHost.config"
-        ScriptBlock            = { Get-Content "$($env:WINDIR)\System32\inetSrv\config\applicationHost.config" }
+        ScriptBlock            = { Get-Content "$($env:WINDIR)\System32\inetSrv\config\applicationHost.config" -Raw }
         CatchActionFunction    = $CatchActionFunction
     }
 


### PR DESCRIPTION
**Reason:**
During a discussion of one of the issues, it was brought up about the xml size of Health Checker. After digging into this, it was determined the cause to be likely related to the class being removed and how the `depth` was handling the objects now.

**Fix:**
Ended up reverting the `Export-Clixml -Depth` value down to 2 instead of 6. Also, when running `Get-Content` now including the `-Raw` switch to avoid additional overhead in the export. 

**Validation:**
Lab tested. 

Originally was at about 124,000 KB and now it is at about 10,000 KB. Plus all the data appears to still be there. 
