### PR TITLE
Minor adjustments to Confirm-ExchangeShell and SerializedDataSigning

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySerializedDataSigningState.ps1
@@ -104,6 +104,7 @@ function Invoke-AnalyzerSecuritySerializedDataSigningState {
             if ($serializedDataSigningInformation -eq 1) {
                 Write-Verbose "SerializedDataSigning enabled via Registry Value"
                 $serializedDataSigningState = $true
+                $serializedDataSigningWriteType = "Green"
             } else {
                 Write-Verbose "SerializedDataSigning not configured or explicitly disabled via Registry Value"
                 $serializedDataSigningState = $false

--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -60,9 +60,7 @@ function Confirm-ExchangeShell {
         }
     }
     process {
-        $currentErrors = $Error.Count
         $isEMS = IsExchangeManagementSession $CatchActionFunction
-        Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
         if ($isEMS.CallWasSuccessful) {
             Write-Verbose "Exchange PowerShell Module already loaded."
         } else {
@@ -75,10 +73,10 @@ function Confirm-ExchangeShell {
             }
 
             if (Test-Path "$setupKey") {
-                $currentErrors = $Error.Count
                 Write-Verbose "We are on Exchange 2013 or newer"
 
                 try {
+                    $currentErrors = $Error.Count
                     if (Test-Path $edgeTransportKey) {
                         Write-Verbose "We are on Exchange Edge Transport Server"
                         [xml]$PSSnapIns = Get-Content -Path "$env:ExchangeInstallPath\Bin\exShell.psc1" -ErrorAction Stop
@@ -93,10 +91,10 @@ function Confirm-ExchangeShell {
                         Import-Module $env:ExchangeInstallPath\bin\RemoteExchange.ps1 -ErrorAction Stop
                         Connect-ExchangeServer -Auto -ClientApplication:ManagementShell
                     }
+                    Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
 
                     Write-Verbose "Imported Module. Trying Get-EventLogLevel Again"
                     $isEMS = IsExchangeManagementSession $CatchActionFunction
-                    Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
                     if (($isEMS.CallWasSuccessful) -and
                         ($isEMS.IsManagementShell)) {
                         Write-Verbose "Successfully loaded Exchange Management Shell"
@@ -114,7 +112,6 @@ function Confirm-ExchangeShell {
     }
     end {
 
-        $currentErrors = $Error.Count
         $returnObject = [PSCustomObject]@{
             ShellLoaded = $isEMS.CallWasSuccessful
             Major       = ((Get-ItemProperty -Path $setupKey -Name "MsiProductMajor" -ErrorAction SilentlyContinue).MsiProductMajor)
@@ -126,8 +123,6 @@ function Confirm-ExchangeShell {
             RemoteShell = $isEMS.CallWasSuccessful -and $remoteShell
             EMS         = $isEMS.IsManagementShell
         }
-
-        Invoke-CatchActionErrorLoop $currentErrors $CatchActionFunction
 
         return $returnObject
     }


### PR DESCRIPTION
**Issue:**
If the script was run in powershell.exe, the first time during `Confirm-ExchangeShell` run, the error handling didn't work as expected. Also, serialized data signing enabled was displayed in yellow instead of green, when the feature was enabled via registry on Exchange Server 2013.

**Reason:**
Error handling was moved inside `IsExchangeManagementSession` and existing error handling logic wasn't adjusted properly. This caused the F/P.

**Fix:**
Removed outdated error handling logic in `Confirm-ExchangeShell`.

**Validation:**
Lab

