### PR TITLE
Address Credential Guard also being flagged when Disable Async Notification is set

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -103,11 +103,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
         Name                = "Disable Async Notification"
         Details             = $displayValue
         DisplayWriteType    = $displayWriteType
-        DisplayTestingValue = $true
+        DisplayTestingValue = $displayValue -ne 0
     }
     Add-AnalyzedResultInformation @params
 
-    $credentialGuardValue = $osInformation.RegistryValues.CredentialGuard -ne 0
+    $displayValue = $credentialGuardValue = $osInformation.RegistryValues.CredentialGuard -ne 0
     $displayWriteType = "Grey"
 
     if ($credentialGuardValue) {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -112,6 +112,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "RPC Min Connection Timeout" 0
             TestObjectMatch "FIPS Algorithm Policy Enabled" 0
             TestObjectMatch "CTS Processor Affinity Percentage" 0 -WriteType "Green"
+            TestObjectMatch "Disable Async Notification" $false
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"


### PR DESCRIPTION
**Issue:**
When Disable Async Notification key is set, we then show Credential Guard being enabled as well with the same wording.  


**Fix:**
Resolved #1617

**Validation:**
Lab tested

