### PR TITLE
Fix Log Collector to make sure 10GB free space on the drive

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -165,6 +165,8 @@ function Main {
     Test-NoSwitchesProvided
 
     Write-Host "Exchange Log Collector v$($BuildVersion)"
+    # Used throughout the script for checking for free space available.
+    $Script:StandardFreeSpaceInGBCheckSize = 10
 
     if ( $PSCmdlet.ParameterSetName -eq "LogPeriod" -and ( $LogAge.CompareTo($LogEndAge) -ne 1 ) ) {
         Write-Host "LogStartDate time should smaller than LogEndDate time." -ForegroundColor "Yellow"


### PR DESCRIPTION
**Issue:**
See issue #1537 

Caused by commit 88e04a48bb75366c8283845c03d4339888c15d46

**Reason:**
Must check for free space, otherwise you can fill up your drive. 

**Fix:**
Define the value for `$Script:StandardFreeSpaceInGBCheckSize` once again. 

**Validation:**
Lab tested

Resolved #1537 

