### PR TITLE
Confirm-ExchangeShell function improved to work on management server with SerializedDataSigning turned on

### DIFF
--- a/Shared/Confirm-ExchangeManagementShell.ps1
+++ b/Shared/Confirm-ExchangeManagementShell.ps1
@@ -12,7 +12,9 @@ function Confirm-ExchangeManagementShell {
     }
 
     $level = Get-EventLogLevel | Select-Object -First 1
-    if ($level.GetType().Name -eq "EventCategoryObject") {
+    if (($level.GetType().Name -eq "EventCategoryObject") -or
+        (($level.GetType().Name -eq "PSObject") -and
+            ($null -ne $level.SerializationData))) {
         return $true
     }
 


### PR DESCRIPTION
**Issue:**
It was reported that `Confirm-ExchangeShell` doesn't work well in specific scenarios. After some research we were able to pin it down to the Serialized Data Signing feature which causes this behavior if turned on and if the script was executed on a management server (no Exchange roles installed).

Resolve #1507 

**Reason:**
The type will change to `PSObject` if Serialized Data Signing was enabled and EMS on a management server is used.
We have an internal work item regarding this behavior as several customers reported it. 

**Fix:**
Check for the `SerializationData` property if `GetType().Name` property is not `EventCategoryObject`. The `SerializationData` property is available in EMS, it is not available if Exchange servers was connected by using remote PowerShell.

![image](https://user-images.githubusercontent.com/40993616/220091479-86d47ae1-e67f-4f58-b39b-3fc6b40f7ff1.png)

**Validation:**
Lab

