### PR TITLE
Improve credential validation as the display output is misleading if script runs against Exchange on-premises, trying to locate Autodiscover

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -235,6 +235,7 @@ begin {
     . $PSScriptRoot\..\..\..\Shared\Get-NuGetPackage.ps1
     . $PSScriptRoot\..\..\..\Shared\Invoke-ExtractArchive.ps1
     . $PSScriptRoot\..\..\..\Shared\LoggerFunctions.ps1
+    . $PSScriptRoot\..\..\..\Shared\ActiveDirectoryFunctions\Test-ADCredentials.ps1
     . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-GraphAccessToken.ps1
     . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-CloudServiceEndpoint.ps1
     . $PSScriptRoot\..\..\..\Shared\AzureFunctions\Get-NewJsonWebToken.ps1
@@ -293,6 +294,24 @@ begin {
                 CheckOnpremCredentials -EWSService $Service
             } else {
                 try {
+                    $credentialTestResult = Test-ADCredentials -Credentials $credential
+                    if ($credentialTestResult.CredentialsValid) {
+                        Write-Host "Credentials validated successfully." -ForegroundColor Green
+                    } elseif ($credentialTestResult.CredentialsValid -eq $false) {
+                        Write-Host "Credentials that were provided are incorrect." -ForegroundColor Red
+                        exit
+                    } else {
+                        Write-Host "Credentials couldn't be validated. Trying to use the credentials anyway." -ForegroundColor Yellow
+                    }
+
+                    if (($credentialTestResult.UsernameFormat -eq "downlevel") -or
+                        ($credentialTestResult.UsernameFormat -eq "local")) {
+                        Write-Host "Username: $($Credential.UserName) was passed in $($credentialTestResult.UsernameFormat) format" -ForegroundColor Red
+                        Write-Host "You must use the -EWSServerURL parameter if the username is not in UPN (username@domain) format." -ForegroundColor Red
+                        Write-Host "More information: https://aka.ms/CVE-2023-23397ScriptDoc" -ForegroundColor Red
+                        exit
+                    }
+
                     $redirectionCallback = {
                         param([string]$url)
                         return $url.ToLower().StartsWith($autoDSecureName)
@@ -300,16 +319,18 @@ begin {
 
                     $Service.AutodiscoverUrl($Credential.UserName, $redirectionCallback)
                 } catch [Microsoft.Exchange.WebServices.Data.AutodiscoverLocalException] {
-                    Write-Host "Username: $($Credential.UserName) was passed in UPN format but must use a domain which is an accepted domain by Exchange Server." -ForegroundColor Red
-                    Write-Host "You must use the -EWSServerURL parameter if the UPN does not match an email domain used by Exchange." -ForegroundColor Red
+                    Write-Host "Unable to locate the Autodiscover service by using username $($Credential.UserName)" -ForegroundColor Red
+                    Write-Host "A reason could be that the username that was passed uses a domain which is not an accepted domain by Exchange Server." -ForegroundColor Red
+                    Write-Host "You must use the -EWSServerURL parameter if the Autodiscover service cannot be located." -ForegroundColor Red
                     Write-Host "More information: https://aka.ms/CVE-2023-23397ScriptDoc" -ForegroundColor Red
-                    Write-Host "Inner Exception`n`n$_" -ForegroundColor Red
+                    Write-Host "Inner Exception:`n$_" -ForegroundColor Red
                     exit
                 } catch [System.FormatException] {
-                    Write-Host "Username: $($Credential.UserName) was passed in Domain\SamAccountName format" -ForegroundColor Red
-                    Write-Host "You must use the -EWSServerURL parameter if the username is provided in domain\user format." -ForegroundColor Red
+                    # We should no longer get here as we are validating the username format above, however, keeping this as failsafe for now
+                    Write-Host "Username: $($Credential.UserName) was passed in an unexpected format" -ForegroundColor Red
+                    Write-Host "Please try again or use the -EWSServerURL parameter to provide the EWS url." -ForegroundColor Red
                     Write-Host "More information: https://aka.ms/CVE-2023-23397ScriptDoc" -ForegroundColor Red
-                    Write-Host "Inner Exception`n`n$_" -ForegroundColor Red
+                    Write-Host "Inner Exception:`n$_" -ForegroundColor Red
                     exit
                 } catch {
                     Write-Host "Unable to make Autodiscover call to fetch EWS endpoint details. Please make sure you have enter valid credentials. Inner Exception`n`n$_" -ForegroundColor Red

--- a/Shared/ActiveDirectoryFunctions/Test-ADCredentials.ps1
+++ b/Shared/ActiveDirectoryFunctions/Test-ADCredentials.ps1
@@ -1,0 +1,92 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\Invoke-CatchActionError.ps1
+
+function Test-ADCredentials {
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]$Credentials,
+
+        [Parameter(Mandatory = $false)]
+        [ScriptBlock]$CatchActionFunction
+    )
+
+    <#
+        This function tests whether the credentials provided are valid by trying to connect to LDAP server using Kerberos authentication.
+        It returns a PSCustomObject with two properties:
+        - UsernameFormat: "local", "upn" or "downlevel" depending on the format of the username provided
+        - CredentialsValid: $true if the credentials are valid, $false if they are not valid, $null if the function was unable to perform the validation
+    #>
+
+    begin {
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        $credentialsValid = $null
+        # Username formats: https://learn.microsoft.com/windows/win32/secauthn/user-name-formats
+        $usernameFormat = "local"
+        try {
+            Add-Type -AssemblyName System.DirectoryServices.Protocols -ErrorAction Stop
+        } catch {
+            Write-Verbose "Failed to load System.DirectoryServices.Protocols"
+            Write-Verbose "Exception: $_"
+            Invoke-CatchActionError $CatchActionFunction
+        }
+    }
+    process {
+        $domain = $Credentials.GetNetworkCredential().Domain
+        if ([System.String]::IsNullOrEmpty($domain)) {
+            Write-Verbose "Domain is empty which could be an indicator that UPN was passed instead of domain\username"
+            $domain = ($Credentials.GetNetworkCredential().UserName).Split("@")
+            if ($domain.Count -eq 2) {
+                Write-Verbose "Domain was extracted from UPN"
+                $domain = $domain[-1]
+                $usernameFormat = "upn"
+            } else {
+                Write-Verbose "Failed to extract domain from UPN - seems that username was passed without domain and so cannot be validated"
+                $domain = $null
+            }
+        } else {
+            Write-Verbose "Username was provided in down-level logon name format"
+            $usernameFormat = "downlevel"
+        }
+
+        if (-not([System.String]::IsNullOrEmpty($domain))) {
+            $ldapDirectoryIdentifier = New-Object System.DirectoryServices.Protocols.LdapDirectoryIdentifier($domain)
+            # Use Kerberos authentication as NTLM might lead to false/positive results in case the password was changed recently
+            $ldapConnection = New-Object -TypeName System.DirectoryServices.Protocols.LdapConnection($ldapDirectoryIdentifier, $Credentials, [DirectoryServices.Protocols.AuthType]::Kerberos)
+            # Enable Kerberos encryption (sign and seal)
+            $ldapConnection.SessionOptions.Signing = $true
+            $ldapConnection.SessionOptions.Sealing = $true
+            try {
+                $ldapConnection.Bind()
+                Write-Verbose "Connection succeeded with credentials"
+                $credentialsValid = $true
+            } catch [System.DirectoryServices.Protocols.LdapException] {
+                if ($_.Exception.ErrorCode -eq 49) {
+                    # ErrorCode 49 means invalid credentials
+                    Write-Verbose "Failed to connect to LDAP server with credentials provided"
+                    $credentialsValid = $false
+                } else {
+                    Write-Verbose "Failed to connect to LDAP server for other reason"
+                }
+                Write-Verbose "Exception: $_"
+                Invoke-CatchActionError $CatchActionFunction
+            } catch {
+                Write-Verbose "Exception occurred while connecting to LDAP server - unable to perform credential validation"
+                Write-Verbose "Exception: $_"
+                Invoke-CatchActionError $CatchActionFunction
+            }
+        }
+    }
+    end {
+        if ($null -ne $ldapConnection) {
+            $ldapConnection.Dispose()
+        }
+        return [PSCustomObject]@{
+            UsernameFormat   = $usernameFormat
+            CredentialsValid = $credentialsValid
+        }
+    }
+}

--- a/Shared/ActiveDirectoryFunctions/Test-ADCredentials.ps1
+++ b/Shared/ActiveDirectoryFunctions/Test-ADCredentials.ps1
@@ -70,6 +70,7 @@ function Test-ADCredentials {
                     $credentialsValid = $false
                 } else {
                     Write-Verbose "Failed to connect to LDAP server for other reason"
+                    Write-Verbose "ErrorCode: $($_.Exception.ErrorCode)"
                 }
                 Write-Verbose "Exception: $_"
                 Invoke-CatchActionError $CatchActionFunction


### PR DESCRIPTION
**Description:**
This PR resolves the last issue which was found during internal testing (ADO 3484268). It adds functionality to validate the credentials which were passed to run the script against Exchange Server on-premises.



