### PR TITLE
Add -SkipSearchFolderCreation switch

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -67,6 +67,8 @@
     This switch causes the script to use deep-traversal search folders, significantly improving performance.
 .PARAMETER SearchFolderCleanup
     Clean up any search folders left behind by the -UseSearchFolders switch.
+.PARAMETER SkipSearchFolderCreation
+    Skip the first pass of -UseSearchFolders and just check the existing search folders for results.
 .PARAMETER TimeoutSeconds
     This optional parameter lets you specify the timeout value for the ExchangeService object. Defaults to 5 minutes.
 .EXAMPLE
@@ -174,6 +176,9 @@ param(
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [switch]$SearchFolderCleanup,
+
+    [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
+    [switch]$SkipSearchFolderCreation,
 
     [Parameter(Mandatory = $false, ParameterSetName = "Audit")]
     [Parameter(Mandatory = $false, ParameterSetName = "Cleanup")]
@@ -884,7 +889,7 @@ begin {
 
         $searchFolders = @(GetSearchFolder $ewsService $userMailbox)
         if ($searchFolders.Count -lt 1) {
-            Write-Host "Search folder missing. Could not get results."
+            Write-Warning "Search folder missing. Could not get results."
             return
         }
 
@@ -909,6 +914,17 @@ begin {
     }
 } end {
     Write-Host ("CVE-2023-23397 script version $($BuildVersion)") -ForegroundColor Green
+
+    # Using either of these switches implies -UseSearchFolders
+    if ($SearchFolderCleanup -or $SkipSearchFolderCreation) {
+        # But using them together is not valid
+        if ($SearchFolderCleanup -and $SkipSearchFolderCreation) {
+            Write-Host "The -SearchFolderCleanup and -SkipSearchFolderCreation switches cannot be used together."
+            exit
+        }
+
+        $UseSearchFolders = $true
+    }
 
     if (([System.String]::IsNullOrEmpty($CleanupInfoFilePath)) -and
         ($ScriptUpdateOnly -eq $false) -and
@@ -1128,58 +1144,60 @@ begin {
 
             $searchFolderCreationTimer = $null
 
-            foreach ($mailAddress in $mailAddresses) {
-                $ewsService.HttpHeaders.Clear()
-                $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
-                Write-Host ("$actionText search folders in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
+            if (-not $SkipSearchFolderCreation) {
+                foreach ($mailAddress in $mailAddresses) {
+                    $ewsService.HttpHeaders.Clear()
+                    $ewsService.HttpHeaders.Add("X-AnchorMailbox", $mailAddress)
+                    Write-Host ("$actionText search folders in $($mailboxProcessed + 1) of $($mailAddresses.Count) mailboxes (currently: $mailAddress)")
 
-                $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
+                    $userMailbox = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($mailAddress)
 
-                if ($null -eq $userMailbox) {
-                    Write-Host ("Unable to get mailbox associated with mail address $mailAddress")
-                    $failedMailboxes.Add($mailAddress)
-                    $mailboxProcessed += 1
-                    continue
-                }
-
-                try {
-                    # Check for token expiry
-                    CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
-                    $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
-
-                    if ($SearchFolderCleanup) {
-                        RemoveSearchFolder $ewsService $userMailbox
+                    if ($null -eq $userMailbox) {
+                        Write-Host ("Unable to get mailbox associated with mail address $mailAddress")
+                        $failedMailboxes.Add($mailAddress)
                         $mailboxProcessed += 1
                         continue
                     }
 
-                    $searchFolders = GetSearchFolder $ewsService $userMailbox
+                    try {
+                        # Check for token expiry
+                        CheckTokenExpiry -Environment $Environment -Token ([ref]$EWSToken) -EWSService ([ref]$ewsService) -ApplicationInfo $applicationInfo -EWSOnlineURL $ewsOnlineURL -EWSOnlineScope $ewsOnlineScope -AzureADEndpoint $azureADEndpoint
+                        $ewsService.ImpersonatedUserId = New-Object Microsoft.Exchange.WebServices.Data.ImpersonatedUserId([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $mailAddress)
 
-                    if ($searchFolders.Count -gt 0) {
-                        Write-Host "  Search folder already exists in this mailbox."
+                        if ($SearchFolderCleanup) {
+                            RemoveSearchFolder $ewsService $userMailbox
+                            $mailboxProcessed += 1
+                            continue
+                        }
+
+                        $searchFolders = GetSearchFolder $ewsService $userMailbox
+
+                        if ($searchFolders.Count -gt 0) {
+                            Write-Host "  Search folder already exists in this mailbox."
+                            $mailboxProcessed += 1
+                            continue
+                        }
+
+                        # Create a new search folder
+                        if ($null -eq $searchFolderCreationTimer) {
+                            $searchFolderCreationTimer = New-Object System.Diagnostics.Stopwatch
+                            $searchFolderCreationTimer.Start()
+                        }
+
+                        NewSearchFolder $ewsService $userMailbox
+                        $mailboxProcessed += 1
+                    } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
+                        Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
+                        Write-Host ("Inner Exception: $_") -ForegroundColor Red
+                        $failedMailboxes.Add($mailAddress)
+                        $mailboxProcessed += 1
+                        continue
+                    } catch {
+                        Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
+                        $failedMailboxes.Add($mailAddress)
                         $mailboxProcessed += 1
                         continue
                     }
-
-                    # Create a new search folder
-                    if ($null -eq $searchFolderCreationTimer) {
-                        $searchFolderCreationTimer = New-Object System.Diagnostics.Stopwatch
-                        $searchFolderCreationTimer.Start()
-                    }
-
-                    NewSearchFolder $ewsService $userMailbox
-                    $mailboxProcessed += 1
-                } catch [Microsoft.Exchange.WebServices.Data.ServiceResponseException] {
-                    Write-Host ("Unable to access mailbox: $mailAddress") -ForegroundColor Red
-                    Write-Host ("Inner Exception: $_") -ForegroundColor Red
-                    $failedMailboxes.Add($mailAddress)
-                    $mailboxProcessed += 1
-                    continue
-                } catch {
-                    Write-Host ("Unable to process mailbox $mailAddress as it seems to be inaccessible. Inner Exception:`n`n$_") -ForegroundColor Red
-                    $failedMailboxes.Add($mailAddress)
-                    $mailboxProcessed += 1
-                    continue
                 }
             }
 

--- a/docs/Security/CVE-2023-23397/index.md
+++ b/docs/Security/CVE-2023-23397/index.md
@@ -99,6 +99,7 @@ IgnoreCertificateMismatch | This optional parameter lets you ignore TLS certific
 Credential | This optional parameter lets you pass admin credentials when running on Exchange Server.
 UseSearchFolders | This parameter causes the script to use deep-traversal search folders, significantly improving performance.
 SearchFolderCleanup | This parameter cleans up any search folders left behind by the asynchronous search feature. It must be used together with the `UseSearchFolders` parameter.
+SkipSearchFolderCreation | This parameter skips the creation of search folders. It must be used together with the `UseSearchFolders` parameter.
 TimeoutSeconds | This optional parameter specifies the timeout on the EWS ExchangeService object. The default is 300 seconds (5 minutes).
 
 #### Set Exchange Online Cloud Specific values:


### PR DESCRIPTION
Users should have the ability to skip the first pass of -UseSearchFolders when the search folders already exist. If we fail to find the search folder, that is now logged as a warning instead of informational.

This change also makes the syntax more forgiving. Passing -SearchFolderCleanup or -SkipSearchFolderCreation now implies -UseSearchFolders.

Fixes #1663.

![image](https://user-images.githubusercontent.com/4518572/232602076-57d95adb-c57d-4c01-a60f-93672fafcbe5.png)
