### PR TITLE
Avoid errors in case that the MP is not available

### DIFF
--- a/Setup/SetExchAVExclusions/Set-ExchAVExclusions.ps1
+++ b/Setup/SetExchAVExclusions/Set-ExchAVExclusions.ps1
@@ -105,9 +105,16 @@ if (-not $ListRecommendedExclusions) {
         exit
     }
 
-    if (-not (Get-MpComputerStatus).AntivirusEnabled ) {
-        Write-Warning "Microsoft Defender is not enabled."
-        Write-Warning "We will apply the exclusions but they do not take effect until you Enabled Microsoft Defender."
+    $mpStatus = $null
+    $mpStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
+    if ($null -eq $mpStatus) {
+        Write-Error "We cannot get Microsoft Defender information"
+        exit
+    } else {
+        if (-not $mpStatus.AntivirusEnabled ) {
+            Write-Warning "Microsoft Defender is not enabled."
+            Write-Warning "We will apply the exclusions but they do not take effect until you Enabled Microsoft Defender."
+        }
     }
 }
 


### PR DESCRIPTION
**Issue:**
If the server has a 3rd party antivirus the Get-MpComputerStatus cmdlet could fail and shows and error in the execution

**Reason:**
Avoid the error in the execution

**Fix:**
Verify if the cmdlet get the information

**Validation:**
Test in lab

