### PR TITLE
Don't log already cleared properties as failures

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -1254,7 +1254,7 @@ begin {
                             $item.Delete([Microsoft.Exchange.WebServices.Data.DeleteMode]::HardDelete)
                         } else {
                             if (-not $item.RemoveExtendedProperty($mailInfo["PidLidReminderFileParameter"])) {
-                                Write-Host ("Failed to clear property for entry number: $entryCount, Line number: $($entryCount + 1)") -ForegroundColor Red
+                                Write-Host ("Property already cleared on entry number: $entryCount, Line number: $($entryCount + 1)") -ForegroundColor Yellow
                                 $invalidEntries.Add($entryCount)
                                 continue
                             }


### PR DESCRIPTION
When items have already been cleaned up, we log a failure:

![image](https://user-images.githubusercontent.com/4518572/228245467-77d44a42-b8b0-4214-82ec-dbfaf49dd147.png)

This is misleading. Nothing failed, because we didn't try to do anything. The property is already cleared.

This PR changes the text to "Property already cleared" and removes the scary red color:

![image](https://user-images.githubusercontent.com/4518572/228248965-57422d67-7c0a-4bd3-b5ae-f1c9ee8ac8c7.png)

Fixes #1634 