### PR TITLE
Update wording of missing property

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -1254,7 +1254,7 @@ begin {
                             $item.Delete([Microsoft.Exchange.WebServices.Data.DeleteMode]::HardDelete)
                         } else {
                             if (-not $item.RemoveExtendedProperty($mailInfo["PidLidReminderFileParameter"])) {
-                                Write-Host ("Failed to clear property for entry number: $entryCount, Line number: $($entryCount + 1)") -ForegroundColor Red
+                                Write-Host ("Property isn't present any longer on the item. Entry number: $entryCount, Line number: $($entryCount + 1)") -ForegroundColor Yellow
                                 $invalidEntries.Add($entryCount)
                                 continue
                             }


### PR DESCRIPTION
**Issue:**
The current output is confusing. Customers appear to run the script twice trying to remove the item, but that isn't a valid way of verifying that the item has been removed. 

**Fix:**
Cleaned up the wording of the error. 

Resolved #1634 

**Validation:**
N/A

