### PR TITLE
Remove AzureAD module dependencies

### DIFF
--- a/.build/cspell-words.txt
+++ b/.build/cspell-words.txt
@@ -106,11 +106,13 @@ ntlm
 NTFS
 NUMA
 nupkg
+odata
 onmicrosoft
 onprem
 OutlookiOS
 Perflib
 perfmon
+PKCE
 Pkcs
 Prelicensing
 PROCMON

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -39,7 +39,7 @@
     Use this switch if you are running on Exchange 2013 server mailboxes
 .PARAMETER MaxCSVLength
     This optional parameter allows you to provide maximum csv length
-.PARAMETER AzureEnvironmentName
+.PARAMETER AzureEnvironment
     This optional parameter allows you to provide Azure environment
 .PARAMETER AzureApplicationName
     This optional parameter allows you to provide Azure application name
@@ -49,10 +49,6 @@
     This optional parameter allows you to provide the AppId of the Azure application created by the script
 .PARAMETER Organization
     This optional parameter allows you to provide the organization name e.g., contoso.onmicrosoft.com
-.PARAMETER EWSOnlineURL
-    This optional parameter allows you to provide EWS online url
-.PARAMETER EWSOnlineScope
-    This optional parameter allows you to provide EWS online scope
 .PARAMETER AzureADEndpoint
     This optional parameter allows you to provide Azure AD endpoint
 .PARAMETER EWSServerURL
