### PR TITLE
BinSearchFolder false-positive caused by PR 1495

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -198,9 +198,10 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
         $binSearchFoldersNotFound = $iisConfigurationSettings |
             Where-Object { $_.Location -like "*\ClientAccess\ecp\web.config" -and $_.Exist -eq $true } |
             Where-Object {
-                $binSearchFolders = $_.Content | Select-String "BinSearchFolders" | Select-Object -ExpandProperty Line
-                $startIndex = $binSearchFolders.IndexOf("value=`"") + 7
-                $paths = $binSearchFolders.Substring($startIndex, $binSearchFolders.LastIndexOf("`"") - $startIndex).Split(";").Trim().ToLower()
+                $binSearchFolders = (([xml]($_.Content)).configuration.appSettings.add | Where-Object {
+                        $_.key -eq "BinSearchFolders"
+                    }).value
+                $paths = $binSearchFolders.Split(";").Trim().ToLower()
                 $paths | ForEach-Object { Write-Verbose "BinSearchFolder: $($_)" }
                 $installPath = $exchangeInformation.RegistryValues.MsiInstallPath
                 foreach ($binTestPath in  @("bin", "bin\CmdletExtensionAgents", "ClientAccess\Owa\bin")) {

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -202,7 +202,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 $startIndex = $binSearchFolders.IndexOf("value=`"") + 7
                 $paths = $binSearchFolders.Substring($startIndex, $binSearchFolders.LastIndexOf("`"") - $startIndex).Split(";").Trim().ToLower()
                 $paths | ForEach-Object { Write-Verbose "BinSearchFolder: $($_)" }
-                $installPath = $exchangeInformation.RegistryValues.MisInstallPath
+                $installPath = $exchangeInformation.RegistryValues.MsiInstallPath
                 foreach ($binTestPath in  @("bin", "bin\CmdletExtensionAgents", "ClientAccess\Owa\bin")) {
                     $testPath = [System.IO.Path]::Combine($installPath, $binTestPath).ToLower()
                     Write-Verbose "Testing path: $testPath"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -87,7 +87,7 @@ function Get-ExchangeInformation {
         }
 
         $registryValues = Get-ExchangeRegistryValues -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
-        $serverExchangeBinDirectory = [System.Io.Path]::Combine($registryValues.MisInstallPath, "Bin\")
+        $serverExchangeBinDirectory = [System.Io.Path]::Combine($registryValues.MsiInstallPath, "Bin\")
         Write-Verbose "Found Exchange Bin: $serverExchangeBinDirectory"
 
         if ($getExchangeServer.IsEdgeServer -eq $false) {

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeRegistryValues.ps1
@@ -51,6 +51,6 @@ function Get-ExchangeRegistryValues {
         DisableGranularReplication     = [int](Get-RemoteRegistryValue @blockReplParams)
         DisableAsyncNotification       = [int](Get-RemoteRegistryValue @disableAsyncParams)
         SerializedDataSigning          = [int](Get-RemoteRegistryValue @serializedDataSigningParams)
-        MisInstallPath                 = [string](Get-RemoteRegistryValue @installDirectoryParams)
+        MsiInstallPath                 = [string](Get-RemoteRegistryValue @installDirectoryParams)
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
@@ -10,6 +10,7 @@ function Get-IISWebApplication {
             $linkedConfigurationLine = $null
             $webConfigContent = $null
             $linkedConfigurationFilePath = $null
+            $validWebConfig = $false # able to convert the file to xml type
             $siteName = $webApplication.ItemXPath | Select-String -Pattern "site\[\@name='(.+)'\s|\]"
             $friendlyName = "$($siteName.Matches.Groups[1].Value)$($webApplication.Path)"
             $configurationFilePath = (Get-WebConfigFile "IIS:\Sites\$friendlyName").FullName
@@ -17,10 +18,15 @@ function Get-IISWebApplication {
 
             if ($webConfigExists) {
                 $webConfigContent = Get-Content $configurationFilePath -Raw
-                $linkedConfigurationLine = ($webConfigContent | Select-String "linkedConfiguration").Line
 
-                if ($null -ne $linkedConfigurationLine) {
-                    $linkedConfigurationFilePath = ($linkedConfigurationLine | Select-String "file://(.+)\`"").Matches.Groups[1].Value
+                try {
+                    $linkedConfigurationLine = ([xml]$webConfigContent).configuration.assemblyBinding.linkedConfiguration.href
+                    $validWebConfig = $true
+                    if ($null -ne $linkedConfigurationLine) {
+                        $linkedConfigurationFilePath = $linkedConfigurationLine.Substring("file://".Length)
+                    }
+                } catch {
+                    Write-Verbose "Failed to convert '$configurationFilePath' to xml. Exception: $($_.Exception)"
                 }
             }
         } catch {
@@ -32,6 +38,7 @@ function Get-IISWebApplication {
                 FriendlyName               = $friendlyName
                 Path                       = $webApplication.Path
                 ConfigurationFileInfo      = ([PSCustomObject]@{
+                        Valid                       = $validWebConfig
                         Location                    = $configurationFilePath
                         Content                     = $webConfigContent
                         Exist                       = $webConfigExists

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -25,9 +25,18 @@ function Get-IISWebSite {
         $configurationFilePath = (Get-WebConfigFile "IIS:\Sites\$($site.Name)").FullName
         $webConfigExists = Test-Path $configurationFilePath
         $webConfigContent = $null
+        $validWebConfig = $false
 
         if ($webConfigExists) {
             $webConfigContent = Get-Content $configurationFilePath -Raw
+
+            try {
+                [xml]$webConfigContent | Out-Null
+                $validWebConfig = $true
+            } catch {
+                # Inside of Invoke-Command, can't use Invoke-CatchActions
+                Write-Verbose "Failed to convert IIS web config '$configurationFilePath' to xml. Exception: $($_.Exception)"
+            }
         }
 
         $returnList.Add([PSCustomObject]@{
@@ -49,6 +58,7 @@ function Get-IISWebSite {
                     Location = $configurationFilePath
                     Content  = $webConfigContent
                     Exist    = $webConfigExists
+                    Valid    = $validWebConfig
                 }
             }
         )


### PR DESCRIPTION
**Issue:**
`BinSearchFolder` is reported as missing. However, it's there and not missing so it's a false-positive.

**Reason:**
Due to the work to reduce the size of the exported file, we added the `Raw` parameter at some places. By using the `Raw` parameter, the contents of a file (web.config in this case) is returned as one string, instead of an array of strings. As a result, it broke our logic in `Invoke-AnalyzerFrequentConfigurationIssues` and caused the false-positive
PR #1495

**Fix:**
Changed the logic in `Invoke-AnalyzerFrequentConfigurationIssues` to handle this properly by converting the content to `xml` and searching for the `BinSearchFolders` key.

Resolved #1506

**Validation:**
Lab

