### PR TITLE
Docs check file parsing improvement

### DIFF
--- a/.build/Docs.ps1
+++ b/.build/Docs.ps1
@@ -3,16 +3,12 @@
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
 $docsDir = "$repoRoot\docs"
-$markDownFiles = Get-Content "$repoRoot\mkdocs.yml" |
-    Where-Object { $_ -like "*.md" } |
-    ForEach-Object {
-        if ($_.Contains(":")) {
-            $_.Split(":")[1].Trim()
-        } else {
-            $_.Replace("-", "").Trim()
-        }
-    }
+$markDownFiles = Get-Content "$repoRoot\mkdocs.yml" | Select-String "(\S+\.md)" | ForEach-Object {
+    $_.Matches.Groups[1].Value
+}
+
 $allDocs = Get-ChildItem $docsDir -Recurse -File | Where-Object { $_.Extension -eq ".md" }
+
 Write-Host "Checking to make sure all the docs are in the mkdocs.yml file."
 
 foreach ($doc in $allDocs) {


### PR DESCRIPTION
This happens to valid files with dashes in the name:

![image](https://user-images.githubusercontent.com/4518572/225367091-e1733c9b-2c3e-492f-8b93-d9a04a917e33.png)
