### PR TITLE
Only block pipeline for ps1 files with ValidateMerge.ps1

### DIFF
--- a/.build/ValidateMerge.ps1
+++ b/.build/ValidateMerge.ps1
@@ -114,6 +114,12 @@ foreach ($commitMatch in $m) {
     }
 
     foreach ($affectedFile in $allAffectedFiles) {
+        # Only care about .ps1 files for versioning
+        if (-not ($affectedFile.EndsWith(".ps1"))) {
+            Write-Host "Skipping non ps1 file: $affectedFile"
+            continue
+        }
+
         $commitTimeOnMainString = git log origin/$Branch -n 1 --format="%cd" --date=rfc -- $affectedFile
         $commitTimeOnMain = $null
         if (-not [string]::IsNullOrEmpty($commitTimeOnMainString)) {


### PR DESCRIPTION
**Issue:**
Pipeline failure for versioning on files that don't matter: 

![image](https://user-images.githubusercontent.com/22776718/222151425-c13072fe-85d8-4ef1-bc02-3e064a168e2b.png)


**Reason:**
Don't want to have to force engineers to rebase and update for failed pipelines due to `ValidateMerge.ps1` on files like `mkdocs.yml` & `cspell-words.txt`

**Fix:**
Skip over those files.

**Validation:**
Ran against PR that is currently failing. 

