### PR TITLE
Call out 2013 no longer has SU fixes coming

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -132,6 +132,13 @@ function Invoke-AnalyzerExchangeInformation {
             DisplayCustomTabNumber = 2
         }
         Add-AnalyzedResultInformation @params
+    } elseif ($extendedSupportDate -le ([DateTime]::Now)) {
+        $params = $baseParams + @{
+            Details                = "Latest SU installed. Error: No new SUs available after End of Life. Server might be persistently vulnerable."
+            DisplayWriteType       = "Red"
+            DisplayCustomTabNumber = 2
+        }
+        Add-AnalyzedResultInformation @params
     }
 
     $params = @{


### PR DESCRIPTION
**Reason:**
Change the way Exchange 2013 shows that they are on the latest SU build, but no more security fixes are coming.

![image](https://user-images.githubusercontent.com/22776718/236494949-931023ff-8e70-4946-b096-b9feac63f447.png)


**Validation:**
Lab tested
