### PR TITLE
Fix wording for docs

### DIFF
--- a/docs/Security/CVE-2023-23397/index.md
+++ b/docs/Security/CVE-2023-23397/index.md
@@ -2,7 +2,7 @@
 
 Download the latest release: [CVE-2023-23397.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/CVE-2023-23397.ps1)
 
-CVE-2023-23397.ps1 is a script that checks Exchange messaging items (mail, calendar and tasks) to see whether a property is populated with a UNC path. If required, admins can use this script to clean up the property for items that are malicious or even delete the items permanently. Please see [CVE-2023-23397](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-23397) for more information.
+CVE-2023-23397.ps1 is a script that checks Exchange messaging items (mail, calendar and tasks) to see whether a property is populated at all. It is up to the admin to determine if the value is malicious or not. If required, admins can use this script to clean up the property for items that are malicious or even delete the items permanently. Please see [CVE-2023-23397](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-23397) for more information.
 
 There are two modes for the script: Audit and Cleanup.
 


### PR DESCRIPTION
**Reason:**
Script determines if the property is set, doesn't determine if UNC path is used or not. Up to the admin to decide.

