### PR TITLE
Add TimeoutSeconds parameter and increase default timeout

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -61,6 +61,8 @@
     This optional parameter lets you ignore TLS certificate mismatch errors.
 .PARAMETER Credential
     This optional parameter lets you pass administrator credential object while running on Exchange Server on-premises.
+.PARAMETER TimeoutSeconds
+    This optional parameter lets you specify the timeout value for the ExchangeService object. Defaults to 5 minutes.
 .EXAMPLE
     PS C:\> .\CVE-2023-23397.ps1 -CreateAzureApplication
     This will run the tool to create a new Azure application with required permissions
@@ -157,7 +159,11 @@ param(
     [Parameter(Mandatory=$false, ParameterSetName="DeleteAzureApplication")]
     [Parameter(Mandatory=$false, ParameterSetName="Audit")]
     [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
-    [switch]$IgnoreCertificateMismatch
+    [switch]$IgnoreCertificateMismatch,
+
+    [Parameter(Mandatory=$false, ParameterSetName="Audit")]
+    [Parameter(Mandatory=$false, ParameterSetName="Cleanup")]
+    [int]$TimeoutSeconds = 300
 )
 
 dynamicparam {
@@ -238,6 +244,8 @@ begin {
         } else {
             $Service = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2016)
         }
+
+        $Service.Timeout = $TimeoutSeconds * 1000
 
         if ($Environment -eq "Onprem") {
             $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials($credential.UserName, [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))


### PR DESCRIPTION
Users experience timeouts on large mailboxes when running CVE-2023-23397.ps1. The default timeout of 100 seconds on the ExchangeService object is too short.

This change increases the default timeout to 5 minutes, and adds a parameter so it can be increased further if necessary.

Fixes #1581.