### PR TITLE
CSS-Exchange download statistics added and logo changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Exchange Server Support Scripts
 
 [![Build Status](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_apis/build/status/microsoft.CSS-Exchange?branchName=release)](https://dev.azure.com/CSS-Exchange-Tools/CSS%20Exchange%20Scripts/_build/latest?definitionId=7&branchName=release)
+[![Download Statistics](https://img.shields.io/github/downloads/microsoft/css-exchange/total.svg?label=Downloads&maxAge=9999)](https://github.com/microsoft/CSS-Exchange/releases/latest)
 
 ## The Repository
 

--- a/docs/images/MicrosoftLogo.svg
+++ b/docs/images/MicrosoftLogo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30"><path fill="#f3f3f3" d="M0 0h23v23H0z"/><path fill="#f35325" d="M1 1h10v10H1z"/><path fill="#81bc06" d="M12 1h10v10H12z"/><path fill="#05a6f0" d="M1 12h10v10H1z"/><path fill="#ffba08" d="M12 12h10v10H12z"/></svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,11 +111,14 @@ theme:
   features:
     - navigation.indexes
     - content.action.edit
+  palette:
+    primary: black
   icon:
     admonition:
       note: octicons/tag-16
       info: octicons/info-16
       warning: octicons/alert-16
+  logo: docs/images/MicrosoftLogo.svg
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
**Description:**
- Download counter added (`readme.md`)
<img width="397" alt="image" src="https://github.com/microsoft/CSS-Exchange/assets/40993616/00e85885-a5be-4414-bbab-951788ceb49b">

- Microsoft logo added to GitHub pages
- Primary color changed to black


