### PR TITLE
Prevent Pester from running when only non PS1 files are changed

### DIFF
--- a/.build/HelpFunctions/Get-CommitFilesOnBranch.ps1
+++ b/.build/HelpFunctions/Get-CommitFilesOnBranch.ps1
@@ -1,0 +1,53 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This should only be called if we have a branch that we want to compare against
+function Get-CommitFilesOnBranch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Branch
+    )
+    $filesFullPath = New-Object 'System.Collections.Generic.HashSet[string]'
+    $repoRoot = Get-Item "$PSScriptRoot\..\.."
+
+    Write-Verbose "Checking commits only"
+    # Get all the commits between origin/$Branch and HEAD.
+    $gitlog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
+    $m = $gitlog | Select-String "^(\S+) (.*)$"
+
+    foreach ($commitMatch in $m) {
+        $commitHash = $commitMatch.Matches.Groups[1].Value
+        $filesChangedInCommit = git diff-tree --no-commit-id --name-only -r $commitHash
+
+        foreach ($fileChanged in $filesChangedInCommit) {
+            $fullPath = Join-Path $repoRoot $fileChanged
+
+            if (-not (Test-Path $fullPath)) {
+                # not typical scenario, but want to have the pipeline continue
+                Write-Verbose "File no longer exists, skip file: $fullPath"
+                continue
+            }
+
+            Write-Verbose "Adding commit file to list: $fullPath"
+            [void]$filesFullPath.Add($fullPath)
+        }
+    }
+
+    # Also include modified files, but not committed yet for local work.
+    $gitStatus = git status --short
+    $m = $gitStatus | Select-String "M (.*)"
+    foreach ($match in $m) {
+        $file = $match.Matches.Groups[1].Value.Trim()
+        $fullPath = Join-Path $PSScriptRoot $file
+
+        Write-Verbose "Adding modified file to list: $fullPath"
+        [void]$filesFullPath.Add($fullPath)
+    }
+
+    Write-Verbose "Files changed or modified"
+    $filesFullPath | Write-Verbose
+
+    return $filesFullPath
+}

--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -25,8 +25,10 @@ steps:
 
 - pwsh: |
     cd .\.build
-    .\Pester.ps1 -NoProgress
+    .\Pester.ps1 -NoProgress -Branch $env:TargetBranchName
   displayName: "Running Invoke-Pester"
+  env:
+    TargetBranchName: $(System.PullRequest.TargetBranch)
 
 - pwsh: |
     cd .\.build


### PR DESCRIPTION
**Issue:**
No need to waste the build pipeline on pester if we don't have `ps1` files that are changed. 

**Fix:**
Shared the code that finds all the files that are changed in the branch. Made pester use it and only will do pester tests if there are any ps1 files changes. 

**Validation:**
Tested locally
