### PR TITLE
So when registry keys aren't set for AllowInsecureRenego Keys

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemRegistryValues.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemRegistryValues.ps1
@@ -46,12 +46,18 @@ function Get-OperatingSystemRegistryValues {
         GetValue  = "AllowInsecureRenegoClients"
         ValueType = "DWord"
     }
+    $renegoClientValue = Get-RemoteRegistryValue @renegoClientsParams
+
+    if ($null -eq $renegoClientValue) { $renegoClientValue = "NULL" }
 
     $renegoServersParams = $baseParams + @{
         SubKey    = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL"
         GetValue  = "AllowInsecureRenegoServers"
         ValueType = "DWord"
     }
+    $renegoServerValue = Get-RemoteRegistryValue @renegoServersParams
+
+    if ($null -eq $renegoServerValue) { $renegoServerValue = "NULL" }
 
     $credGuardParams = $baseParams + @{
         SubKey   = "SYSTEM\CurrentControlSet\Control\LSA"
@@ -74,8 +80,8 @@ function Get-OperatingSystemRegistryValues {
         IPv6DisabledComponents          = [int](Get-RemoteRegistryValue @ipv6ComponentsParams)
         TCPKeepAlive                    = [int](Get-RemoteRegistryValue @tcpKeepAliveParams)
         RpcMinConnectionTimeout         = [int](Get-RemoteRegistryValue @rpcMinParams)
-        AllowInsecureRenegoServers      = [int](Get-RemoteRegistryValue @renegoServersParams)
-        AllowInsecureRenegoClients      = [int](Get-RemoteRegistryValue @renegoClientsParams)
+        AllowInsecureRenegoServers      = $renegoServerValue
+        AllowInsecureRenegoClients      = $renegoClientValue
         CredentialGuard                 = [int](Get-RemoteRegistryValue @credGuardParams)
     }
 }


### PR DESCRIPTION
**Issue:**
When comparing a 2016 server and 2019 server they appear to be the same for TLS settings, but that isn't the case. TLS is rejecting a TLS session from a NLB due to this security setting set on 2019. 

**Reason:**
Correctly report the value so we can properly compare servers.

**Fix:**
When a value is `null` trying to read the key, report it as `NULL` and not `0`. 

**Validation:**
Lab tested

