### PR TITLE
NuGet url changed to download net40 version

### DIFF
--- a/docs/Security/CVE-2023-23397.md
+++ b/docs/Security/CVE-2023-23397.md
@@ -33,7 +33,7 @@ To run this script in an Exchange Online environment, you need to be a member of
 Note: The script uses Microsoft.Exchange.WebServices.dll to make EWS calls. The script will try to download the DLL and use it. However, if it is unable to, you will need to download the DLL and specify the path.
 
 #### Steps to Download Microsoft.Exchange.WebServices.dll:
--  Download the nuget package from [NuGet Gallery | Exchange.WebServices.Managed.Api 2.2.1.2](https://www.nuget.org/api/v2/package/Exchange.WebServices.Managed.Api/2.2.1.2)
+-  Download the nuget package from [NuGet Gallery | Microsoft.Exchange.WebServices.2.2.0](https://api.nuget.org/v3-flatcontainer/microsoft.exchange.webservices/2.2.0/microsoft.exchange.webservices.2.2.0.nupkg)
 -  Change the extension of the file from .nupkg to .zip
 -  Unzip the package.
 -  Use the dll present at “\lib\net35” location in the package


### PR DESCRIPTION
**Issue:**
The download uri in CVE-2023-23397 pointed to the `Microsoft.Exchange.WebServices.dll` .Net 3.5 version. Changed it to the .Net 4.0 which is the same one that we download if the computer on which the script runs has internet connectivity.
