### PR TITLE
Use deep traversal search folder to improve performance

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -250,8 +250,6 @@ begin {
             $Service = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2016)
         }
 
-        $Service.Timeout = 900000 # 15 minutes
-
         if ($Environment -eq "Onprem") {
             $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials($credential.UserName, [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
         } else {

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -160,10 +160,10 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [switch]$SkipVersionCheck,
 
-    [Parameter(Mandatory=$false, ParameterSetName="CreateAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [switch]$IgnoreCertificateMismatch,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
@@ -172,8 +172,8 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [switch]$SearchFolderCleanup,
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [ValidateRange(1, 2147483)]
     [int]$TimeoutSeconds = 300
 )
@@ -429,7 +429,7 @@ begin {
     function ConnectAzureAD {
         [CmdletBinding()]
         param(
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory = $true)]
             [string]$AzureEnvironmentName
         )
 

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -75,88 +75,88 @@
 
 param(
     [ValidateSet("Online", "Onprem")]
-    [Parameter(Mandatory=$true, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$true, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $true, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $true, ParameterSetName = "Cleanup")]
     [String]$Environment,
 
-    [Parameter(Mandatory=$true, ParameterSetName="CreateAzureApplication")]
+    [Parameter(Mandatory = $true, ParameterSetName = "CreateAzureApplication")]
     [Switch]$CreateAzureApplication,
 
-    [Parameter(Mandatory=$true, ParameterSetName="DeleteAzureApplication")]
+    [Parameter(Mandatory = $true, ParameterSetName = "DeleteAzureApplication")]
     [Switch]$DeleteAzureApplication,
 
-    [Parameter(Mandatory=$true, ParameterSetName="Audit", ValueFromPipelineByPropertyName = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = "Audit", ValueFromPipelineByPropertyName = $true)]
     [Alias("PrimarySmtpAddress")]
     [String[]]$UserMailboxes,
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [DateTime]$StartTimeFilter,
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [DateTime]$EndTimeFilter,
 
     [ValidateSet("ClearProperty", "ClearItem")]
-    [Parameter(Mandatory=$true, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $true, ParameterSetName = "Cleanup")]
     [string]$CleanupAction,
 
     [ValidateScript({ Test-Path -Path $_ -PathType leaf })]
-    [Parameter(Mandatory=$true, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $true, ParameterSetName = "Cleanup")]
     [string]$CleanupInfoFilePath,
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [switch]$EWSExchange2013,
 
     [ValidateRange(1, [Int]::MaxValue)]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Int]$MaxCSVLength = 200000,
 
-    [Parameter(Mandatory=$false, ParameterSetName="CreateAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [String]$AzureEnvironmentName = "AzureCloud",
 
-    [Parameter(Mandatory=$false, ParameterSetName="CreateAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [String]$AzureApplicationName = "CVE-2023-23397Application",
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [Uri]$EWSOnlineURL = "https://outlook.office365.com/EWS/Exchange.asmx",
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [String]$EWSOnlineScope = "https://outlook.office365.com/.default",
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [Uri]$AzureADEndpoint = "https://login.microsoftonline.com/",
 
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [Uri]$EWSServerURL,
 
     [ValidateScript({ Test-Path $_ })]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [String]$DLLPath,
 
-    [Parameter(Mandatory=$true, ParameterSetName="ScriptUpdateOnly")]
+    [Parameter(Mandatory = $true, ParameterSetName = "ScriptUpdateOnly")]
     [switch]$ScriptUpdateOnly,
 
-    [Parameter(Mandatory=$false, ParameterSetName="CreateAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [switch]$SkipVersionCheck,
 
-    [Parameter(Mandatory=$false, ParameterSetName="CreateAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
-    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
-    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
     [switch]$IgnoreCertificateMismatch
 )
 
@@ -197,6 +197,7 @@ dynamicparam {
 
 begin {
     $BuildVersion = ""
+    $searchFolderName = "ReminderFileParameterItems"
     $credential = $PSBoundParameters['Credential']
 
     . $PSScriptRoot\WriteFunctions.ps1
@@ -238,6 +239,8 @@ begin {
         } else {
             $Service = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2016)
         }
+
+        $Service.Timeout = 900000 # 15 minutes
 
         if ($Environment -eq "Onprem") {
             $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials($credential.UserName, [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
@@ -378,7 +381,7 @@ begin {
         )
 
         try {
-            $body=@{
+            $body = @{
                 scope         = $Scope
                 client_id     = $ClientID
                 client_secret = $AppSecret
@@ -556,12 +559,12 @@ begin {
         $requiredResourcesAccess.Add($requiredAccess)
 
         #Set permissions in newly created Azure AD App
-        $appObjectId=$aadApplication.ObjectId
+        $appObjectId = $aadApplication.ObjectId
         Write-Host "`nSetting Azure AD Permissions"
         Set-AzureADApplication -ObjectId $appObjectId -RequiredResourceAccess $requiredResourcesAccess | Out-Null
 
         #Create Service Principal
-        $appId=$aadApplication.AppId
+        $appId = $aadApplication.AppId
         $servicePrincipal = New-AzureADServicePrincipal -AppId $appId -Tags @("WindowsAzureActiveDirectoryIntegratedApp")
 
         #Grant Admin Consent for App Permissions
@@ -605,6 +608,56 @@ begin {
             $token.Value = CreateOAUTHToken -TenantID $applicationInfo.TenantID -ClientID $applicationInfo.ClientID -AppSecret $applicationInfo.AppSecret -AzureADEndpoint $AzureADEndpoint -Scope $EWSOnlineScope
             $ewsService.Value = EWSAuth -Environment $Environment -token $token.Value -EWSOnlineURL $EWSOnlineURL
         }
+    }
+
+    ## function to get our named search folder
+    function GetSearchFolder {
+        param($ewsService, $userMailbox)
+
+        $searchFoldersId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::Root, $userMailbox)
+        $searchFoldersFolder = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($ewsService, $searchFoldersId)
+        $searchFoldersView = New-Object Microsoft.Exchange.WebServices.Data.FolderView(100)
+        $searchFoldersFilter = New-Object Microsoft.Exchange.WebServices.Data.SearchFilter+IsEqualTo([Microsoft.Exchange.WebServices.Data.FolderSchema]::DisplayName, $searchFolderName)
+        $results = $searchFoldersFolder.FindFolders($searchFoldersFilter, $searchFoldersView)
+        return $results
+    }
+
+    ## function to create our named search folder
+    function NewSearchFolder {
+        param($ewsService, $userMailbox)
+
+        $rootFolderId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot, $userMailbox)
+        $searchFoldersId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::Root, $userMailbox)
+
+        $mySearchFolder = New-Object Microsoft.Exchange.WebServices.Data.SearchFolder($ewsService)
+        $mySearchFolder.DisplayName = $searchFolderName
+        $mySearchFolder.SearchParameters.SearchFilter = $searchFilterCollection
+        $mySearchFolder.SearchParameters.RootFolderIds.Add($rootFolderId)
+        $mySearchFolder.SearchParameters.Traversal = [Microsoft.Exchange.WebServices.Data.SearchFolderTraversal]::Deep
+        [void]$mySearchFolder.Save($searchFoldersId)
+    }
+
+    function GetSearchFolderItemResults {
+        param($ewsService, $userMailbox)
+
+        $searchFolders = @(GetSearchFolder $ewsService $userMailbox)
+        if ($searchFolders.Count -lt 1) {
+            Write-Host "Search folder missing. Could not get results."
+            return
+        }
+
+        $offset = 0
+        $pageSize = 100
+        $findItemsResults = $null
+        do {
+            $itemView = New-Object Microsoft.Exchange.WebServices.Data.ItemView($pageSize, $offset);
+            $findItemsResults = $searchFolders[0].FindItems($itemView)
+            foreach ($item in $findItemsResults.Items) {
+                $item
+            }
+
+            $offset = $findItemsResults.NextPageOffset
+        } while ($findItemsResults.MoreAvailable)
     }
 
     $mailAddresses = New-Object System.Collections.ArrayList
@@ -752,7 +805,7 @@ begin {
         foreach ($mailAddress in $mailAddresses) {
             $ewsService.HttpHeaders.Clear()
             $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
-            Write-Host ("Scanning $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
+            Write-Host ("Creating search folders in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
 
             $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
 
@@ -768,13 +821,53 @@ begin {
                 CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
                 $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
-                $rootFolderId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot, $userMailbox)
-                $rootFolder = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($ewsService, $rootFolderId)
+                # Check if the search folder already exists
 
-                # Create a new ArrayList to hold the folder
-                $foldersList = New-Object System.Collections.ArrayList
+                $searchFolders = @(GetSearchFolder $ewsService $userMailbox)
+                if ($searchFolders.Count -gt 0) {
+                    Write-Host "  Search folder already exists in this mailbox."
+                    continue
+                }
 
-                GetSubFolders -folder $rootFolder -foldersList $foldersList
+                # Create a new search folder
+                NewSearchFolder $ewsService $userMailbox
+                $mailboxProcessed += 1
+            } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+                Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
+                Write-Host ("Inner Exception: $_") -ForegroundColor Red
+                $failedMailboxes.Add($mailAddress)
+                $mailboxProcessed += 1
+                continue
+            } catch {
+                Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
+                $failedMailboxes.Add($mailAddress)
+                $mailboxProcessed += 1
+                continue
+            }
+        }
+
+        $mailboxProcessed = 0
+
+        foreach ($mailAddress in $mailAddresses) {
+            if ($failedMailboxes.Contains($mailAddress)) {
+                continue
+            }
+
+            $ewsService.HttpHeaders.Clear()
+            $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
+            Write-Host ("Getting search results in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
+
+            $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
+
+            $itemResults = @()
+
+            try {
+                # Check for token expiry
+                CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
+
+                [Microsoft.Exchange.WebServices.Data.Item[]]$itemResults = @(GetSearchFolderItemResults $ewsService $userMailbox)
+                $mailboxProcessed += 1
             } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
                 Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
                 Write-Host ("Inner Exception: $_") -ForegroundColor Red
@@ -790,32 +883,22 @@ begin {
 
             $IdsProcessed = New-Object 'System.Collections.Generic.HashSet[string]'
 
-            foreach ($folder in $foldersList) {
-                try {
-                    # Check for token expiry
-                    CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
-                    $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
-                    $results = $ewsService.FindItems($folder.Id, $searchFilterCollection, $itemView)
-                    if ($null -ne $results -and $null -ne $results.Items -and $results.Items.Count -gt 0) {
-                        $items = $ewsService.LoadPropertiesForItems($results.Items, $PropertySet)
-                    } else {
-                        continue
-                    }
+            if ($itemResults.Count -lt 1) {
+                continue
+            }
 
-                    foreach ($item in $items) {
-                        if (-not $IdsProcessed.Contains($item.Item.Id)) {
-                            CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
-                            $rowCount ++
-                            if ($rowCount -ge $MaxCSVLength) {
-                                Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
-                                Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
-                                exit
-                            }
-                            [void]$IdsProcessed.Add($item.Item.Id)
-                        }
+            $items = $ewsService.LoadPropertiesForItems($itemResults, $PropertySet)
+
+            foreach ($item in $items) {
+                if (-not $IdsProcessed.Contains($item.Item.Id)) {
+                    CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
+                    $rowCount ++
+                    if ($rowCount -ge $MaxCSVLength) {
+                        Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
+                        Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
+                        exit
                     }
-                } catch {
-                    Write-Host "Error while scanning $($folder.DisplayName) of the mailbox $mailAddress. Inner Exception:`n`n$_" -ForegroundColor Red
+                    [void]$IdsProcessed.Add($item.Item.Id)
                 }
             }
 

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -61,6 +61,10 @@
     This optional parameter lets you ignore TLS certificate mismatch errors.
 .PARAMETER Credential
     This optional parameter lets you pass administrator credential object while running on Exchange Server on-premises.
+.PARAMETER UseSearchFolders
+    This switch causes the script to use deep-traversal search folders, significantly improving performance.
+.PARAMETER SearchFolderCleanup
+    Clean up any search folders left behind by the -UseSearchFolders switch.
 .EXAMPLE
     PS C:\> .\CVE-2023-23397.ps1 -CreateAzureApplication
     This will run the tool to create a new Azure application with required permissions
@@ -157,7 +161,13 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [switch]$IgnoreCertificateMismatch
+    [switch]$IgnoreCertificateMismatch,
+
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [switch]$UseSearchFolders,
+
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [switch]$SearchFolderCleanup
 )
 
 dynamicparam {
@@ -616,7 +626,7 @@ begin {
 
         $searchFoldersId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::Root, $userMailbox)
         $searchFoldersFolder = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($ewsService, $searchFoldersId)
-        $searchFoldersView = New-Object Microsoft.Exchange.WebServices.Data.FolderView(100)
+        $searchFoldersView = New-Object Microsoft.Exchange.WebServices.Data.FolderView(1)
         $searchFoldersFilter = New-Object Microsoft.Exchange.WebServices.Data.SearchFilter+IsEqualTo([Microsoft.Exchange.WebServices.Data.FolderSchema]::DisplayName, $searchFolderName)
         $results = $searchFoldersFolder.FindFolders($searchFoldersFilter, $searchFoldersView)
         return $results
@@ -635,6 +645,16 @@ begin {
         $mySearchFolder.SearchParameters.RootFolderIds.Add($rootFolderId)
         $mySearchFolder.SearchParameters.Traversal = [Microsoft.Exchange.WebServices.Data.SearchFolderTraversal]::Deep
         [void]$mySearchFolder.Save($searchFoldersId)
+    }
+
+    function RemoveSearchFolder {
+        param($ewsService, $userMailbox)
+
+        $searchFolders = @(GetSearchFolder $ewsService $userMailbox)
+        if ($searchFolders.Count -gt 0) {
+            Write-Host "  Cleaning up search folder."
+            [void]$searchFolders[0].Delete([Microsoft.Exchange.WebServices.Data.DeleteMode]::HardDelete)
+        }
     }
 
     function GetSearchFolderItemResults {
@@ -802,113 +822,221 @@ begin {
         $mailboxProcessed = 0
         $rowCount = 0
 
-        foreach ($mailAddress in $mailAddresses) {
-            $ewsService.HttpHeaders.Clear()
-            $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
-            Write-Host ("Creating search folders in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
-
-            $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
-
-            if ($null -eq $userMailbox) {
-                Write-Host ("Unable to get mailbox associated with mail address $mailAddress")
-                $failedMailboxes.Add($mailAddress)
-                $mailboxProcessed += 1
-                continue
+        if ($UseSearchFolders) {
+            $actionText = "Creating"
+            if ($SearchFolderCleanup) {
+                $actionText = "Removing"
             }
 
-            try {
-                # Check for token expiry
-                CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
-                $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
+            $searchFolderCreationTimer = $null
 
-                # Check if the search folder already exists
+            foreach ($mailAddress in $mailAddresses) {
+                $ewsService.HttpHeaders.Clear()
+                $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
+                Write-Host ("$actionText search folders in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
 
-                $searchFolders = @(GetSearchFolder $ewsService $userMailbox)
-                if ($searchFolders.Count -gt 0) {
-                    Write-Host "  Search folder already exists in this mailbox."
+                $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
+
+                if ($null -eq $userMailbox) {
+                    Write-Host ("Unable to get mailbox associated with mail address $mailAddress")
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
                     continue
                 }
 
-                # Create a new search folder
-                NewSearchFolder $ewsService $userMailbox
-                $mailboxProcessed += 1
-            } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
-                Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
-                Write-Host ("Inner Exception: $_") -ForegroundColor Red
-                $failedMailboxes.Add($mailAddress)
-                $mailboxProcessed += 1
-                continue
-            } catch {
-                Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
-                $failedMailboxes.Add($mailAddress)
-                $mailboxProcessed += 1
-                continue
-            }
-        }
+                try {
+                    # Check for token expiry
+                    CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                    $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
-        $mailboxProcessed = 0
-
-        foreach ($mailAddress in $mailAddresses) {
-            if ($failedMailboxes.Contains($mailAddress)) {
-                continue
-            }
-
-            $ewsService.HttpHeaders.Clear()
-            $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
-            Write-Host ("Getting search results in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
-
-            $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
-
-            $itemResults = @()
-
-            try {
-                # Check for token expiry
-                CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
-                $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
-
-                [Microsoft.Exchange.WebServices.Data.Item[]]$itemResults = @(GetSearchFolderItemResults $ewsService $userMailbox)
-                $mailboxProcessed += 1
-            } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
-                Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
-                Write-Host ("Inner Exception: $_") -ForegroundColor Red
-                $failedMailboxes.Add($mailAddress)
-                $mailboxProcessed += 1
-                continue
-            } catch {
-                Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
-                $failedMailboxes.Add($mailAddress)
-                $mailboxProcessed += 1
-                continue
-            }
-
-            $IdsProcessed = New-Object 'System.Collections.Generic.HashSet[string]'
-
-            if ($itemResults.Count -lt 1) {
-                continue
-            }
-
-            $items = $ewsService.LoadPropertiesForItems($itemResults, $PropertySet)
-
-            foreach ($item in $items) {
-                if (-not $IdsProcessed.Contains($item.Item.Id)) {
-                    CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
-                    $rowCount ++
-                    if ($rowCount -ge $MaxCSVLength) {
-                        Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
-                        Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
-                        exit
+                    if ($SearchFolderCleanup) {
+                        RemoveSearchFolder $ewsService $userMailbox
+                        $mailboxProcessed += 1
+                        continue
                     }
-                    [void]$IdsProcessed.Add($item.Item.Id)
+
+                    $searchFolders = GetSearchFolder $ewsService $userMailbox
+
+                    if ($searchFolders.Count -gt 0) {
+                        Write-Host "  Search folder already exists in this mailbox."
+                        $mailboxProcessed += 1
+                        continue
+                    }
+
+                    # Create a new search folder
+                    if ($null -eq $searchFolderCreationTimer) {
+                        $searchFolderCreationTimer = New-Object System.Diagnostics.Stopwatch
+                        $searchFolderCreationTimer.Start()
+                    }
+
+                    NewSearchFolder $ewsService $userMailbox
+                    $mailboxProcessed += 1
+                } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+                    Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
+                    Write-Host ("Inner Exception: $_") -ForegroundColor Red
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
+                    continue
+                } catch {
+                    Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
+                    continue
                 }
             }
 
-            $mailboxProcessed ++;
+            if (-not $SearchFolderCleanup) {
+                if ($null -ne $SearchFolderCreationTimer) {
+                    $waitSecondsAfterCreatingFirstSearchFolder = 60
+                    if ($SearchFolderCreationTimer.ElapsedMilliseconds -lt $waitSecondsAfterCreatingFirstSearchFolder * 1000) {
+                        $secondsElapsed = $SearchFolderCreationTimer.ElapsedMilliseconds / 1000
+                        $secondsRemaining = $waitSecondsAfterCreatingFirstSearchFolder - $secondsElapsed
+                        Write-Host "First search folder created $secondsElapsed seconds ago. Waiting $secondsRemaining seconds to allow a full minute for population."
+                        Start-Sleep -Seconds $secondsRemaining
+                    }
+                }
+
+                $mailboxProcessed = 0
+
+                foreach ($mailAddress in $mailAddresses) {
+                    if ($failedMailboxes.Contains($mailAddress)) {
+                        $mailboxProcessed += 1
+                        continue
+                    }
+
+                    $ewsService.HttpHeaders.Clear()
+                    $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
+                    Write-Host ("Getting search results in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
+
+                    $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
+
+                    $itemResults = @()
+
+                    try {
+                        # Check for token expiry
+                        CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                        $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
+
+                        [Microsoft.Exchange.WebServices.Data.Item[]]$itemResults = @(GetSearchFolderItemResults $ewsService $userMailbox)
+                    } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+                        Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
+                        Write-Host ("Inner Exception: $_") -ForegroundColor Red
+                        $failedMailboxes.Add($mailAddress)
+                        $mailboxProcessed += 1
+                        continue
+                    } catch {
+                        Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
+                        $failedMailboxes.Add($mailAddress)
+                        $mailboxProcessed += 1
+                        continue
+                    }
+
+                    $IdsProcessed = New-Object 'System.Collections.Generic.HashSet[string]'
+
+                    if ($itemResults.Count -lt 1) {
+                        $mailboxProcessed += 1
+                        continue
+                    }
+
+                    $items = $ewsService.LoadPropertiesForItems($itemResults, $PropertySet)
+
+                    foreach ($item in $items) {
+                        if (-not $IdsProcessed.Contains($item.Item.Id)) {
+                            CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
+                            $rowCount ++
+                            if ($rowCount -ge $MaxCSVLength) {
+                                Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
+                                Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
+                                exit
+                            }
+                            [void]$IdsProcessed.Add($item.Item.Id)
+                        }
+                    }
+
+                    $mailboxProcessed ++;
+                }
+            }
+        } else {
+            foreach ($mailAddress in $mailAddresses) {
+                $ewsService.HttpHeaders.Clear()
+                $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
+                Write-Host ("Scanning $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
+
+                $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
+
+                if ($null -eq $userMailbox) {
+                    Write-Host ("Unable to get mailbox associated with mail address $mailAddress")
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
+                    continue
+                }
+
+                try {
+                    # Check for token expiry
+                    CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                    $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
+
+                    $rootFolderId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot, $userMailbox)
+                    $rootFolder = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($ewsService, $rootFolderId)
+
+                    # Create a new ArrayList to hold the folder
+                    $foldersList = New-Object System.Collections.ArrayList
+
+                    GetSubFolders -folder $rootFolder -foldersList $foldersList
+                } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+                    Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
+                    Write-Host ("Inner Exception: $_") -ForegroundColor Red
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
+                    continue
+                } catch {
+                    Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
+                    $failedMailboxes.Add($mailAddress)
+                    $mailboxProcessed += 1
+                    continue
+                }
+
+                $IdsProcessed = New-Object 'System.Collections.Generic.HashSet[string]'
+
+                foreach ($folder in $foldersList) {
+                    try {
+                        # Check for token expiry
+                        CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                        $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
+                        $results = $ewsService.FindItems($folder.Id, $searchFilterCollection, $itemView)
+                        if ($null -ne $results -and $null -ne $results.Items -and $results.Items.Count -gt 0) {
+                            $items = $ewsService.LoadPropertiesForItems($results.Items, $PropertySet)
+                        } else {
+                            continue
+                        }
+
+                        foreach ($item in $items) {
+                            if (-not $IdsProcessed.Contains($item.Item.Id)) {
+                                CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
+                                $rowCount ++
+                                if ($rowCount -ge $MaxCSVLength) {
+                                    Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
+                                    Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
+                                    exit
+                                }
+                                [void]$IdsProcessed.Add($item.Item.Id)
+                            }
+                        }
+                    } catch {
+                        Write-Host "Error while scanning $($folder.DisplayName) of the mailbox $mailAddress. Inner Exception:`n`n$_" -ForegroundColor Red
+                    }
+                }
+
+                $mailboxProcessed ++;
+            }
         }
 
-        if ($rowCount -eq 0) {
-            Write-Host "No vulnerable item found" -ForegroundColor Green
-        } else {
-            Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
+        if (-not $SearchFolderCleanup) {
+            if ($rowCount -eq 0) {
+                Write-Host "No vulnerable item found" -ForegroundColor Green
+            } else {
+                Write-Host ("Please find the audit results in $csvFileName created in the current folder.")
+            }
         }
     } else {
         $params = @{

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -889,7 +889,7 @@ begin {
                     if ($SearchFolderCreationTimer.ElapsedMilliseconds -lt $waitSecondsAfterCreatingFirstSearchFolder * 1000) {
                         $secondsElapsed = $SearchFolderCreationTimer.ElapsedMilliseconds / 1000
                         $secondsRemaining = $waitSecondsAfterCreatingFirstSearchFolder - $secondsElapsed
-                        Write-Host "First search folder created $secondsElapsed seconds ago. Waiting $secondsRemaining seconds to allow a full minute for population."
+                        Write-Host "First search folder created $secondsElapsed seconds ago. Waiting $secondsRemaining seconds to allow for population."
                         Start-Sleep -Seconds $secondsRemaining
                     }
                 }


### PR DESCRIPTION
The CVE-2023-23397.ps1 script can take a long time to run.

In the current version, we bind to each individual folder in the mailbox and perform a search in that folder. This means repeated calls against the same mailbox. The more folders, the more calls.

Also, this search is synchronous. The FindItems call will not return until the server has the results. So we spend time waiting for these calls, and potentially more time on folders with lots of items.

This PR uses a different approach, essentially making the search asynchronous.

* In the first pass, we create a single search folder in each mailbox. This search folder searches the whole mailbox for relevant items.
* In the second pass, we read the results from that folder.

This allows the server to do the work in the background. The script can just come by later and read the results.

Usage:

To take advantage of the new feature, run with the same syntax as usual, but add -UseSearchFolders. Example:

```powershell
Get-Mailbox -ResultSize Unlimited | .\CVE-2023-23397.ps1 -Environment Online -UseSearchFolders
```

This switch only applies to Audit mode. Cleanup mode has no syntax changes. To take maximum advantage of the search folders, it's best to leave them in place until cleanup is done, so you can repeatedly and quickly search for any new items. After cleanup is completed, the search folders can be removed with:

```powershell
Get-Mailbox -ResultSize Unlimited | .\CVE-2023-23997.ps1 -Environment Online -UseSearchFolders -SearchFolderCleanup
```