### PR TITLE
Don't include date filter in search folder criteria

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -949,12 +949,12 @@ begin {
 
         $searchFilterCollection = New-Object Microsoft.Exchange.WebServices.Data.SearchFilter+SearchFilterCollection
 
-        if ($null -ne $StartTimeFilter) {
+        if ($null -ne $StartTimeFilter -and -not $UseSearchFolders) {
             $searchFilterStartTime = New-Object Microsoft.Exchange.WebServices.Data.SearchFilter+IsGreaterThan([Microsoft.Exchange.WebServices.Data.ItemSchema]::DateTimeCreated, $StartTimeFilter)
             $searchFilterCollection.Add($searchFilterStartTime)
         }
 
-        if ($null -ne $EndTimeFilter) {
+        if ($null -ne $EndTimeFilter -and -not $UseSearchFolders) {
             $searchFilterEndTime = New-Object Microsoft.Exchange.WebServices.Data.SearchFilter+IsLessThan([Microsoft.Exchange.WebServices.Data.ItemSchema]::DateTimeCreated, $EndTimeFilter)
             $searchFilterCollection.Add($searchFilterEndTime)
         }
@@ -1089,6 +1089,14 @@ begin {
                     $items = $ewsService.LoadPropertiesForItems($itemResults, $PropertySet)
 
                     foreach ($item in $items) {
+                        if ($null -ne $StartTimeFilter -and $item.Item.DateTimeReceived -lt $StartTimeFilter) {
+                            continue
+                        }
+
+                        if ($null -ne $EndTimeFilter -and $item.Item.DateTimeReceived -gt $EndTimeFilter) {
+                            continue
+                        }
+
                         if (-not $IdsProcessed.Contains($item.Item.Id) -and -not [System.String]::IsNullOrEmpty($item.Item.ExtendedProperties[0].Value)) {
                             CreateCustomCSV -mailbox $mailAddress -data $item.Item -CsvPath $csvFileName
                             $rowCount ++


### PR DESCRIPTION
Currently, if -StartTimeFilter or -EndTimeFilter is provided in combination with -UseSearchFolders, the results can be unexpected., because the search criteria is set at the time of search folder creation, and it never changes. Thus, the script always returns results based on the time filters provided during the first run against a given mailbox. Even if subsequent runs use different filters, the results never change, unless the search folders are cleaned up.

In this PR, we no longer include the time filters in the search folder criteria. The search folders will always contain all items that have the PidLidReminderFileParameter property. The script reads those results and then filters them if the time filter parameters are provided. This way, the script can be repeatedly run with different filters and return the correct results without having to recreate the search folders.