### PR TITLE
Addressed CU13 being latest SU as well

### DIFF
--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -126,6 +126,7 @@ function Get-ExchangeBuildVersionInformation {
                     $cuLevel = "CU13"
                     $cuReleaseDate = "05/03/2023"
                     $supportedBuildNumber = $true
+                    $latestSUBuild = $true
                 }
                 { $_ -lt (GetBuildVersion $ex19 "CU13") } {
                     $cuLevel = "CU12"

--- a/Shared/Tests/Get-ExchangeBuildVersionInformation.Tests.ps1
+++ b/Shared/Tests/Get-ExchangeBuildVersionInformation.Tests.ps1
@@ -100,31 +100,31 @@ Describe "Testing Get-ExchangeBuildVersionInformation.ps1" {
         It "Exchange 2013 CU23" {
             $results = Get-ExchangeBuildVersionInformation -Version "Exchange2013" -CU "CU23"
             $results.BuildVersion.ToString() | Should -Be "15.0.1497.2"
-            $results.FriendlyName  | Should -Be "Exchange 2013 CU23"
+            $results.FriendlyName | Should -Be "Exchange 2013 CU23"
         }
 
         It "Exchange 2013 CU23 Jan23SU" {
             $results = Get-ExchangeBuildVersionInformation -Version "Exchange2013" -CU "CU23" -SU "Jan23SU"
             $results.BuildVersion.ToString() | Should -Be "15.0.1497.45"
-            $results.FriendlyName  | Should -Be "Exchange 2013 CU23 Jan23SU"
+            $results.FriendlyName | Should -Be "Exchange 2013 CU23 Jan23SU"
         }
 
         It "Exchange 2016 CU22" {
             $results = Get-ExchangeBuildVersionInformation -Version "Exchange2016" -CU "CU22"
             $results.BuildVersion.ToString() | Should -Be "15.1.2375.7"
-            $results.FriendlyName  | Should -Be "Exchange 2016 CU22"
+            $results.FriendlyName | Should -Be "Exchange 2016 CU22"
         }
 
         It "Exchange 2016 CU22 Jan23SU - Should Be CU22 Base" {
             $results = Get-ExchangeBuildVersionInformation -Version "Exchange2016" -CU "CU22" -SU "Jan23SU"
             $results.BuildVersion.ToString() | Should -Be "15.1.2375.7"
-            $results.FriendlyName  | Should -Be "Exchange 2016 CU22"
+            $results.FriendlyName | Should -Be "Exchange 2016 CU22"
         }
 
         It "Exchange 2019 CU12" {
             $results = Get-ExchangeBuildVersionInformation -Version "Exchange2019" -CU "CU12"
             $results.BuildVersion.ToString() | Should -Be "15.2.1118.7"
-            $results.FriendlyName  | Should -Be "Exchange 2019 CU12"
+            $results.FriendlyName | Should -Be "Exchange 2019 CU12"
         }
 
         It "Exchange 2019 CU23 - Should be NULL" {
@@ -137,6 +137,114 @@ Describe "Testing Get-ExchangeBuildVersionInformation.ps1" {
         It "Nov22SU" {
             $results = Get-ExchangeBuildVersionInformation -FindBySUName "Nov22SU"
             $results.Count | Should -Be 5
+        }
+    }
+
+    # This is to make sure the latest SU do include the flag for latest SU.
+    Context "Latest SU Results" {
+        BeforeAll {
+            $Script:results = @{
+                "Exchange2019" = (GetExchangeBuildDictionary)["Exchange2019"].Values.CU |
+                    ForEach-Object { [System.Version]$_ } |
+                    Sort-Object -Descending |
+                    Select-Object -First 3
+                "Exchange2016" = (GetExchangeBuildDictionary)["Exchange2016"].Values.CU |
+                    ForEach-Object { [System.Version]$_ } |
+                    Sort-Object -Descending |
+                    Select-Object -First 2
+            }
+        }
+        It "Exchange 2019 Latest CU" {
+            $latest3CUs = $Script:results["Exchange2019"]
+
+            # Latest CU in the list check to see if there are SUs
+            $latestCU = Get-ExchangeBuildVersionInformation -FileVersion $latest3CUs[0]
+            $noSUsYet = $null -eq (GetExchangeBuildDictionary)["Exchange2019"][$latestCU.CU].SU
+
+            if ($noSUsYet) {
+                $latestCU.Supported | Should -Be $true
+                $latestCU.LatestSU | Should -Be $true
+            } else {
+                $latestCU.Supported | Should -Be $true
+                $latestCU.LatestSU | Should -Be $false
+
+                # Now we need to find the latest SU
+                $latest2SUs = (GetExchangeBuildDictionary)["Exchange2019"][$latestCU.CU].SU.Values |
+                    ForEach-Object { [System.Version]$_ } |
+                    Sort-Object -Descending |
+                    Select-Object -First 2
+                $latestSU = Get-ExchangeBuildVersionInformation -FileVersion $latest2SUs[0]
+                $latestSU.Supported | Should -Be $true
+                $latestSU.LatestSU | Should -Be $true
+
+                if ($latest2SUs.Count -eq 2) {
+                    $latestSU = Get-ExchangeBuildVersionInformation -FileVersion $latest2SUs[1]
+                    $latestSU.Supported | Should -Be $true
+                    $latestSU.LatestSU | Should -Be $false
+                }
+            }
+        }
+        It "Exchange 2019 Previous CUs" {
+            $latest3CUs = $Script:results["Exchange2019"]
+
+            # Previous CUs should always have SUs.
+            $latestCU = Get-ExchangeBuildVersionInformation -FileVersion $latest3CUs[0]
+            $supportedCU = Get-ExchangeBuildVersionInformation -FileVersion $latest3CUs[1]
+            $unSupportedCU = Get-ExchangeBuildVersionInformation -FileVersion $latest3CUs[2]
+            $noSUsYet = $null -eq (GetExchangeBuildDictionary)["Exchange2019"][$latestCU.CU].SU
+
+            $latestSupportedSUs = (GetExchangeBuildDictionary)["Exchange2019"][$supportedCU.CU].SU.Values |
+                ForEach-Object { [System.Version]$_ } |
+                Sort-Object -Descending |
+                Select-Object -First 2
+
+            $latestSupportedSU = Get-ExchangeBuildVersionInformation -FileVersion $latestSupportedSUs[0]
+            $latestSupportedSU.Supported | Should -Be $true
+            $latestSupportedSU.LatestSU | Should -Be $true
+
+            if ($latestSupportedSUs.Count -eq 2) {
+                $latestSupportedSU = Get-ExchangeBuildVersionInformation -FileVersion $latestSupportedSUs[1]
+                $latestSupportedSU.Supported | Should -Be $true
+                $latestSupportedSU.LatestSU | Should -Be $false
+            }
+
+            $latestUnsupportedSUs = (GetExchangeBuildDictionary)["Exchange2019"][$unSupportedCU.CU].SU.Values |
+                ForEach-Object { [System.Version]$_ } |
+                Sort-Object -Descending |
+                Select-Object -First 2
+
+            $latestUnsupportedSU = Get-ExchangeBuildVersionInformation -FileVersion $latestUnsupportedSUs[0]
+            $latestUnsupportedSU.Supported | Should -Be $false
+            $latestUnsupportedSU.LatestSU | Should -Be ($true -eq $noSUsYet)
+
+            if ($latestUnsupportedSUs.Count -eq 2) {
+                $latestUnsupportedSU = Get-ExchangeBuildVersionInformation -FileVersion $latestUnsupportedSUs[1]
+                $latestUnsupportedSU.Supported | Should -Be $false
+                $latestUnsupportedSU.LatestSU | Should -Be $false
+            }
+        }
+        It "Exchange 2016 Latest SU" {
+            $latest2CUs = $Script:results["Exchange2016"]
+
+            $latestCU = Get-ExchangeBuildVersionInformation -FileVersion $latest2CUs[0]
+            $latestCU.CU | Should -Be "CU23"
+            $latestCU.Supported | Should -Be $true
+            $latestCU.LatestSU | Should -Be $false
+
+            $latest2SUs = (GetExchangeBuildDictionary)["Exchange2016"][$latestCU.CU].SU.Values |
+                ForEach-Object { [System.Version]$_ } |
+                Sort-Object -Descending |
+                Select-Object -First 2
+
+            $latestSU = Get-ExchangeBuildVersionInformation -FileVersion $latest2SUs[0]
+            $latestSU.Supported | Should -Be $true
+            $latestSU.LatestSU | Should -Be $true
+
+            $previousSU = Get-ExchangeBuildVersionInformation -FileVersion $latest2SUs[1]
+            $previousSU.Supported | Should -Be $true
+            $previousSU.LatestSU | Should -Be $false
+
+            (Get-ExchangeBuildVersionInformation -FileVersion $latest2CUs[1]).Supported | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
**Issue:**
Health Checker was reporting that Exchange 2019 CU13 wasn't the latest SU as well. 

**Reason:**
CU13 does contain the latest SU fixes.

**Fix:**
Set the flag for `$latestSUBuild` to `$true` for CU13.
Added in pester testing to make sure that we don't run into this issue again. 

**Validation:**
Lab tested and pester tested
