### PR TITLE
Do not write performance counter information to debug log

### DIFF
--- a/Shared/Get-RemoteRegistryValue.ps1
+++ b/Shared/Get-RemoteRegistryValue.ps1
@@ -67,7 +67,11 @@ function Get-RemoteRegistryValue {
         }
     }
     end {
-        Write-Verbose "Get-RemoteRegistryValue Return Value: '$registryGetValue'"
+        if ($registryGetValue.Length -le 100) {
+            Write-Verbose "$($MyInvocation.MyCommand) Return Value: '$registryGetValue'"
+        } else {
+            Write-Verbose "$($MyInvocation.MyCommand) Return Value is too long to log"
+        }
         return $registryGetValue
     }
 }


### PR DESCRIPTION
**Description:**
HealthChecker logs all performance counter information to the debug log. This blows the debug log file up to 3-4 MB. 
With this change we exclude registry information from being logged if the value length is > 100.
This probably only applies to the performance counter information. The new debug log file size is ~ 400 kb.