### PR TITLE
Have HTML Report use OutputFilePath directory

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HtmlServerReport.ps1
@@ -3,7 +3,10 @@
 
 function Get-HtmlServerReport {
     param(
-        [Parameter(Mandatory = $true)][array]$AnalyzedHtmlServerValues
+        [Parameter(Mandatory = $true)]
+        [array]$AnalyzedHtmlServerValues,
+
+        [string]$HtmlOutFilePath
     )
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
 
@@ -96,5 +99,5 @@ function Get-HtmlServerReport {
 
     $htmlReport = $htmlHeader + $htmlOverviewTable + $htmlServerDetails + "</body>$([System.Environment]::NewLine)</html>"
 
-    $htmlReport | Out-File $HtmlReportFile -Encoding UTF8
+    $htmlReport | Out-File $HtmlOutFilePath -Encoding UTF8
 }

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -211,6 +211,15 @@ begin {
         $Script:date = (Get-Date)
         $Script:dateTimeStringFormat = $date.ToString("yyyyMMddHHmmss")
 
+        # Some companies might already provide a full path for HtmlReportFile
+        # Detect if it is just a name, if it is, then append OutputFilePath to it.
+        # Otherwise, keep it as is
+        if ($HtmlReportFile.Contains("\")) {
+            $htmlOutFilePath = $HtmlReportFile
+        } else {
+            $htmlOutFilePath = [System.IO.Path]::Combine($OutputFilePath, $HtmlReportFile)
+        }
+
         # Features that doesn't require Exchange Shell
         if ($BuildHtmlServersReport) {
             Invoke-SetOutputInstanceLocation -FileName "HealthChecker-HTMLServerReport"
@@ -220,7 +229,7 @@ begin {
                 Write-Host "Doesn't appear to be any Health Check XML files here....stopping the script"
                 exit
             }
-            Get-HtmlServerReport -AnalyzedHtmlServerValues $importData.HtmlServerValues
+            Get-HtmlServerReport -AnalyzedHtmlServerValues $importData.HtmlServerValues -HtmlOutFilePath $htmlOutFilePath
             Start-Sleep 2;
             return
         }
@@ -241,7 +250,7 @@ begin {
                 $analyzedResults += $analyzedServerResults
             }
 
-            Get-HtmlServerReport -AnalyzedHtmlServerValues $analyzedResults.HtmlServerValues
+            Get-HtmlServerReport -AnalyzedHtmlServerValues $analyzedResults.HtmlServerValues -HtmlOutFilePath $htmlOutFilePath
             return
         }
 


### PR DESCRIPTION
**Issue:**
#1717 

**Reason:**
The HTML Report should be used as a file name and if `OutputFilePath` is used, combined the two in order to get the desired results. 

**Fix:**
Detect if `$HtmlReportFile` is already a file path, if it is use it. Otherwise, combined `$OutputFilePath` and `$HtmlReportFile` to get the desired result. 

Resolved #1717 

**Validation:**
Lab tested

