### PR TITLE
Handle csv files with double quotation marks

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -854,7 +854,14 @@ begin {
 
         Show-Disclaimer @params
 
-        $cleanupCSV = (Import-Csv $CleanupInfoFilePath -Delimiter ',')
+        if (Get-Content -Path $CleanupInfoFilePath -First 1 | Select-String -Pattern '""') {
+            Write-Host "CSV file uses double quotation marks for empty values"
+            $cleanupCSV = Get-Content -Path $CleanupInfoFilePath | ForEach-Object {
+                ($_ -replace '"', "")
+            } | ConvertFrom-Csv -Delimiter ","
+        } else {
+            $cleanupCSV = (Import-Csv $CleanupInfoFilePath -Delimiter ',')
+        }
 
         $entryCount = 0
 


### PR DESCRIPTION
**Issue:**
We received multiple reports that in some cases `csv` files are not properly handled by the script.

**Reason:**
Research has turned out that .csv files with space e.g., in subject may use double quotes. The `Import-CSV` call doesn't properly import these files and so, the execution of the action isn't performed and script outputs the following:

```
Delete items
The script will perform store operation on mailboxes using EWS
[J] Ja  [A] Ja, alle  [N] Nein  [K] Nein, keine  [H] Anhalten  [?] Hilfe (Standard ist "J"): j
No Id present for entry number: 1, Line number: 2
No Id present for entry number: 2, Line number: 3
No Id present for entry number: 3, Line number: 4
No Id present for entry number: 4, Line number: 5
No Id present for entry number: 5, Line number: 6
No Id present for entry number: 6, Line number: 7
No Id present for entry number: 7, Line number: 8
No Id present for entry number: 8, Line number: 9
No Id present for entry number: 9, Line number: 10
```

**Fix:**
Import the first line and parse for double quotes. If found, replace them and call `ConvertFrom-Csv -Delimiter ","` instead of `Import-Csv`.

**Validation:**
Lab/Customer

