### PR TITLE
Block PowerShell Core from running with the script

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -701,6 +701,10 @@ begin {
 } end {
     Write-Host ("CVE-2023-23397 script version $($BuildVersion)") -ForegroundColor Green
 
+    if ($null -ne $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core") {
+        throw "Script doesn't support PowerShell Core, must use PowerShell Version 5 or lower"
+    }
+
     if (([System.String]::IsNullOrEmpty($CleanupInfoFilePath)) -and
         ($ScriptUpdateOnly -eq $false) -and
         ($UseSearchFolders -eq $false) -and


### PR DESCRIPTION
**Issue:**
Customers run into issues because of trying to run the script with PowerShell core.

**Reason:**
Because it isn't clear as to why the script is failing, we should just block the ability to run PowerShell core with the script.

**Fix:**
We can't use `#Requires -PSEdition Desktop` because it will cause PS 3 and 4 versions to fail. Because we still support that we need to manually look at the `$PSVersionTable`. 

**Validation:**
Lab tested

