### PR TITLE
Log type and basetype to simplify troubleshooting

### DIFF
--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -42,6 +42,7 @@ function Confirm-ExchangeShell {
                 $eventLogLevel = Get-EventLogLevel -ErrorAction Stop | Select-Object -First 1
                 $getEventLogLevelCallSuccessful = $true
                 foreach ($e in $eventLogLevel) {
+                    Write-Verbose "Type is: $($e.GetType().Name) BaseType is: $($e.GetType().BaseType)"
                     if (($e.GetType().Name -eq "EventCategoryObject") -or
                         (($e.GetType().Name -eq "PSObject") -and
                             ($null -ne $e.SerializationData))) {


### PR DESCRIPTION
**Issue:**
Issue #1507
`Confirm-ExchangeShell` still fails in `SerializedDataSigning` enabled scenarios. Write out object type information for troubleshooting.


