### PR TITLE
Fix issue when Get-OrganizationConfig fails to get data

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOrganizationInformation.ps1
@@ -37,8 +37,8 @@ function Invoke-AnalyzerOrganizationInformation {
     }
     Add-AnalyzedResultInformation @params
 
-    if ($organizationInformation.EnableDownloadDomains.ToString() -eq "Unknown" -and
-        $null -ne $organizationInformation.GetOrganizationConfig) {
+    if ($null -ne $organizationInformation.GetOrganizationConfig -and
+        $organizationInformation.EnableDownloadDomains.ToString() -eq "Unknown") {
         $params = $baseParams + @{
             Details                = "This is 'Unknown' because EMS is connected to an Exchange Version that doesn't know about Enable Download Domains in Get-OrganizationConfig"
             DisplayCustomTabNumber = 2

--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
@@ -20,7 +20,7 @@ function Get-OrganizationInformation {
         $wellKnownSecurityGroups = $null
         $adSchemaInformation = $null
         $getHybridConfiguration = $null
-        $enableDownloadDomains = $null
+        $enableDownloadDomains = "Unknown" # Set to unknown by default.
         $getAcceptedDomain = $null
         $mapiHttpEnabled = $false
         $securityResults = $null
@@ -45,7 +45,6 @@ function Get-OrganizationInformation {
                 $enableDownloadDomains = $organizationConfig.EnableDownloadDomains
             } else {
                 Write-Verbose "No EnableDownloadDomains detected on Get-OrganizationConfig"
-                $enableDownloadDomains = "Unknown"
             }
         } else {
             Write-Verbose "MAPI HTTP Enabled and Download Domains Enabled results not accurate"


### PR DESCRIPTION
**Issue:**
Customer reported the following issue:

```
Error Index: 0
 : You cannot call a method on a null-valued expression.
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.PSScriptCmdlet.DoEndProcessing()
   at System.Management.Automation.CommandProcessorBase.Complete()
Position Message: At C:\HealthChecker.ps1:4289 char:9
+     if ($organizationInformation.EnableDownloadDomains.ToString() -eq ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Invoke-AnalyzerOrganizationInformation, C:\HealthChecker.ps1: line 4289
at Invoke-AnalyzerEngine, C:\HealthChecker.ps1: line 6804
at Get-HealthCheckerData, C:\HealthChecker.ps1: line 13212
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 13283
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 14016
at <ScriptBlock>, <No file>: line 1
-----------------------------------
```

**Reason:**
Not doing a proper `if` statement order check. `$null` check needs to occur first before trying to do a method of `ToString()`

**Fix:**
Default set `EnableDownloadDomains` to be `Unknown` and have the correct order in the if statement. 

**Validation:**
Pester tested, pending customer feedback