### PR TITLE
Place Get-HotFix in try catch block

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -36,7 +36,14 @@ function Get-OperatingSystemInformation {
         $powerPlan = Get-PowerPlanSetting -Server $Server
         $pageFile = Get-PageFileInformation -Server $Server
         $networkInformation = Get-NetworkingInformation -Server $Server
-        $hotFixes = (Get-HotFix -ComputerName $Server -ErrorAction SilentlyContinue) #old school check still valid and faster and a failsafe
+
+        try {
+            $hotFixes = (Get-HotFix -ComputerName $Server -ErrorAction Stop) #old school check still valid and faster and a failsafe
+        } catch {
+            Write-Verbose "Failed to run Get-HotFix"
+            Invoke-CatchActions
+        }
+
         $serverPendingReboot = (Get-ServerRebootPending -ServerName $Server -CatchActionFunction ${Function:Invoke-CatchActions})
         $timeZoneInformation = Get-TimeZoneInformation -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $tlsSettings = Get-AllTlsSettings -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}


### PR DESCRIPTION
**Issue:**
Customer was reporting the following error

```
Errors that occurred that wasn't handled
Error Index: 0
Get-HotFix : Call cancelled 
Inner Exception:    at System.Management.ManagementException.ThrowWithExtendedInfo(ManagementStatus errorCode)
   at System.Management.ManagementObjectCollection.ManagementObjectEnumerator.MoveNext()
   at Microsoft.PowerShell.Commands.GetHotFixCommand.BeginProcessing()
   at System.Management.Automation.Cmdlet.DoBeginProcessing()
   at System.Management.Automation.CommandProcessorBase.DoBegin()
Position Message: At C:\HealthChecker.ps1:12367 char:22
+ ... hotFixes = (Get-HotFix -ComputerName $Server -ErrorAction SilentlyCon ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Get-OperatingSystemInformation<Process>, C:\HealthChecker.ps1: line 12367
at Get-HealthCheckerExchangeServer<Process>, C:\HealthChecker.ps1: line 12407
at Get-HealthCheckerData, C:\HealthChecker.ps1: line 13142
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 13218
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 13951
at <ScriptBlock>, <No file>: line 1
-----------------------------------

```

**Fix:**
Place `Get-HotFix` inside of `try` `catch` block

**Validation:**
Pending customer confirmation. 

