### PR TITLE
Auto-update does no longer work due to newly introduced Invoke-WebRequestWithProxyDetection ParametersObjectparameter

### DIFF
--- a/Shared/ScriptUpdateFunctions/Get-ScriptUpdateAvailable.ps1
+++ b/Shared/ScriptUpdateFunctions/Get-ScriptUpdateAvailable.ps1
@@ -33,7 +33,7 @@ function Get-ScriptUpdateAvailable {
         Write-Warning "This script appears to be an unsigned test build. Skipping version check."
     } else {
         try {
-            $versionData = [Text.Encoding]::UTF8.GetString((Invoke-WebRequestWithProxyDetection $VersionsUrl -UseBasicParsing).Content) | ConvertFrom-Csv
+            $versionData = [Text.Encoding]::UTF8.GetString((Invoke-WebRequestWithProxyDetection -Uri $VersionsUrl -UseBasicParsing).Content) | ConvertFrom-Csv
             $latestVersion = ($versionData | Where-Object { $_.File -eq $scriptName }).Version
             $result.LatestVersion = $latestVersion
             if ($null -ne $latestVersion) {

--- a/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
+++ b/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
@@ -32,7 +32,7 @@ function Invoke-ScriptUpdate {
 
     if ($PSCmdlet.ShouldProcess("$scriptName", "Update script to latest version")) {
         try {
-            Invoke-WebRequestWithProxyDetection "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$scriptName" -OutFile $tempFullName
+            Invoke-WebRequestWithProxyDetection -Uri "https://github.com/microsoft/CSS-Exchange/releases/latest/download/$scriptName" -OutFile $tempFullName
         } catch {
             Write-Warning "AutoUpdate: Failed to download update: $($_.Exception.Message)"
             return $false


### PR DESCRIPTION
**Issue/Reason:**
```
VERBOSE: Error Index: 0
VERBOSE: Invoke-WebRequestWithProxyDetection : A positional parameter cannot be found that accepts argument
'https://aka.ms/HC-VersionsUrl'.
VERBOSE: Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext
 funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
VERBOSE: Position Message: At C:\Temp\test\HealthChecker.ps1:13741 char:61
+ ... .GetString((Invoke-WebRequestWithProxyDetection $VersionsUrl -UseBasi ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
VERBOSE: Script Stack: at Get-ScriptUpdateAvailable, C:\Temp\test\HealthChecker.ps1: line 13741
at Test-ScriptVersion, C:\Temp\test\HealthChecker.ps1: line 13897
at <ScriptBlock><End>, C:\Temp\test\HealthChecker.ps1: line 13982                                                       at <ScriptBlock>, <No file>: line 1                                                                                     VERBOSE: -----------------------------------                                                                                                                                                                                                    VERBOSE:
```

With PR #1638 we added a new parameter `ParametersObjectparameter` to the shared function `Invoke-WebRequestWithProxyDetection`. As we call the `Invoke-WebRequestWithProxyDetection` function in `Invoke-ScriptUpdate` without the `Uri` parameter, we fail to properly assign it to the expected ParameterSet causing the issue.

**Fix:**
Explicitly pass the Uri by defining the `Uri` parameter

**Validation:**
Lab

