### PR TITLE
Missing credentials for connect-AzureAD

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -416,7 +416,7 @@ begin {
             if ($null -ne (Get-InstalledModule -Name "AzureAD" -ErrorAction SilentlyContinue)) {
                 Import-Module "AzureAD" -ErrorAction Stop
                 Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
-                Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
+                Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName  -Credential $credential  -ErrorAction Stop
             } else {
                 throw "AzureAD module was not found on this computer. You can install it by running Install-Module AzureAD"
             }


### PR DESCRIPTION
There was a parameter for credentials on the main .PS1, but that was not used with Connect-AzureAD

**Issue:**
Even when you are using -credential, that still prompting the credential box for user. And because of that this cannot be used as a job.

**Reason:**
Error correction

**Fix:**
Even when you are using -credential, that still prompting the credential box for user. And because of that this cannot be used as a job.

**Validation:**
n/a

