### PR TITLE
Use Get-CimInstance instead of Get-WmiObject

### DIFF
--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-FreeSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-FreeSpace.ps1
@@ -11,7 +11,7 @@ function Get-FreeSpace {
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     Write-Verbose "Passed: [string]FilePath: $FilePath"
 
-    $drivesList = Get-WmiObject Win32_Volume -Filter "DriveType = 3"
+    $drivesList = Get-CimInstance Win32_Volume -Filter "DriveType = 3"
     $testPath = $FilePath
     $freeSpaceSize = -1
     while ($true) {


### PR DESCRIPTION
The only thing preventing ExchangeLogCollector from working in PowerShell 6+ is that we're using the deprecated Get-WmiObject instead of the new Get-CimInstance:

https://stackoverflow.com/questions/54495023/what-library-for-powershell-6-contains-the-get-wmiobject-command

This one-line code change makes ExchangeLogCollector work fine in PowerShell Core, _as long as you already connected to Exchange_. Confirm-ExchangeShell does not create a working session if one is not already present, but that's a separate issue.

![image](https://user-images.githubusercontent.com/4518572/223300395-57d782d5-d42e-4e0b-913f-da4bb48ac271.png)
