### PR TITLE
Explicitly set comma as delimiter for export- and import-csv

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -335,7 +335,7 @@ begin {
             "Cleanup"                     = "N"
         }
 
-        $row | Export-Csv -Path $CsvPath -NoTypeInformation -Append -Encoding utf8 -Force
+        $row | Export-Csv -Path $CsvPath -Delimiter ',' -NoTypeInformation -Append -Encoding utf8 -Force
     }
 
     # Define a function to get all the SubFolders of a given folder
@@ -844,7 +844,7 @@ begin {
 
         Show-Disclaimer @params
 
-        $cleanupCSV = (Import-Csv $CleanupInfoFilePath)
+        $cleanupCSV = (Import-Csv $CleanupInfoFilePath -Delimiter ',')
 
         $entryCount = 0
 


### PR DESCRIPTION
Forced the delimiter to be exported with ',' and also imported with ','

**Issue:**
#1584 

**Reason:**
To force the delimiter to be a specific character to avoid problems with operating systems having set a different delimiter.

**Fix:**
Forced the delimiter to be exported with ',' and also imported with ',' by specifying -Delimiter ',' paramter on both Import-Csv and Export-Csv cmdlet

**Validation:**
#1584 

