### PR TITLE
Don't add files to list that don't exist any longer

### DIFF
--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -48,6 +48,13 @@ if ($optimizeCodeFormatter) {
 
         foreach ($fileChanged in $filesChangedInCommit) {
             $fullPath = Join-Path $repoRoot $fileChanged
+
+            if (-not (Test-Path $fullPath)) {
+                # not typical scenario, but want to have the pipeline continue
+                Write-Verbose "File no longer exists, skip file: $fullPath"
+                continue
+            }
+
             Write-Verbose "Adding commit file to list: $fullPath"
             [void]$filesFullPath.Add($fullPath)
         }


### PR DESCRIPTION
**Issue:**
File was renamed in a PR, causing this script to fail. 

**Reason:**
Want to have the pipeline be optimized, but still review the true data in the PR.

**Fix:**
Skip over files that don't exist any longer in the PR.

**Validation:**
Test out on broken branch. 

