### PR TITLE
CVE-2023-23397.ps1 failed to add API permission in Gallatin environment

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -587,7 +587,7 @@ begin {
         Add-AzureADApplicationOwner -ObjectId $aadApplication.ObjectId -RefObjectId $currentUser.ObjectId | Out-Null
 
         #Get Service Principal of MS Graph Resource API
-        $ews_SP = Get-AzureADServicePrincipal -All $true | Where-Object { $_.DisplayName -eq "Office 365 Exchange Online" }
+        $ews_SP = Get-AzureADServicePrincipal -All $true | Where-Object { $_.AppId -eq "00000002-0000-0ff1-ce00-000000000000" }
 
         #Initialize RequiredResourceAccess for Microsoft Graph Resource API
         $requiredAccess = New-Object Microsoft.Open.AzureAD.Model.RequiredResourceAccess


### PR DESCRIPTION
Describe the issue
Run .\https://github.com/advisories/GHSA-4778-q233-jmh5.ps1 -CreateAzureApplication -AzureEnvironmentName AzureChinaCloud
Application was created but the full_access_as_app permission was failed to add.

Expected behavior
full_access_as_app permission should be added to the application.

Script Output
No warning message for this.

Additional context
We found the name of Exchange APP is "Microsoft.Exchange" in Gallatin instead of "Office 365 Exchange Online" in WW.
So we should consider use Application ID instead of DisplayName in the following codes:
#Get Service Principal of MS Graph Resource API
$ews_SP = Get-AzureADServicePrincipal -All $true | Where-Object { $_.DisplayName -eq "Office 365 Exchange Online" }

Snapshot:
![image](https://user-images.githubusercontent.com/1555117/229033898-1b0c695f-ca15-442e-991d-30392f148e32.png)
