### PR TITLE
Remove mailbox requirement for impersonation user

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -287,6 +287,14 @@ begin {
         } catch [Microsoft.Exchange.WebServices.Data.ServiceRequestException] {
             Write-Host "Unable to connect to EWS endpoint. Please make sure you have enter valid credentials. Inner Exception`n`n$_" -ForegroundColor Red
             exit
+        } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+            if ($_.Exception.ErrorCode -eq "ErrorNonExistentMailbox") {
+                # This is fine. This means this account is not mail-enabled, but creds worked.
+                return
+            } else {
+                Write-Host "Could not open mailbox. Inner Exception`n`n$_" -ForegroundColor Red
+                exit
+            }
         } catch {
             Write-Host "Could not open mailbox. Inner Exception`n`n$_" -ForegroundColor Red
             exit

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -624,7 +624,7 @@ begin {
     Write-Host ("CVE-2023-23397 script version $($BuildVersion)") -ForegroundColor Green
 
     if ($ScriptUpdateOnly) {
-        switch (Test-ScriptVersion -AutoUpdate -Confirm:$false) {
+        switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/CVE-2023-23397-VersionsUrl" -Confirm:$false) {
             ($true) { Write-Host ("Script was successfully updated") -ForegroundColor Green }
             ($false) { Write-Host ("No update of the script performed") -ForegroundColor Yellow }
             default { Write-Host ("Unable to perform ScriptUpdateOnly operation") -ForegroundColor Red }

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -291,6 +291,10 @@ begin {
             if ($_.Exception.ErrorCode -eq "ErrorNonExistentMailbox") {
                 # This is fine. This means this account is not mail-enabled, but credentials worked.
                 return
+            } elseif ($_.Exception.ErrorCode -eq "ErrorMissingEmailAddress") {
+                # On Exchange 2013, even if we handle this error, it doesn't work.
+                Write-Host "Could not open mailbox due to ErrorMissingEmailAddress. If running on Exchange 2013, the impersonation user must have a mailbox on prem."
+                exit
             } else {
                 Write-Host "Could not open mailbox. Inner Exception`n`n$_" -ForegroundColor Red
                 exit

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -293,7 +293,7 @@ begin {
                 return
             } elseif ($_.Exception.ErrorCode -eq "ErrorMissingEmailAddress") {
                 # On Exchange 2013, even if we handle this error, it doesn't work.
-                Write-Host "Could not open mailbox due to ErrorMissingEmailAddress. If running on Exchange 2013, the impersonation user must have a mailbox on prem."
+                Write-Host "Could not open mailbox due to ErrorMissingEmailAddress. If running on Exchange 2013, the impersonation user must have a mailbox on prem. Inner Exception`n`n$_" -ForegroundColor Red
                 exit
             } else {
                 Write-Host "Could not open mailbox. Inner Exception`n`n$_" -ForegroundColor Red

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -289,7 +289,7 @@ begin {
             exit
         } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
             if ($_.Exception.ErrorCode -eq "ErrorNonExistentMailbox") {
-                # This is fine. This means this account is not mail-enabled, but creds worked.
+                # This is fine. This means this account is not mail-enabled, but credentials worked.
                 return
             } else {
                 Write-Host "Could not open mailbox. Inner Exception`n`n$_" -ForegroundColor Red

--- a/docs/Security/CVE-2023-23397/FAQ.md
+++ b/docs/Security/CVE-2023-23397/FAQ.md
@@ -54,4 +54,5 @@ work for your UPN, or if domain\user is being specified, then Autodiscover can b
 
 ## In OnPrem, does the impersonation account need to have a mailbox?
 
-The latest version of the script no longer requires the impersonation account to have a mailbox.
+The latest version of the script no longer requires the impersonation account to have a mailbox if running on Exchange 2016 or later.
+Exchange 2013 still requires that the impersonation user have a mailbox on prem.

--- a/docs/Security/CVE-2023-23397/FAQ.md
+++ b/docs/Security/CVE-2023-23397/FAQ.md
@@ -54,4 +54,4 @@ work for your UPN, or if domain\user is being specified, then Autodiscover can b
 
 ## In OnPrem, does the impersonation account need to have a mailbox?
 
-In the current version of the script, yes, the impersonation account must have a mailbox on prem.
+The latest version of the script no longer requires the impersonation account to have a mailbox.


### PR DESCRIPTION
Fixes #1573. Note Exchange 2013 still requires the impersonation user to have a mailbox.