### PR TITLE
Address Cleanup operation fixes

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -684,6 +684,7 @@ begin {
 
     $failedMailboxes = New-Object 'System.Collections.Generic.List[string]'
     $invalidEntries = New-Object 'System.Collections.Generic.List[string]'
+    $removedEntries = New-Object 'System.Collections.Generic.List[string]'
 
     #MailInfo
     $mailInfo = @{
@@ -886,6 +887,8 @@ begin {
                                 $item.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AlwaysOverwrite)
                             }
                         }
+                        # If we get here, it should be successful.
+                        $removedEntries.Add($entryCount)
                     } catch {
                         Write-Host ("Unable to perform cleanup action on entry number: $entryCount, Line number: $($entryCount + 1) Inner Exception`n`n$_") -ForegroundColor Red
                         $invalidEntries.Add($entryCount)
@@ -899,7 +902,13 @@ begin {
             }
         }
 
-        Write-Host "Completed cleanup operation!"
+        Write-Host "Successfully removed $($removedEntries.Count) of $($cleanupCSV.Count)"
+
+        if ($removedEntries.Count -eq 0) {
+            Write-Host "No entries were removed. Please update the Cleanup column for the items you wish to cleanup." -ForegroundColor Yellow
+        } else {
+            Write-Host "Completed cleanup operation!"
+        }
     }
 
     if ($mode -eq "Audit" -and $null -ne $failedMailboxes -and $failedMailboxes.Count -gt 0) {

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -879,7 +879,12 @@ begin {
 
                             CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
                             $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $entry.Mailbox)
-                            $item.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AlwaysOverwrite);
+
+                            if ($entry.ItemType -eq "Calendar") {
+                                $item.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AlwaysOverwrite, [Microsoft.Exchange.WebServices.Data.SendInvitationsOrCancellationsMode]::SendToNone)
+                            } else {
+                                $item.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AlwaysOverwrite)
+                            }
                         }
                     } catch {
                         Write-Host ("Unable to perform cleanup action on entry number: $entryCount, Line number: $($entryCount + 1) Inner Exception`n`n$_") -ForegroundColor Red


### PR DESCRIPTION
**Issue:**
When doing `ClearProperty` on calendar items you can get an error back, but the property is still removed.
Admins didn't update the CSV file to determine which entries to remove.

**Reason:**
Avoid email/call volume.

**Fix:**
For calendar items include `[Microsoft.Exchange.WebServices.Data.SendInvitationsOrCancellationsMode]::SendToNone` on the update. 

If no entries were changed, throw a warning on the screen. 

**Validation:**
Lab tested

