### PR TITLE
Improve AzureAD module check by getting rid of Get-InstalledModule call

### DIFF
--- a/.build/cspell-words.txt
+++ b/.build/cspell-words.txt
@@ -149,3 +149,4 @@ vuln
 wbxml
 Webex
 Weve
+windir

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -418,7 +418,7 @@ begin {
             Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
         } catch [System.IO.FileNotFoundException] {
             Write-Host "The AzureAD module was not found on this computer. Please install it by running: Install-Module -Name `"AzureAD`"" -ForegroundColor Red
-            Write-Host "AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSversiontable.PSVersion)" -ForegroundColor Red
+            Write-Host "AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSVersionTable.PSVersion)" -ForegroundColor Red
             exit
         } catch {
             Write-Host "Unable to connect to Azure AD. Inner Exception`n`n$_" -ForegroundColor Red

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -405,6 +405,27 @@ begin {
         return $Token
     }
 
+    function ConnectAzureAD {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory=$true)]
+            [string]$AzureEnvironmentName
+        )
+
+        try {
+            Import-Module "AzureAD" -ErrorAction Stop
+            Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
+            Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
+        } catch [System.IO.FileNotFoundException] {
+            Write-Host "The AzureAD module was not found on this computer. Please install it by running: Install-Module -Name `"AzureAD`"" -ForegroundColor Red
+            Write-Host "The AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSversiontable.PSVersion)" -ForegroundColor Red
+            exit
+        } catch {
+            Write-Host "Unable to connect to Azure AD. Inner Exception`n`n$_" -ForegroundColor Red
+            exit
+        }
+    }
+
     ## function that create an App secret to for a given application and return it
     function GetApplicationDetails {
         param (
@@ -412,18 +433,7 @@ begin {
             $AzureEnvironmentName
         )
 
-        try {
-            if ($null -ne (Get-InstalledModule -Name "AzureAD" -ErrorAction SilentlyContinue)) {
-                Import-Module "AzureAD" -ErrorAction Stop
-                Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
-                Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
-            } else {
-                throw "AzureAD module was not found on this computer. You can install it by running Install-Module AzureAD"
-            }
-        } catch {
-            Write-Host "Unable to connect to Azure AD... Make sure you have AzureAD module installed. Inner Exception`n`n$_" -ForegroundColor Red
-            exit
-        }
+        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
 
         try {
             $aadApplication = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
@@ -458,18 +468,7 @@ begin {
             $AzureApplicationName
         )
 
-        try {
-            if ($null -ne (Get-InstalledModule -Name "AzureAD" -ErrorAction SilentlyContinue)) {
-                Import-Module "AzureAD" -ErrorAction Stop
-                Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
-                Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
-            } else {
-                throw "AzureAD module was not found on this computer. You can install it by running Install-Module AzureAD"
-            }
-        } catch {
-            Write-Host "Unable to connect to Azure AD... Make sure you have AzureAD module installed. Inner Exception`n`n$_" -ForegroundColor Red
-            exit
-        }
+        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
 
         try {
             $app = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
@@ -500,18 +499,7 @@ begin {
             $AzureApplicationName
         )
 
-        try {
-            if ($null -ne (Get-InstalledModule -Name "AzureAD" -ErrorAction SilentlyContinue)) {
-                Import-Module "AzureAD" -ErrorAction Stop
-                Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
-                Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
-            } else {
-                throw "AzureAD module was not found on this computer. You can install it by running Install-Module AzureAD"
-            }
-        } catch {
-            Write-Host "Unable to connect to Azure AD... Make sure you have AzureAD module installed Inner Exception`n`n$_" -ForegroundColor Red
-            exit
-        }
+        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
 
         $aadApplication = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
 

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -418,7 +418,7 @@ begin {
             Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
         } catch [System.IO.FileNotFoundException] {
             Write-Host "The AzureAD module was not found on this computer. Please install it by running: Install-Module -Name `"AzureAD`"" -ForegroundColor Red
-            Write-Host "The AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSversiontable.PSVersion)" -ForegroundColor Red
+            Write-Host "AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSversiontable.PSVersion)" -ForegroundColor Red
             exit
         } catch {
             Write-Host "Unable to connect to Azure AD. Inner Exception`n`n$_" -ForegroundColor Red


### PR DESCRIPTION
**Description:**
The current approach doesn't work properly if the AzureAD module wasn't installed via PowerShellGet.

**Reason:**
`Get-InstalledModule` works only with modules that were installed by PowerShellGet.
https://learn.microsoft.com/powershell/module/powershellget/get-installedmodule?view=powershell-7.3

**Fix:**
Try to import the module and properly handle the `System.IO.FileNotFoundException` exception.

Resolve #1595 

**Validation:**
Lab
![image](https://user-images.githubusercontent.com/40993616/225930353-2e796ce2-b2fc-4b1c-9697-13fa0fc9e142.png)
