### PR TITLE
Fixed a few issues with Troubleshoot-ModernSearch

### DIFF
--- a/Search/Troubleshoot-ModernSearch.ps1
+++ b/Search/Troubleshoot-ModernSearch.ps1
@@ -177,6 +177,8 @@ function Main {
             if ($ExcludeFullyIndexedMailboxes -and
                 $_.FullyIndexPercentage -eq 100) {
                 # Don't add to the list
+            } elseif ($_.TotalBigFunnelSearchableItems -eq 0) {
+                Write-Verbose "Not adding mailbox $($_.MailboxGuid) to list because there are no searchable items"
             } else {
                 return $_
             }

--- a/Search/Troubleshoot-ModernSearch.ps1
+++ b/Search/Troubleshoot-ModernSearch.ps1
@@ -420,6 +420,7 @@ try {
 
     Write-Verbose "Starting Script At: $([DateTime]::Now)"
     Write-Host "Exchange Troubleshot Modern Search Version $BuildVersion"
+    Set-ADServerSettings -ViewEntireForest $true
     Main
     Write-Verbose "Finished Script At: $([DateTime]::Now)"
 

--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-StoreQueryFolderInformation.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-StoreQueryFolderInformation.ps1
@@ -61,6 +61,8 @@ function Get-StoreQueryFolderInformation {
             InvokeGetStoreQuery
 
         foreach ($folder in $folderInformation) {
+            # Log the return display name
+            Write-Verbose "FolderID: $($folder.FolderId) DisplayName: $($folder.DisplayName)"
             $folderList.Add([PSCustomObject]@{
                     FolderId             = $folder.FolderId
                     DisplayName          = $folder.DisplayName


### PR DESCRIPTION
**Issue:**
The script wasn't able to find users because it is likely they are in a different domain and view entire forest wasn't set. Also wasted effort trying to find mailboxes that don't have any possible messages to be indexed.

**Fix:**
- Always set the AD Server Settings to view the Entire Forest.
- Don't include mailboxes that don't have any messages that are indexable. If we really want to know more about those mailboxes, we need to run the script against them.
- Include a debug log to show the display name of a folder lookup for easy review. 

**Validation:**
Lab tested. 

