### PR TITLE
Prevent unexpected files from being passed via CleanupInfoFilePath parameter

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -103,6 +103,8 @@ param(
 
     [ValidateScript({ Test-Path -Path $_ -PathType leaf })]
     [Parameter(Mandatory=$true, ParameterSetName="Cleanup")]
+    [ValidatePattern("(.*?)\.(csv)$")]
+    [ValidateScript({ Get-Content $_ -First 1 | Select-String -Pattern "," })]
     [string]$CleanupInfoFilePath,
 
     [Parameter(Mandatory=$false, ParameterSetName="Audit")]

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -104,7 +104,6 @@ param(
     [ValidateScript({ Test-Path -Path $_ -PathType leaf })]
     [Parameter(Mandatory=$true, ParameterSetName="Cleanup")]
     [ValidatePattern("(.*?)\.(csv)$")]
-    [ValidateScript({ Get-Content $_ -First 1 | Select-String -Pattern "," })]
     [string]$CleanupInfoFilePath,
 
     [Parameter(Mandatory=$false, ParameterSetName="Audit")]


### PR DESCRIPTION
**Description:**
Prevent unexpected files from being passed via `CleanupInfoFilePath` parameter.

**Reason:**
We noticed cases where customers passed the results of the script run as .xls or .xlsx file via `CleanupInfoFilePath` parameter. We also saw cases where the delimiter was unexpected like `;` or ``t`. This was accepted by the script but not handled correctly by our logic and so caused the script to fail.

**Fix:**
- Check for csv file extension
- ~~Validate that the first line is comma separated~~

**Validation:**
Lab / Internal testing