@@ -89,17 +85,17 @@ param(
     [ValidateSet("Online", "Onprem")]
     [Parameter(Mandatory = $true, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $true, ParameterSetName = "Cleanup")]
-    [String]$Environment,
+    [string]$Environment,
 
     [Parameter(Mandatory = $true, ParameterSetName = "CreateAzureApplication")]
-    [Switch]$CreateAzureApplication,
+    [switch]$CreateAzureApplication,
 
     [Parameter(Mandatory = $true, ParameterSetName = "DeleteAzureApplication")]
-    [Switch]$DeleteAzureApplication,
+    [switch]$DeleteAzureApplication,
 
     [Parameter(Mandatory = $true, ParameterSetName = "Audit", ValueFromPipelineByPropertyName = $true)]
     [Alias("PrimarySmtpAddress")]
-    [String[]]$UserMailboxes,
+    [string[]]$UserMailboxes,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [DateTime]$StartTimeFilter,
@@ -122,52 +118,41 @@ param(
 
     [ValidateRange(1, [Int]::MaxValue)]
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
-    [Int]$MaxCSVLength = 200000,
+    [int]$MaxCSVLength = 200000,
+
+    [ValidateSet("Global", "USGovernmentL4", "USGovernmentL5", "ChinaCloud")]
+    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
+    [string]$AzureEnvironment = "Global",
 
     [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
     [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$AzureEnvironmentName = "AzureCloud",
-
-    [Parameter(Mandatory = $false, ParameterSetName = "CreateAzureApplication")]
-    [Parameter(Mandatory = $false, ParameterSetName = "DeleteAzureApplication")]
-    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
-    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$AzureApplicationName = "CVE-2023-23397Application",
+    [string]$AzureApplicationName = "CVE-2023-23397Application",
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$CertificateThumbprint,
+    [string]$CertificateThumbprint,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$AppId,
+    [string]$AppId,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$Organization,
+    [string]$Organization,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [Uri]$EWSOnlineURL = "https://outlook.office365.com/EWS/Exchange.asmx",
-
-    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
-    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$EWSOnlineScope = "https://outlook.office365.com/.default",
-
-    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
-    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [Uri]$AzureADEndpoint = "https://login.microsoftonline.com/",
-
-    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
-    [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [Uri]$EWSServerURL,
+    [uri]$EWSServerURL,
 
     [ValidateScript({ Test-Path $_ })]
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
-    [String]$DLLPath,
+    [string]$DLLPath,
 
     [Parameter(Mandatory = $true, ParameterSetName = "ScriptUpdateOnly")]
     [switch]$ScriptUpdateOnly,
@@ -245,7 +230,10 @@ begin {
     . $PSScriptRoot\..\..\..\Shared\Get-NuGetPackage.ps1
     . $PSScriptRoot\..\..\..\Shared\Invoke-ExtractArchive.ps1
     . $PSScriptRoot\..\..\..\Shared\LoggerFunctions.ps1
+    . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-GraphAccessToken.ps1
+    . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-CloudServiceEndpoint.ps1
     . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-NewJsonWebToken.ps1
+    . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Invoke-GraphApiRequest.ps1
     . $PSScriptRoot\..\..\..\Shared\Show-Disclaimer.ps1
 
     $loggerParams = @{
@@ -262,11 +250,20 @@ begin {
 
     $mode = $PsCmdlet.ParameterSetName
 
+    $cloudService = Get-CloudServiceEndpoint $AzureEnvironment
+
+    # Define the endpoints that we need for the various calls to the Azure AD Graph API and EWS
+    $ewsOnlineURL = "$($cloudService.ExchangeOnlineEndpoint)/EWS/Exchange.asmx"
+    $ewsOnlineScope = "$($cloudService.ExchangeOnlineEndpoint)/.default"
+    $autoDSecureName = $cloudService.AutoDiscoverSecureName
+    $azureADEndpoint = $cloudService.AzureADEndpoint
+    $graphApiEndpoint = $cloudService.GraphApiEndpoint
+
     ## function to create ews managed api service object
     function EWSAuth {
         param(
             [string]$Environment,
-            $token,
+            $Token,
             $EWSOnlineURL,
             $EWSServerURL
         )
@@ -282,18 +279,18 @@ begin {
         if ($Environment -eq "Onprem") {
             $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials($credential.UserName, [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
         } else {
-            $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.OAuthCredentials($token.access_token)
+            $Service.Credentials = New-Object Microsoft.Exchange.WebServices.Data.OAuthCredentials($Token.access_token)
         }
 
         if ($Environment -eq "Onprem") {
             if (-not([System.String]::IsNullOrEmpty($EWSServerURL))) {
                 $Service.Url = New-Object Uri($EWSServerURL)
-                CheckOnpremCredentials -ewsService $Service
+                CheckOnpremCredentials -EWSService $Service
             } else {
                 try {
                     $redirectionCallback = {
                         param([string]$url)
-                        return $url.ToLower().StartsWith("https://autodiscover-s.outlook.com")
+                        return $url.ToLower().StartsWith($autoDSecureName)
                     }
 
                     $Service.AutodiscoverUrl($Credential.UserName, $redirectionCallback)
@@ -323,12 +320,12 @@ begin {
 
     ## function to validate onprem credential
     function CheckOnpremCredentials {
-        param (
-            $ewsService
+        param(
+            $EWSService
         )
 
         try {
-            $null = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($ewsService, [Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot)
+            $null = [Microsoft.Exchange.WebServices.Data.Folder]::Bind($EWSService, [Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot)
         } catch [Microsoft.Exchange.WebServices.Data.ServiceRequestException] {
             Write-Host "Unable to connect to EWS endpoint. Please make sure you have enter valid credentials. Inner Exception`n`n$_" -ForegroundColor Red
             exit
@@ -352,19 +349,19 @@ begin {
 
     ## function to add a row to the csv
     function CreateCustomCSV {
-        param (
-            $mailbox,
-            $data,
+        param(
+            $Mailbox,
+            $Data,
             [string]$CsvPath
         )
 
-        $ItemType = $data.ItemClass
+        $ItemType = $Data.ItemClass
 
-        if ($data.ItemClass.StartsWith("IPM.Note")) {
+        if ($Data.ItemClass.StartsWith("IPM.Note")) {
             $ItemType = "E-Mail"
-        } elseif ($data.ItemClass.StartsWith("IPM.Appointment")) {
+        } elseif ($Data.ItemClass.StartsWith("IPM.Appointment")) {
             $ItemType = "Calendar"
-        } elseif ($data.ItemClass.StartsWith("IPM.Task")) {
+        } elseif ($Data.ItemClass.StartsWith("IPM.Task")) {
             $ItemType = "Task"
         }
 
@@ -374,14 +371,14 @@ begin {
             CleanupInfoFilePath parameter.
         #>
         $row = [PSCustomObject]@{
-            "Mailbox"                     = $mailbox
-            "Id"                          = $data.Id
+            "Mailbox"                     = $Mailbox
+            "Id"                          = $Data.Id
             "ItemType"                    = $ItemType
-            "Sender"                      = ($data.From | Select-Object -ExpandProperty Address) -join ","
-            "Recipient"                   = ($data.ToRecipients | Select-Object -ExpandProperty Address) -join ","
-            "Subject"                     = $data.Subject
-            "DateReceived"                = $data.DateTimeReceived
-            "PidLidReminderFileParameter" = $data.ExtendedProperties[0].Value
+            "Sender"                      = ($Data.From | Select-Object -ExpandProperty Address) -join ","
+            "Recipient"                   = ($Data.ToRecipients | Select-Object -ExpandProperty Address) -join ","
+            "Subject"                     = $Data.Subject
+            "DateReceived"                = $Data.DateTimeReceived
+            "PidLidReminderFileParameter" = $Data.ExtendedProperties[0].Value
             "Cleanup"                     = "N"
         }
 
@@ -390,18 +387,18 @@ begin {
 
     # Define a function to get all the SubFolders of a given folder
     function GetSubFolders {
-        param (
-            $folder,
-            $foldersList
+        param(
+            $Folder,
+            $FoldersList
         )
         # Get the SubFolders of the folder
         $folderView = New-Object Microsoft.Exchange.WebServices.Data.FolderView(100)
         do {
-            $folder.FindFolders($folderView) | ForEach-Object {
+            $Folder.FindFolders($folderView) | ForEach-Object {
                 # Add the folder path to the list
-                $null = $foldersList.Add($_)
+                $null = $FoldersList.Add($_)
                 # Recursively get the SubFolders of this folder
-                GetSubFolders -folder $_ -foldersList $foldersList
+                GetSubFolders -folder $_ -foldersList $FoldersList
             }
             $folderView.Offset += $result.Folders.Count
         } while ($result.MoreAvailable -eq $true)
@@ -409,17 +406,17 @@ begin {
 
     ## function to find item on basis of store ID
     function FindItem {
-        param (
-            [Microsoft.Exchange.WebServices.Data.ExchangeService]$exchangeService,
+        param(
+            [Microsoft.Exchange.WebServices.Data.ExchangeService]$ExchangeService,
             [string]$Id
         )
         $ps = New-Object Microsoft.Exchange.WebServices.Data.PropertySet(New-Object Microsoft.Exchange.WebServices.Data.ExtendedPropertyDefinition([Microsoft.Exchange.WebServices.Data.DefaultExtendedPropertySet]::Common, 0x0000851F, [Microsoft.Exchange.WebServices.Data.MapiPropertyType]::String))
-        return [Microsoft.Exchange.WebServices.Data.Item]::Bind($exchangeService, $Id, $ps);
+        return [Microsoft.Exchange.WebServices.Data.Item]::Bind($ExchangeService, $Id, $ps);
     }
 
     ## function to create OAuth token
     function CreateOAUTHToken {
-        param (
+        param(
             [string]$TenantID,
             [string]$ClientID,
             [string]$AppSecret,
@@ -448,7 +445,7 @@ begin {
 
                 # Create string by joining bodyList with '&'
                 Body        = $body
-                Uri         = "$AzureADEndpoint$TenantID/oauth2/v2.0/token"
+                Uri         = "$AzureADEndpoint/$TenantID/oauth2/v2.0/token"
             }
 
             $Token = Invoke-RestMethod @PostSplat
@@ -462,196 +459,343 @@ begin {
         return $Token
     }
 
-    function ConnectAzureAD {
-        [CmdletBinding()]
+    function GetAzureApplication {
         param(
-            [Parameter(Mandatory = $true)]
-            [string]$AzureEnvironmentName
-        )
-
-        try {
-            Import-Module "AzureAD" -ErrorAction Stop
-            Write-Host "`nPrompting user for authentication, please minimize this window if you do not see an authorization prompt as it may be in the background"
-            Connect-AzureAD -AzureEnvironmentName $AzureEnvironmentName -ErrorAction Stop
-        } catch [System.IO.FileNotFoundException] {
-            Write-Host "The AzureAD module was not found on this computer. Please install it by running: Install-Module -Name `"AzureAD`"" -ForegroundColor Red
-            Write-Host "AzureAD module requires PowerShell version 5.0 or higher. You're running PowerShell $($PSVersionTable.PSVersion)" -ForegroundColor Red
-            exit
-        } catch {
-            Write-Host "Unable to connect to Azure AD. Inner Exception`n`n$_" -ForegroundColor Red
-            exit
-        }
-    }
-
-    ## function that create an App secret to for a given application and return it
-    function GetApplicationDetails {
-        param (
+            $AzAccountsObject,
             $AzureApplicationName,
-            $AzureEnvironmentName,
-            $UseCertificateToAuthenticate = $false
+            $GraphApiUrl
         )
 
-        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
+        <#
+            Get the Azure AD Application ID for the given Azure Application Name
+            https://learn.microsoft.com/graph/api/application-list?view=graph-rest-1.0&tabs=http#request
+        #>
 
-        try {
-            $aadApplication = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
-        } catch {
-            Write-Host "No Azure Application found with the name $AzureApplicationName. Please re-run the script with -CreateAzureApplication to create the application. Inner Exception`n`n$_" -ForegroundColor Red
-            exit
+        $listAadApplicationParams = @{
+            Query       = ("applications?`$filter=displayName eq '{0}'" -f $AzureApplicationName)
+            AccessToken = $AzAccountsObject.AccessToken
+            GraphApiUrl = $GraphApiUrl
+        }
+        $listAadApplicationResponse = Invoke-GraphApiRequest @listAadApplicationParams
+
+        if ($listAadApplicationResponse.Successful) {
+            return $listAadApplicationResponse.Content
         }
 
-        if ($null -eq $aadApplication) {
-            Write-Host "No Azure Application found with the name $AzureApplicationName. Please re-run the script with -CreateAzureApplication to create the application." -ForegroundColor Red
-            exit
-        }
-
-        $returnObject = @{
-            TenantID = (Get-AzureADTenantDetail).ObjectId
-            ClientID = $aadApplication.AppId
-        }
-
-        if ($UseCertificateToAuthenticate -ne $true) {
-            #Assign App Password, make it valid for 7 days
-            $appPassword = New-AzureADApplicationPasswordCredential -ObjectId $aadApplication.ObjectId -CustomKeyIdentifier "AppAccessKey" -EndDate (Get-Date).AddDays(7) -ErrorAction Stop
-
-            Write-Host "`nWaiting 60 seconds for app credentials to register..."
-            Start-Sleep -Seconds 60
-            Write-Host "`nContinuing..."
-            $returnObject.Add("AppSecret", $appPassword.Value)
-        }
-
-        return $returnObject
+        return $null
     }
 
-    ## function to delete Azure AD application
-    function DeleteApplication {
-        param (
-            $AzureEnvironmentName,
-            $AzureApplicationName
-        )
-
-        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
-
-        try {
-            $app = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
-
-            if ($null -eq $app) {
-                Write-Host "No application with name $AzureApplicationName found" -ForegroundColor Red
-                exit
-            }
-
-            Remove-AzureADApplication -ObjectId $app.ObjectId
-
-            if (Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'") {
-                Write-Host "Unable to delete the Azure AD application. Please try again or delete it manually." -ForegroundColor Red
-                exit
-            }
-        } catch {
-            Write-Host "Unable to delete the Azure AD application. Please try again or delete it manually. Inner Exception`n`n$_"
-            exit
-        }
-
-        Write-Host "Successfully deleted the application $AzureApplicationName" -ForegroundColor Green
-    }
-
-    ## function to create Azure AD application
-    function CreateApplication {
+    function NewAzureApplication {
         param(
-            $AzureEnvironmentName,
-            $AzureApplicationName
+            $AzAccountsObject,
+            $AzureApplicationName,
+            $GraphApiUrl
         )
 
-        ConnectAzureAD -AzureEnvironmentName $AzureEnvironmentName
+        <#
+            This function will create an Azure AD Application by calling the Graph API
+            https://docs.microsoft.com/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http
+        #>
 
-        $aadApplication = Get-AzureADApplication -Filter "DisplayName eq '$AzureApplicationName'"
+        $getAadApplicationParams = @{
+            AzAccountsObject     = $AzAccountsObject
+            AzureApplicationName = $AzureApplicationName
+            GraphApiUrl          = $GraphApiUrl
+        }
+        $getAadApplicationResponse = GetAzureApplication @getAadApplicationParams
 
-        if ($null -ne $aadApplication) {
-            Write-Host "Application with name $AzureApplicationName already exists..."
-            Write-Host "Client ID: $($aadApplication.AppId)" -ForegroundColor Green
+        if ($null -eq $getAadApplicationResponse) {
+            Write-Host "Something went wrong while querying the Azure AD Application" -ForegroundColor Red
+            exit
+        } elseif (-not([System.String]::IsNullOrEmpty($getAadApplicationResponse.Value.id))) {
+            Write-Host "Application with name: $AzureApplicationName already exists..."
+            Write-Host "Client ID: $($getAadApplicationResponse.Value.AppId)" -ForegroundColor Green
             exit
         }
 
-        ## Creating application with default name
-        [string]$appName = $AzureApplicationName
+        # Graph API call to create a new Azure AD Application
+        $newAzureAdApplicationParams = @{
+            Query              = "applications"
+            Body               = @{ "displayName" = $AzureApplicationName; "signInAudience" = "AzureADMyOrg" } | ConvertTo-Json
+            AccessToken        = $AzAccountsObject.AccessToken
+            Method             = "Post"
+            ExpectedStatusCode = 201
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $createAzureApplicationResponse = Invoke-GraphApiRequest @newAzureAdApplicationParams
 
-        try {
-            $aadApplication = New-AzureADApplication -DisplayName $appName
-        } catch {
-            Write-Host "`nThere was an error creating the application, please reference the error below and try again Inner Exception`n`n$_" -ForegroundColor Red
+        if ($createAzureApplicationResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while creating the Azure AD Application: $AzureApplicationName" -ForegroundColor Red
             exit
         }
 
-        #Add current user to owner of newly created application
-        $currentUser = (Get-AzureADUser -ObjectId (Get-AzureADCurrentSessionInfo).Account.Id)
-        Write-Host "`nAdding user $($currentUser.UserPrincipalName) as owner of $appName"
-        Add-AzureADApplicationOwner -ObjectId $aadApplication.ObjectId -RefObjectId $currentUser.ObjectId | Out-Null
+        $aadApplication = $createAzureApplicationResponse.Content
 
-        #Get Service Principal of MS Graph Resource API
-        $ews_SP = Get-AzureADServicePrincipal -All $true | Where-Object { $_.DisplayName -eq "Office 365 Exchange Online" }
+        # Graph API call to get the current logged in user
+        $loggedInUserParams = @{
+            Query       = "me"
+            AccessToken = $AzAccountsObject.AccessToken
+            GraphApiUrl = $GraphApiUrl
+        }
+        $loggedInUserResponse = Invoke-GraphApiRequest @loggedInUserParams
 
-        #Initialize RequiredResourceAccess for Microsoft Graph Resource API
-        $requiredAccess = New-Object Microsoft.Open.AzureAD.Model.RequiredResourceAccess
-        $requiredAccess.ResourceAppId = $ews_SP.AppId
-        $requiredAccess.ResourceAccess = New-Object System.Collections.Generic.List[Microsoft.Open.AzureAD.Model.ResourceAccess]
+        if ($loggedInUserResponse.Successful -eq $false) {
+            Write-Host "Unable to query the logged in user. Please try again." -ForegroundColor Red
+            exit
+        }
 
-        #Set Application Permissions
-        $ApplicationPermissions = @('full_access_as_app')
+        $currentUser = $loggedInUserResponse.Content
 
-        #Add app permissions
-        foreach ($permission in $ApplicationPermissions) {
-            $reqPermission = $null
-            #Get required app permission
-            $reqPermission = $ews_SP.AppRoles | Where-Object { $_.Value -eq $permission }
-            if ($reqPermission) {
-                $resourceAccess = New-Object Microsoft.Open.AzureAD.Model.ResourceAccess
-                $resourceAccess.Type = "Role"
-                $resourceAccess.Id = $reqPermission.Id
-                #Add required app permission
-                $requiredAccess.ResourceAccess.Add($resourceAccess)
-            } else {
-                Write-Host "App permission $permission not found in the Graph Resource API" -ForegroundColor Red
+        # Graph API call to query the owners of the Azure AD Application
+        $listOwnerParams = @{
+            Query       = "applications/$($aadApplication.id)/owners"
+            AccessToken = $AzAccountsObject.AccessToken
+            GraphApiUrl = $GraphApiUrl
+        }
+        $listOwnerResponse = Invoke-GraphApiRequest @listOwnerParams
+
+        if ($listOwnerResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while querying the owners of the Azure application: $AzureApplicationName" -ForegroundColor Red
+            exit
+        }
+
+        if ($listOwnerResponse.Content.Value.id.Contains($currentUser.id)) {
+            Write-Host "User: $($currentUser.userPrincipalName) is already an owner of application: $AzureApplicationName"
+        } else {
+            Write-Host "User: $($currentUser.userPrincipalName) is not an owner of application: $AzureApplicationName"
+
+            # Graph API call to add the current user as owner of the Azure AD Application
+            $addUserAsOwnerParams = @{
+                Query              = "applications/$($aadApplication.id)/owners/`$ref"
+                AccessToken        = $AzAccountsObject.AccessToken
+                Body               = @{ "@odata.id" = "$GraphApiUrl/v1.0/directoryObjects/$($currentUser.id)" } | ConvertTo-Json
+                Method             = "Post"
+                ExpectedStatusCode = 204
+                GraphApiUrl        = $GraphApiUrl
+            }
+            $addUserAsOwnerResponse = Invoke-GraphApiRequest @addUserAsOwnerParams
+
+            if ($addUserAsOwnerResponse.Successful -eq $false) {
+                Write-Host "Something went wrong while adding the user as owner of the Azure application: $AzureApplicationName" -ForegroundColor Red
+                exit
             }
         }
 
-        #Add required resource accesses
-        $requiredResourcesAccess = New-Object System.Collections.Generic.List[Microsoft.Open.AzureAD.Model.RequiredResourceAccess]
-        $requiredResourcesAccess.Add($requiredAccess)
+        # Graph API call to update the Azure AD Application and add the required permissions
+        # https://learn.microsoft.com/exchange/client-developer/exchange-web-services/how-to-authenticate-an-ews-application-by-using-oauth#configure-for-delegated-authentication
+        # https://learn.microsoft.com/troubleshoot/azure/active-directory/verify-first-party-apps-sign-in#application-ids-of-commonly-used-microsoft-applications
+        $updateApplicationParams = @{
+            Query              = "applications/$($aadApplication.id)"
+            AccessToken        = $AzAccountsObject.AccessToken
+            Body               = '{ "requiredResourceAccess": [ { "resourceAppId": "00000002-0000-0ff1-ce00-000000000000", "resourceAccess": [ { "id": "dc890d15-9560-4a4c-9b7f-a736ec74ec40", "type": "Role" } ] } ] }'
+            Method             = "Patch"
+            ExpectedStatusCode = 204
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $updateApplicationResponse = Invoke-GraphApiRequest @updateApplicationParams
 
-        #Set permissions in newly created Azure AD App
-        $appObjectId = $aadApplication.ObjectId
-        Write-Host "`nSetting Azure AD Permissions"
-        Set-AzureADApplication -ObjectId $appObjectId -RequiredResourceAccess $requiredResourcesAccess | Out-Null
+        if ($updateApplicationResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while adding the required permission to application: $AzureApplicationName" -ForegroundColor Red
+            exit
+        }
 
-        #Create Service Principal
-        $appId = $aadApplication.AppId
-        $servicePrincipal = New-AzureADServicePrincipal -AppId $appId -Tags @("WindowsAzureActiveDirectoryIntegratedApp")
+        # Graph API call to create a new service principal for the Azure AD Application
+        $newServicePrincipalParams = @{
+            Query              = "servicePrincipals"
+            AccessToken        = $AzAccountsObject.AccessToken
+            Body               = @{ "appId" = $aadApplication.appId; "accountEnabled" = $true } | ConvertTo-Json
+            Method             = "Post"
+            ExpectedStatusCode = 201
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $newServicePrincipalResponse = Invoke-GraphApiRequest @newServicePrincipalParams
 
-        #Grant Admin Consent for App Permissions
-        $requiredResourcesAccess = (Get-AzureADApplication -ObjectId $appObjectId).RequiredResourceAccess
+        if ($newServicePrincipalResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while creating the service principal." -ForegroundColor Red
+            exit
+        }
 
-        Write-Host "`nAssigning Necessary Azure AD Service Roles"
-        foreach ($resourceAppAccess in $requiredResourcesAccess) {
-            $resourceApp = Get-AzureADServicePrincipal -All $true | Where-Object { $_.AppId -eq $resourceAppAccess.ResourceAppId }
+        $servicePrincipal = $newServicePrincipalResponse.Content
 
-            foreach ($permission in $resourceAppAccess.ResourceAccess) {
-                if ($permission.Type -eq "Role") {
-                    New-AzureADServiceAppRoleAssignment -ObjectId $servicePrincipal.ObjectId -PrincipalId $servicePrincipal.ObjectId -ResourceId $resourceApp.ObjectId -Id $permission.Id | Out-Null
+        # Graph API call to update the service principal and add the required tags
+        $updateServicePrincipalParams = @{
+            Query              = "servicePrincipals/$($servicePrincipal.id)"
+            AccessToken        = $AzAccountsObject.AccessToken
+            Body               = @{ "tags" = @("WindowsAzureActiveDirectoryIntegratedApp") } | ConvertTo-Json
+            Method             = "Patch"
+            ExpectedStatusCode = 204
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $updateServicePrincipalResponse = Invoke-GraphApiRequest @updateServicePrincipalParams
+
+        if ($updateServicePrincipalResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while updating the service principal." -ForegroundColor Red
+            exit
+        }
+
+        # Graph API call to query the Office 365 Exchange Online service principal (as we need the object id)
+        $o365ExchangeOnlineServicePrincipalParams = @{
+            Query       = "servicePrincipals?`$filter=appId eq '00000002-0000-0ff1-ce00-000000000000'"
+            AccessToken = $AzAccountsObject.AccessToken
+            GraphApiUrl = $GraphApiUrl
+        }
+        $o365ExchangeOnlineServicePrincipalResponse = Invoke-GraphApiRequest @o365ExchangeOnlineServicePrincipalParams
+
+        if ($o365ExchangeOnlineServicePrincipalResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while querying the Office 365 Exchange Online service principal." -ForegroundColor Red
+            exit
+        }
+
+        $o365ExchangeOnlineObjectId = $o365ExchangeOnlineServicePrincipalResponse.Content.value[0].id
+
+        # Graph API call to provide admin consent to the application
+        $adminConsentParams = @{
+            Query              = "servicePrincipals/$($servicePrincipal.id)/appRoleAssignments"
+            AccessToken        = $AzAccountsObject.AccessToken
+            Body               = @{ "principalId" = $servicePrincipal.id; "resourceId" = $o365ExchangeOnlineObjectId; "appRoleId" = "dc890d15-9560-4a4c-9b7f-a736ec74ec40" } | ConvertTo-Json
+            Method             = "Post"
+            ExpectedStatusCode = 201
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $adminConsentResponse = Invoke-GraphApiRequest @adminConsentParams
+
+        if ($adminConsentResponse.Successful -eq $false) {
+            Write-Host "Something went wrong while providing admin consent to application: $AzureApplicationName" -ForegroundColor Red
+            exit
+        }
+
+        Write-Host "Application: $AzureApplicationName created with required permissions. Client ID: $($aadApplication.appId)" -ForegroundColor Green
+    }
+
+    function NewAzureApplicationAppSecret {
+        param(
+            $AzAccountsObject,
+            $AzureApplicationName,
+            $GraphApiUrl
+        )
+
+        <#
+            This function creates an App secret for a given application and return it.
+            The assigned App Password is valid for 7 days.
+            https://learn.microsoft.com/graph/api/application-addpassword?view=graph-rest-1.0&tabs=http#request
+        #>
+
+        $getAadApplicationParams = @{
+            AzAccountsObject     = $AzAccountsObject
+            AzureApplicationName = $AzureApplicationName
+            GraphApiUrl          = $GraphApiUrl
+        }
+        $getAadApplicationResponse = GetAzureApplication @getAadApplicationParams
+
+        if ($null -eq $getAadApplicationResponse) {
+            Write-Host "Something went wrong while querying the Azure application" -ForegroundColor Red
+            exit
+        } elseif ([System.String]::IsNullOrEmpty($getAadApplicationResponse.value.id)) {
+            Write-Host "No Azure application found with the name: $AzureApplicationName. Please re-run the script with -CreateAzureApplication to create the application." -ForegroundColor Red
+            exit
+        }
+
+        # Garbage collect expired secrets
+        if ($getAadApplicationResponse.value.passwordCredentials.Count -gt 0) {
+            Write-Host "The Azure application already has application secrets - checking for expired ones..."
+            foreach ($password in $getAadApplicationResponse.value.passwordCredentials) {
+                $endDateTime = [DateTime]::Parse($password.endDateTime).ToUniversalTime()
+                if ($endDateTime -lt (Get-Date).ToUniversalTime()) {
+                    Write-Host "Secret with id: $($password.keyId) has expired since: $endDateTime - deleting it now..."
+                    $deleteAadApplicationPasswordParams = @{
+                        Query              = "applications/$($getAadApplicationResponse.value.id)/removePassword"
+                        AccessToken        = $AzAccountsObject.AccessToken
+                        Body               = @{ "keyId" = $password.keyId } | ConvertTo-Json
+                        Method             = "POST"
+                        ExpectedStatusCode = 204
+                        GraphApiUrl        = $GraphApiUrl
+                    }
+                    $deleteAadApplicationPasswordResponse = Invoke-GraphApiRequest @deleteAadApplicationPasswordParams
+
+                    if ($deleteAadApplicationPasswordResponse.Successful -eq $false) {
+                        Write-Host "Unable to delete secret with id: $($password.keyId) - please delete it manually" -ForegroundColor Yellow
+                    }
                 }
             }
         }
 
-        #Use newly created app to query graphAPI
-        [string]$ClientID = $aadApplication.AppId
+        # Graph API call to create a new application password
+        $newAadApplicationPasswordParams = @{
+            Query       = "applications/$($getAadApplicationResponse.value.id)/addPassword"
+            AccessToken = $AzAccountsObject.AccessToken
+            Body        = @{
+                "passwordCredential" = @{
+                    "displayName" = "AppAccessKey"
+                    "endDateTime" = (Get-Date).AddDays(7).ToString("yyyy-MM-ddTHH:mm:ssZ")
+                }
+            } | ConvertTo-Json
+            Method      = "POST"
+            GraphApiUrl = $GraphApiUrl
+        }
+        $newAadApplicationPasswordResponse = Invoke-GraphApiRequest @newAadApplicationPasswordParams
 
-        Write-Host "Application created with required permissions. Client ID: $ClientID" -ForegroundColor Green
+        if ($newAadApplicationPasswordResponse.Successful -eq $false) {
+            Write-Host "Unable to create the Azure application password" -ForegroundColor Red
+            exit
+        }
+
+        Write-Host "Secret created for Azure application: $AzureApplicationName - waiting 60 seconds for replication..."
+        Start-Sleep -Seconds 60
+        Write-Host "Continuing..."
+
+        return $newAadApplicationPasswordResponse.Content.secretText
+    }
+
+    function DeleteAzureApplication {
+        param(
+            $AzAccountsObject,
+            $AzureApplicationName,
+            $GraphApiUrl
+        )
+
+        <#
+            This function will delete the specified Azure AD application
+            https://docs.microsoft.com/graph/api/application-delete?view=graph-rest-1.0&tabs=http
+        #>
+
+        $getAadApplicationParams = @{
+            AzAccountsObject     = $AzAccountsObject
+            AzureApplicationName = $AzureApplicationName
+            GraphApiUrl          = $GraphApiUrl
+        }
+        $getAadApplicationResponse = GetAzureApplication @getAadApplicationParams
+
+        if ($null -eq $getAadApplicationResponse) {
+            Write-Host "Something went wrong while querying the Azure AD Application" -ForegroundColor Red
+            exit
+        } elseif ([System.String]::IsNullOrEmpty($getAadApplicationResponse.Value.id)) {
+            Write-Host "No application with name: $AzureApplicationName found" -ForegroundColor Red
+            exit
+        }
+
+        $deleteAadApplicationParams = @{
+            Query              = "applications/$($getAadApplicationResponse.value[0].id)"
+            AccessToken        = $AzAccountsObject.AccessToken
+            Method             = "DELETE"
+            ExpectedStatusCode = 204
+            GraphApiUrl        = $GraphApiUrl
+        }
+        $deleteAzureApplicationResponse = Invoke-GraphApiRequest @deleteAadApplicationParams
+
+        if ($deleteAzureApplicationResponse.Successful -eq $false) {
+            Write-Host "Unable to delete the Azure AD application. Please try again or delete it manually." -ForegroundColor Red
+            exit
+        }
+
+        Write-Host "Deleted the Azure application: $AzureApplicationName successfully" -ForegroundColor Green
     }
 
     ## function to check if a given token is expired and renew it
     function CheckTokenExpiry {
-        param (
-            $applicationInfo,
-            [ref]$ewsService,
-            [ref]$token,
+        param(
+            $ApplicationInfo,
+            [ref]$EWSService,
+            [ref]$Token,
             [string]$Environment,
             $EWSOnlineURL,
             $EWSOnlineScope,
@@ -665,36 +809,36 @@ begin {
         # if token is going to expire in next 5 min then refresh it
         if ($null -eq $script:tokenLastRefreshTime -or $script:tokenLastRefreshTime.AddMinutes(55) -lt (Get-Date)) {
             $createOAuthTokenParams = @{
-                TenantID                     = $applicationInfo.TenantID
-                ClientID                     = $applicationInfo.ClientID
+                TenantID                     = $ApplicationInfo.TenantID
+                ClientID                     = $ApplicationInfo.ClientID
                 AzureADEndpoint              = $AzureADEndpoint
-                UseCertificateToAuthenticate = (-not([System.String]::IsNullOrEmpty($applicationInfo.CertificateThumbprint)))
+                UseCertificateToAuthenticate = (-not([System.String]::IsNullOrEmpty($ApplicationInfo.CertificateThumbprint)))
                 Scope                        = $EWSOnlineScope
             }
 
             # Check if we use an app secret or certificate by using regex to match Json Web Token (JWT)
-            if ($applicationInfo.AppSecret -match "^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)") {
+            if ($ApplicationInfo.AppSecret -match "^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)") {
                 $jwtParams = @{
-                    CertificateThumbprint = $applicationInfo.CertificateThumbprint
+                    CertificateThumbprint = $ApplicationInfo.CertificateThumbprint
                     CertificateStore      = "CurrentUser"
-                    Issuer                = $applicationInfo.ClientID
-                    Audience              = ("{0}{1}/oauth2/v2.0/token" -f $AzureADEndpoint, $applicationInfo.TenantID)
-                    Subject               = $applicationInfo.ClientID
+                    Issuer                = $ApplicationInfo.ClientID
+                    Audience              = "$AzureADEndpoint/$($ApplicationInfo.TenantID)/oauth2/v2.0/token"
+                    Subject               = $ApplicationInfo.ClientID
                 }
                 $jwt = Get-NewJsonWebToken @jwtParams
 
                 if ($null -eq $jwt) {
-                    Write-Host "Unable to sign a new Json Web Token by using certificate: $($applicationInfo.CertificateThumbprint)" -ForegroundColor Red
+                    Write-Host "Unable to sign a new Json Web Token by using certificate: $($ApplicationInfo.CertificateThumbprint)" -ForegroundColor Red
                     exit
                 }
 
                 $createOAuthTokenParams.Add("AppSecret", $jwt)
             } else {
-                $createOAuthTokenParams.Add("AppSecret", $applicationInfo.AppSecret)
+                $createOAuthTokenParams.Add("AppSecret", $ApplicationInfo.AppSecret)
             }
 
-            $token.Value = CreateOAUTHToken @createOAuthTokenParams
-            $ewsService.Value = EWSAuth -Environment $Environment -token $token.Value -EWSOnlineURL $EWSOnlineURL
+            $Token.Value = CreateOAUTHToken @createOAuthTokenParams
+            $EWSService.Value = EWSAuth -Environment $Environment -Token $Token.Value -EWSOnlineURL $EWSOnlineURL
         }
     }
 
@@ -766,10 +910,6 @@ begin {
 } end {
     Write-Host ("CVE-2023-23397 script version $($BuildVersion)") -ForegroundColor Green
 
-    if ($null -ne $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core") {
-        throw "Script doesn't support PowerShell Core, must use PowerShell Version 5 or lower"
-    }
-
     if (([System.String]::IsNullOrEmpty($CleanupInfoFilePath)) -and
         ($ScriptUpdateOnly -eq $false) -and
         ($UseSearchFolders -eq $false) -and
@@ -812,12 +952,22 @@ begin {
     }
 
     if ($CreateAzureApplication) {
-        $null = CreateApplication -AzureEnvironmentName $AzureEnvironmentName -AzureApplicationName $AzureApplicationName
+        $createAzureApplicationParams = @{
+            AzAccountsObject     = (Get-GraphAccessToken -AzureADEndpoint $azureADEndpoint -GraphApiUrl $graphApiEndpoint)
+            AzureApplicationName = $AzureApplicationName
+            GraphApiUrl          = $graphApiEndpoint
+        }
+        NewAzureApplication @createAzureApplicationParams
         exit
     }
 
     if ($DeleteAzureApplication) {
-        $null = DeleteApplication -AzureEnvironmentName $AzureEnvironmentName -AzureApplicationName $AzureApplicationName
+        $deleteAzureApplicationParams = @{
+            AzAccountsObject     = (Get-GraphAccessToken -AzureADEndpoint $azureADEndpoint -GraphApiUrl $graphApiEndpoint)
+            AzureApplicationName = $AzureApplicationName
+            GraphApiUrl          = $graphApiEndpoint
+        }
+        DeleteAzureApplication @deleteAzureApplicationParams
         exit
     }
 
@@ -874,38 +1024,39 @@ begin {
     }
 
     if ($Environment -eq "Online") {
-        $getApplicationDetailsParams = @{
-            AzureApplicationName         = $AzureApplicationName
-            AzureEnvironmentName         = $AzureEnvironmentName
-            UseCertificateToAuthenticate = (-not([System.String]::IsNullOrEmpty($CertificateThumbprint)))
-        }
-
         if (([System.String]::IsNullOrEmpty($AppId)) -or
             ([System.String]::IsNullOrEmpty($Organization)) -or
             ([System.String]::IsNullOrEmpty($CertificateThumbprint))) {
-            $application = GetApplicationDetails @getApplicationDetailsParams
+            # We need to query the Azure application information from the Azure AD if not explicitly provided via parameter
+            $azAccountsObject = Get-GraphAccessToken -AzureADEndpoint $azureADEndpoint -GraphApiUrl $graphApiEndpoint
+            $application = GetAzureApplication -AzAccountsObject $azAccountsObject -AzureApplicationName $AzureApplicationName -GraphApiUrl $graphApiEndpoint
 
-            $TenantID = $application.Tenant.Id
-            $ClientID = $application.ClientID
+            $tenantID = $azAccountsObject.TenantId
+            $clientID = $application.value.appId
         } else {
-            $TenantID = $Organization
-            $ClientID = $AppId
+            $tenantID = $Organization
+            $clientID = $AppId
         }
 
         $applicationInfo = @{
-            "TenantID" = $TenantID
-            "ClientID" = $ClientID
+            "TenantID" = $tenantID
+            "ClientID" = $clientID
         }
 
-        if ($null -ne $application.AppSecret) {
-            $applicationInfo.Add("AppSecret", $application.AppSecret)
+        if ([System.String]::IsNullOrEmpty($CertificateThumbprint)) {
+            $secret = NewAzureApplicationAppSecret -AzAccountsObject $azAccountsObject -AzureApplicationName $AzureApplicationName -GraphApiUrl $graphApiEndpoint
+            if ([System.String]::IsNullOrEmpty($secret)) {
+                Write-Host "Unable to generate application secret for Azure application: $AzureApplicationName" -ForegroundColor Red
+                exit
+            }
+            $applicationInfo.Add("AppSecret", $secret)
         } else {
             $jwtParams = @{
                 CertificateThumbprint = $CertificateThumbprint
                 CertificateStore      = "CurrentUser"
-                Issuer                = $ClientID
-                Audience              = ("{0}{1}/oauth2/v2.0/token" -f $AzureADEndpoint, $TenantID)
-                Subject               = $ClientID
+                Issuer                = $clientID
+                Audience              = "$azureADEndpoint/$tenantID/oauth2/v2.0/token"
+                Subject               = $clientID
             }
             $jwt = Get-NewJsonWebToken @jwtParams
 
@@ -919,18 +1070,17 @@ begin {
         }
 
         $createOAuthTokenParams = @{
-            TenantID                     = $TenantID
-            ClientID                     = $ClientID
+            TenantID                     = $tenantID
+            ClientID                     = $clientID
             AppSecret                    = $applicationInfo.AppSecret
-            Scope                        = $EWSOnlineScope
-            AzureADEndpoint              = $AzureADEndpoint
+            Scope                        = $ewsOnlineScope
+            AzureADEndpoint              = $azureADEndpoint
             UseCertificateToAuthenticate = (-not([System.String]::IsNullOrEmpty($CertificateThumbprint)))
         }
 
         #Create OAUTH token
         $EWSToken = CreateOAUTHToken @createOAuthTokenParams
-
-        $ewsService = EWSAuth -Environment $Environment -Token $EWSToken -EWSOnlineURL $EWSOnlineURL
+        $ewsService = EWSAuth -Environment $Environment -Token $EWSToken -EWSOnlineURL $ewsOnlineURL
     } else {
         #Server
         $EWSToken = $null
@@ -994,7 +1144,7 @@ begin {
 
                 try {
                     # Check for token expiry
-                    CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                    CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                     $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
                     if ($SearchFolderCleanup) {
@@ -1062,7 +1212,7 @@ begin {
 
                     try {
                         # Check for token expiry
-                        CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                        CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                         $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
                         [Microsoft.Exchange.WebServices.Data.Item[]]$itemResults = @(GetSearchFolderItemResults $ewsService $userMailbox)
@@ -1098,7 +1248,7 @@ begin {
                         }
 
                         if (-not $IdsProcessed.Contains($item.Item.Id) -and -not [System.String]::IsNullOrEmpty($item.Item.ExtendedProperties[0].Value)) {
-                            CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
+                            CreateCustomCSV -Mailbox $mailAddress -Data $item.Item -CsvPath $csvFileName
                             $rowCount ++
                             if ($rowCount -ge $MaxCSVLength) {
                                 Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
@@ -1129,7 +1279,7 @@ begin {
 
                 try {
                     # Check for token expiry
-                    CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                    CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                     $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
                     $rootFolderId = New-Object Microsoft.Exchange.WebServices.Data.FolderId([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::MsgFolderRoot, $userMailbox)
@@ -1138,7 +1288,7 @@ begin {
                     # Create a new ArrayList to hold the folder
                     $foldersList = New-Object System.Collections.ArrayList
 
-                    GetSubFolders -folder $rootFolder -foldersList $foldersList
+                    GetSubFolders -Folder $rootFolder -FoldersList $foldersList
                 } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
                     Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
                     Write-Host ("Inner Exception: $_") -ForegroundColor Red
@@ -1157,7 +1307,7 @@ begin {
                 foreach ($folder in $foldersList) {
                     try {
                         # Check for token expiry
-                        CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                        CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                         $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
                         $results = $ewsService.FindItems($folder.Id, $searchFilterCollection, $itemView)
                         if ($null -ne $results -and $null -ne $results.Items -and $results.Items.Count -gt 0) {
@@ -1168,7 +1318,7 @@ begin {
 
                         foreach ($item in $items) {
                             if (-not $IdsProcessed.Contains($item.Item.Id) -and -not [System.String]::IsNullOrEmpty($item.Item.ExtendedProperties[0].Value)) {
-                                CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
+                                CreateCustomCSV -Mailbox $mailAddress -Data $item.Item -CsvPath $csvFileName
                                 $rowCount ++
                                 if ($rowCount -ge $MaxCSVLength) {
                                     Write-Host ("The csv file has reached it's maximum limit of $MaxCSVLength rows... aborting... Please apply appropriate filters to reduce the result size")
@@ -1261,9 +1411,9 @@ begin {
 
             if ($null -ne $entry.Cleanup -and $entry.Cleanup.ToLower() -eq "y") {
                 # Check for token expiry
-                CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                 $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $entry.Mailbox)
-                $item = FindItem -exchangeService $ewsService -Id $entry.Id
+                $item = FindItem -ExchangeService $ewsService -Id $entry.Id
                 if ($null -ne $item) {
                     try {
                         if ($CleanupAction -eq "ClearItem") {
@@ -1275,7 +1425,7 @@ begin {
                                 continue
                             }
 
-                            CheckTokenExpiry -Environment $Environment -token ([ref]$EWSToken) -ewsService ([ref]$ewsService) -applicationInfo $applicationInfo -EWSOnlineURL $EWSOnlineURL -EWSOnlineScope $EWSOnlineScope -AzureADEndpoint $AzureADEndpoint
+                            CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
                             $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $entry.Mailbox)
 
                             if ($entry.ItemType -eq "Calendar") {

--- a/Shared/AzureFunctions/Convert-JsonWebTokenToObject.ps1
+++ b/Shared/AzureFunctions/Convert-JsonWebTokenToObject.ps1
@@ -1,0 +1,68 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Convert-JsonWebTokenToObject {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern("^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)")]
+        [string]$Token
+    )
+
+    <#
+        This function can be used to split a JSON web token (JWT) into its header, payload, and signature.
+        The JWT is expected to be in the format of <header>.<payload>.<signature>.
+        The function returns a PSCustomObject with the following properties:
+            Header    - The header of the JWT
+            Payload   - The payload of the JWT
+            Signature - The signature of the JWT
+
+            It returns $null if the JWT is not in the expected format or conversion fails.
+    #>
+
+    begin {
+        Write-Verbose "Calling $($MyInvocation.MyCommand)"
+        function ConvertJwtFromBase64StringWithoutPadding {
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$Jwt
+            )
+            $Jwt = ($Jwt.Replace("-", "+")).Replace("_", "/")
+            switch ($Jwt.Length % 4) {
+                0 { return [System.Convert]::FromBase64String($Jwt) }
+                2 { return [System.Convert]::FromBase64String($Jwt + "==") }
+                3 { return [System.Convert]::FromBase64String($Jwt + "=") }
+                default { throw "The JWT is not a valid Base64 string." }
+            }
+        }
+    }
+    process {
+        $tokenParts = $Token.Split(".")
+        $tokenHeader = $tokenParts[0]
+        $tokenPayload = $tokenParts[1]
+        $tokenSignature = $tokenParts[2]
+
+        Write-Verbose "Now processing token header..."
+        $tokenHeaderDecoded = [System.Text.Encoding]::UTF8.GetString((ConvertJwtFromBase64StringWithoutPadding $tokenHeader))
+
+        Write-Verbose "Now processing token payload..."
+        $tokenPayloadDecoded = [System.Text.Encoding]::UTF8.GetString((ConvertJwtFromBase64StringWithoutPadding $tokenPayload))
+
+        Write-Verbose "Now processing token signature..."
+        $tokenSignatureDecoded = [System.Text.Encoding]::UTF8.GetString((ConvertJwtFromBase64StringWithoutPadding $tokenSignature))
+    }
+    end {
+        if (($null -ne $tokenHeaderDecoded) -and
+            ($null -ne $tokenPayloadDecoded) -and
+            ($null -ne $tokenSignatureDecoded)) {
+            Write-Verbose "Conversion of the token was successful"
+            return [PSCustomObject]@{
+                Header    = ($tokenHeaderDecoded | ConvertFrom-Json)
+                Payload   = ($tokenPayloadDecoded | ConvertFrom-Json)
+                Signature = $tokenSignatureDecoded
+            }
+        }
+
+        Write-Verbose "Conversion of the token failed"
+        return $null
+    }
+}

--- a/Shared/AzureFunctions/Get-CloudServiceEndpoint.ps1
+++ b/Shared/AzureFunctions/Get-CloudServiceEndpoint.ps1
@@ -1,0 +1,69 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-CloudServiceEndpoint {
+    [CmdletBinding()]
+    param(
+        [string]$EndpointName
+    )
+
+    <#
+        This shared function is used to get the endpoints for the Azure and Microsoft 365 services.
+        It returns a PSCustomObject with the following properties:
+            GraphApiEndpoint: The endpoint for the Microsoft Graph API
+            ExchangeOnlineEndpoint: The endpoint for Exchange Online
+            AutoDiscoverSecureName: The endpoint for Autodiscover
+            AzureADEndpoint: The endpoint for Azure Active Directory
+            EnvironmentName: The name of the Azure environment
+    #>
+
+    begin {
+        Write-Verbose "Calling $($MyInvocation.MyCommand)"
+    }
+    process {
+        # https://learn.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+        switch ($EndpointName) {
+            "Global" {
+                $environmentName = "AzureCloud"
+                $graphApiEndpoint = "https://graph.microsoft.com"
+                $exchangeOnlineEndpoint = "https://outlook.office.com"
+                $autodiscoverSecureName = "https://autodiscover-s.outlook.com"
+                $azureADEndpoint = "https://login.microsoftonline.com"
+                break
+            }
+            "USGovernmentL4" {
+                $environmentName = "AzureUSGovernment"
+                $graphApiEndpoint = "https://graph.microsoft.us"
+                $exchangeOnlineEndpoint = "https://outlook.office365.us"
+                $autodiscoverSecureName = "https://autodiscover-s.office365.us"
+                $azureADEndpoint = "https://login.microsoftonline.us"
+                break
+            }
+            "USGovernmentL5" {
+                $environmentName = "AzureUSGovernment"
+                $graphApiEndpoint = "https://dod-graph.microsoft.us"
+                $exchangeOnlineEndpoint = "https://outlook-dod.office365.us"
+                $autodiscoverSecureName = "https://autodiscover-s-dod.office365.us"
+                $azureADEndpoint = "https://login.microsoftonline.us"
+                break
+            }
+            "ChinaCloud" {
+                $environmentName = "AzureChinaCloud"
+                $graphApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
+                $exchangeOnlineEndpoint = "https://partner.outlook.cn"
+                $autodiscoverSecureName = "https://autodiscover-s.partner.outlook.cn"
+                $azureADEndpoint = "https://login.partner.microsoftonline.cn"
+                break
+            }
+        }
+    }
+    end {
+        return [PSCustomObject]@{
+            EnvironmentName        = $environmentName
+            GraphApiEndpoint       = $graphApiEndpoint
+            ExchangeOnlineEndpoint = $exchangeOnlineEndpoint
+            AutoDiscoverSecureName = $autodiscoverSecureName
+            AzureADEndpoint        = $azureADEndpoint
+        }
+    }
+}

--- a/Shared/AzureFunctions/Get-GraphAccessToken.ps1
+++ b/Shared/AzureFunctions/Get-GraphAccessToken.ps1
@@ -1,0 +1,95 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\Convert-JsonWebTokenToObject.ps1
+. $PSScriptRoot\Get-NewS256CodeChallengeVerifier.ps1
+. $PSScriptRoot\..\Helpers\Start-LocalListener.ps1
+. $PSScriptRoot\..\ScriptUpdateFunctions\Invoke-WebRequestWithProxyDetection.ps1
+
+function Get-GraphAccessToken {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$AzureADEndpoint = "https://login.microsoftonline.com",
+
+        [Parameter(Mandatory = $false)]
+        [string]$GraphApiUrl = "https://graph.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Scope = "$($GraphApiUrl)//AuditLog.Read.All Directory.AccessAsUser.All email openid profile"
+    )
+
+    <#
+        This function is used to get an access token for the Azure Graph API by using the OAuth 2.0 authorization code flow
+        with PKCE (Proof Key for Code Exchange). The OAuth 2.0 authorization code grant type, or auth code flow,
+        enables a client application to obtain authorized access to protected resources like web APIs.
+        The auth code flow requires a user-agent that supports redirection from the authorization server
+        (the Microsoft identity platform) back to your application.
+
+        More information about the auth code flow with PKCE can be found here:
+        https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#protocol-details
+    #>
+
+    begin {
+        Write-Verbose "Calling $($MyInvocation.MyCommand)"
+
+        $clientId = "1950a258-227b-4e31-a9cf-717495945fc2" # Well-known Microsoft Azure PowerShell application ID
+        $responseType = "code" # Provides the code as a query string parameter on our redirect URI
+        $prompt = "select_account" # We want to show the select account dialog
+        $redirectUri = "http://localhost:8004" # This is the default port for the local listener
+        $codeChallengeMethod = "S256" # The code challenge method is S256 (SHA256)
+        $codeChallengeVerifier = Get-NewS256CodeChallengeVerifier
+        $state = ([guid]::NewGuid()).Guid
+        $connectionSuccessful = $false
+    }
+    process {
+        $codeChallenge = $codeChallengeVerifier.CodeChallenge
+        $codeVerifier = $codeChallengeVerifier.Verifier
+
+        # Request an authorization code from the Microsoft Azure Active Directory endpoint
+        $authCodeRequestUrl = "$AzureADEndpoint/organizations/oauth2/v2.0/authorize?client_id=$clientId" +
+        "&response_type=$responseType&redirect_uri=$redirectUri&scope=$scope&state=$state&prompt=$prompt" +
+        "&code_challenge_method=$codeChallengeMethod&code_challenge=$codeChallenge"
+
+        Start-Process -FilePath $authCodeRequestUrl
+        $authCodeResponse = Start-LocalListener
+
+        if ($null -ne $authCodeResponse) {
+            # Redeem the returned code for an access token
+            $redeemAuthCodeParams = @{
+                Uri             = "$AzureADEndpoint/organizations/oauth2/v2.0/token"
+                Method          = "POST"
+                ContentType     = "application/x-www-form-urlencoded"
+                Body            = @{
+                    client_id     = $clientId
+                    scope         = $scope
+                    code          = ($($authCodeResponse.Split("=")[1]).Split("&")[0])
+                    redirect_uri  = $redirectUri
+                    grant_type    = "authorization_code"
+                    code_verifier = $codeVerifier
+                }
+                UseBasicParsing = $true
+            }
+            $redeemAuthCodeResponse = Invoke-WebRequestWithProxyDetection -ParametersObject $redeemAuthCodeParams
+
+            if ($redeemAuthCodeResponse.StatusCode -eq 200) {
+                $tokens = $redeemAuthCodeResponse.Content | ConvertFrom-Json
+                $connectionSuccessful = $true
+            } else {
+                Write-Host "Unable to redeem the authorization code for an access token." -ForegroundColor Red
+            }
+        } else {
+            Write-Host "Unable to acquire an authorization code from the Microsoft Azure Active Directory endpoint." -ForegroundColor Red
+        }
+    }
+    end {
+        if ($connectionSuccessful) {
+            return [PSCustomObject]@{
+                AccessToken = $tokens.access_token
+                TenantId    = (Convert-JsonWebTokenToObject $tokens.id_token).Payload.tid
+            }
+        }
+
+        exit
+    }
+}

--- a/Shared/AzureFunctions/Get-NewS256CodeChallengeVerifier.ps1
+++ b/Shared/AzureFunctions/Get-NewS256CodeChallengeVerifier.ps1
@@ -1,0 +1,58 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-NewS256CodeChallengeVerifier {
+    param()
+
+    <#
+        This function can be used to generate a new SHA256 code challenge and verifier following the PKCE specification.
+        The Proof Key for Code Exchange (PKCE) extension describes a technique for public clients to mitigate the threat
+        of having the authorization code intercepted. The technique involves the client first creating a secret,
+        and then using that secret again when exchanging the authorization code for an access token.
+
+        The function returns a PSCustomObject with the following properties:
+        Verifier: The verifier that was generated
+        CodeChallenge: The code challenge that was generated
+
+        It returns $null if the code challenge and verifier generation fails.
+
+        More information about the auth code flow with PKCE can be found here:
+        https://www.rfc-editor.org/rfc/rfc7636
+    #>
+
+    Write-Verbose "Calling $($MyInvocation.MyCommand)"
+
+    $bytes = [System.Byte[]]::new(64)
+    ([System.Security.Cryptography.RandomNumberGenerator]::Create()).GetBytes($bytes)
+    $b64String = [Convert]::ToBase64String($bytes)
+    $verifier = (($b64String.TrimEnd("=")).Replace("+", "-")).Replace("/", "_")
+
+    $newMemoryStream = [System.IO.MemoryStream]::new()
+    $newStreamWriter = [System.IO.StreamWriter]::new($newMemoryStream)
+    $newStreamWriter.write($verifier)
+    $newStreamWriter.Flush()
+    $newMemoryStream.Position = 0
+    $hash = Get-FileHash -InputStream $newMemoryStream | Select-Object Hash
+    $hex = $hash.Hash
+
+    $bytesArray = [byte[]]::new($hex.Length / 2)
+
+    for ($i = 0; $i -lt $hex.Length; $i+=2) {
+        $bytesArray[$i/2] = [Convert]::ToByte($hex.Substring($i, 2), 16)
+    }
+
+    $base64Encoded = [Convert]::ToBase64String($bytesArray)
+    $base64UrlEncoded = (($base64Encoded.TrimEnd("=")).Replace("+", "-")).Replace("/", "_")
+
+    if ((-not([System.String]::IsNullOrEmpty($verifier))) -and
+        (-not([System.String]::IsNullOrEmpty(($base64UrlEncoded))))) {
+        Write-Verbose "Verifier and CodeChallenge generated successfully"
+        return [PSCustomObject]@{
+            Verifier      = $verifier
+            CodeChallenge = $base64UrlEncoded
+        }
+    }
+
+    Write-Verbose "Verifier and CodeChallenge generation failed"
+    return $null
+}

--- a/Shared/AzureFunctions/Invoke-GraphApiRequest.ps1
+++ b/Shared/AzureFunctions/Invoke-GraphApiRequest.ps1
@@ -1,0 +1,85 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\ScriptUpdateFunctions\Invoke-WebRequestWithProxyDetection.ps1
+
+function Invoke-GraphApiRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Query,
+
+        [ValidateSet("v1.0", "beta")]
+        [Parameter(Mandatory = $false)]
+        [string]$Endpoint = "v1.0",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Method = "GET",
+
+        [Parameter(Mandatory = $false)]
+        [string]$ContentType = "application/json",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Body,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern("^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)")]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [int]$ExpectedStatusCode = 200,
+
+        [Parameter(Mandatory = $true)]
+        [string]$GraphApiUrl
+    )
+
+    <#
+        This shared function is used to make requests to the Microsoft Graph API.
+        It returns a PSCustomObject with the following properties:
+            Content: The content of the response (converted from JSON to a PSCustomObject)
+            Response: The full response object
+            StatusCode: The status code of the response
+            Successful: A boolean indicating whether the request was successful
+    #>
+
+    begin {
+        Write-Verbose "Calling $($MyInvocation.MyCommand)"
+        $successful = $false
+        $content = $null
+    }
+    process {
+        $graphApiRequestParams = @{
+            Uri             = "$GraphApiUrl/$Endpoint/$($Query.TrimStart("/"))"
+            Header          = @{ Authorization = "Bearer $AccessToken" }
+            Method          = $Method
+            ContentType     = $ContentType
+            UseBasicParsing = $true
+            ErrorAction     = "Stop"
+        }
+
+        if (-not([System.String]::IsNullOrEmpty($Body))) {
+            $graphApiRequestParams.Add("Body", $Body)
+        }
+
+        $graphApiResponse = Invoke-WebRequestWithProxyDetection -ParametersObject $graphApiRequestParams
+
+        if (($null -eq $graphApiResponse) -or
+            ([System.String]::IsNullOrEmpty($graphApiResponse.StatusCode))) {
+            Write-Verbose "Graph API request failed - no response"
+        } elseif ($graphApiResponse.StatusCode -ne $ExpectedStatusCode) {
+            Write-Verbose "Graph API status code $($graphApiResponse.StatusCode) does not match expected status code $ExpectedStatusCode"
+        } else {
+            Write-Verbose "Graph API request successful"
+            $successful = $true
+            $content = $graphApiResponse.Content | ConvertFrom-Json
+        }
+    }
+    end {
+        return [PSCustomObject]@{
+            Content    = $content
+            Response   = $graphApiResponse
+            StatusCode = $graphApiResponse.StatusCode
+            Successful = $successful
+        }
+    }
+}

--- a/Shared/Helpers/Start-LocalListener.ps1
+++ b/Shared/Helpers/Start-LocalListener.ps1
@@ -1,0 +1,83 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Start-LocalListener {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Only non-destructive operations are performed in this function.')]
+    param(
+        [Parameter(Mandatory = $false)]
+        [int]$Port = 8004,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 60,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UrlContains = "code=",
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExpectedHttpMethod = "GET",
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResponseOutput = "Authentication complete. You can return to the application. Feel free to close this browser tab."
+    )
+
+    <#
+        This function is used to start a local listener on the specified port (default: 8004).
+        It will wait for the specified amount of seconds (default: 60) for a request to be made.
+        The function will return the URL of the request that was made.
+    #>
+
+    begin {
+        Write-Verbose "Calling $($MyInvocation.MyCommand)"
+        $url = $null
+        $signalled = $false
+        $listener = New-Object Net.HttpListener
+    }
+    process {
+        $listener.Prefixes.add("http://localhost:$($Port)/")
+        try {
+            Write-Verbose "Starting listener..."
+            Write-Verbose "Listening on port: $($Port)"
+            Write-Verbose "Waiting $($TimeoutSeconds) seconds for request to be made to url that contains: $($UrlContains)"
+            $listener.Start()
+
+            while ($listener.IsListening) {
+                $task = $listener.GetContextAsync()
+                $signalled = $task.AsyncWaitHandle.WaitOne(($TimeoutSeconds * 1000), $true)
+
+                if ($signalled) {
+                    $context = $task.GetAwaiter().GetResult()
+                    $request = $context.Request
+                    $response = $context.Response
+                    $url = $request.RawUrl
+                    $content = [byte[]]@()
+
+                    if (($url.Contains($UrlContains)) -and
+                        ($request.HttpMethod -eq $ExpectedHttpMethod)) {
+                        Write-Verbose "Request made to listener and url that was called is as expected. HTTP Method: $($request.HttpMethod)"
+                        $content = [System.Text.Encoding]::UTF8.GetBytes($ResponseOutput)
+                        $response.StatusCode = 200 # OK
+                        $response.OutputStream.Write($content, 0, $content.Length)
+                        $response.Close()
+                        break
+                    } else {
+                        Write-Verbose "Request made to listener but the url that was called is not as expected. URL: $($url)"
+                        $response.StatusCode = 404 # Not Found
+                        $response.OutputStream.Write($content, 0, $content.Length)
+                        $response.Close()
+                        break
+                    }
+                } else {
+                    Write-Verbose "Timeout of $($TimeoutSeconds) seconds reached..."
+                    break
+                }
+            }
+        } finally {
+            Write-Verbose "Stopping listener..."
+            Start-Sleep -Seconds 2
+            $listener.Stop()
+        }
+    }
+    end {
+        return $url
+    }
+}

--- a/docs/Security/CVE-2023-23397/index.md
+++ b/docs/Security/CVE-2023-23397/index.md
@@ -59,8 +59,6 @@ To run this script in an Exchange Online environment, you need to be a `Global A
 
 Furthermore it is possible to use a certificate to run the script in `Audit` and `Cleanup` mode. This is called `Certificate Based Authentication (CBA)`. The steps are outlined in the [FAQ section](FAQ.md\#what-are-the-required-steps-to-prepare-the-cve-2023-23397application-application-to-support-certificate-based-authentication-cba).
 
-To scan cloud mailboxes, you also need to add the Azure-AD module to PowerShell. See [Install AzureAD PowerShell for Graph](https://learn.microsoft.com/powershell/azure/active-directory/install-adv2?view=azureadps-2.0) for more information.
-
 **NOTE:** The script uses Microsoft.Exchange.WebServices.dll to make EWS calls. The script will try to download the DLL and use it. However, if it is unable to, you will need to download the DLL and specify the path.
 
 #### Steps to Download Microsoft.Exchange.WebServices.dll:
@@ -92,11 +90,8 @@ AzureApplicationName | Provide the name of the application which the script shou
 CertificateThumbprint | Provide the thumbprint of the certificate which was uploaded to the Azure application. The certificate must exist under the 'Cert:\CurrentUser\My' path on the machine. It can only be used if the private key exists and is accessible.
 AppId | Provide the ID of the application which was created in Azure and which is required to run the script in audit or cleanup mode. The ID can be found within the Azure application under 'Overview' and is labeled as: 'Application (client) ID'. If you don't specify this parameter but specify the `CertificateThumbprint` parameter, the script will ask you to logon to query the required information.
 Organization | Provide the ID of your organization. It can be provided in GUID format or by using your onmicrosoft.com domain. If you don't specify this parameter but specify the `CertificateThumbprint` parameter, the script will ask you to logon to query the required information.
-AzureEnvironmentName | Provide the Azure Environment name. This is an optional parameter. The default value is AzureCloud.
+AzureEnvironment | Provide the Azure Environment name. This is an optional parameter. The default value is `Global`.
 MaxCSVLength | Provide the maximum number of rows the script should create in the CSV while running in Audit mode. This is an optional parameter. The default is 200,000.
-AzureADEndpoint | Provide the Azure AD endpoint which the script should contact to get the authentication token for the app. This is an optional parameter. The default is https://login.microsoftonline.com.
-EWSOnlineURL | Provide the EWS endpoint. This is an optional parameter. The default is https://outlook.office365.com/EWS/Exchange.asmx.
-EWSOnlineScope | Provide the EWS online scope. This is an optional parameter. The default is https://outlook.office365.com/.default.
 EWSServerURL | Provide the EWS endpoint. If not provided, the script will make an Autodiscover call to get it. This parameter works only with Exchange Server.
 ScriptUpdateOnly | This optional parameter allows you to only update the script without performing any other actions.
 SkipVersionCheck | This optional parameter allows you to skip the automatic version check and script update.
@@ -107,7 +102,14 @@ SearchFolderCleanup | This parameter cleans up any search folders left behind by
 TimeoutSeconds | This optional parameter specifies the timeout on the EWS ExchangeService object. The default is 300 seconds (5 minutes).
 
 #### Set Exchange Online Cloud Specific values:
-If you are in the worldwide (WW) cloud, the values for AzureEnvironmentName, AzureADEndpoint, EWSOnlineURL, and EWSOnlineScope can be left as default.
+You can use the `AzureEnvironment` parameter to specify the cloud against which the script runs. By default, the script will run against the Global (worldwide) service. Supported values are:
+
+|AzureEnvironment|Cloud Environment|Name                           |
+|----------------|-----------------|-------------------------------|
+|Global          |AzureCloud       |WW                             |
+|USGovernmentL4  |AzureUSGovernment|GCC                            |
+|USGovernmentL5  |AzureUSGovernment|DOD                            |
+|ChinaCloud      |AzureChinaCloud  |Office365 operated by 21Vianet |
 
 ### Running Against Exchange Server (On-Premises) Mailboxes
 


### PR DESCRIPTION
**Description:**
First draft to get rid of using the AzureAD module which will be deprecated soon (June 2023). Another benefit is, that we support PowerShell Core now.

With this change, we do no longer need any external module to perform the required action against Exchange Online.
![image](https://user-images.githubusercontent.com/40993616/229566670-b0ba17f3-97da-45b1-8810-326e61db991f.png)

Resolve #1562 
Resolve #1643 
