### PR TITLE
Use Unlimited for store query trying to find Conversations folder

### DIFF
--- a/Search/Troubleshoot-ModernSearch/StoreQuery/Get-StoreQueryMailboxMessagesByCategory.ps1
+++ b/Search/Troubleshoot-ModernSearch/StoreQuery/Get-StoreQueryMailboxMessagesByCategory.ps1
@@ -29,8 +29,9 @@ function Get-StoreQueryMailboxMessagesByCategory {
         $messageList = New-Object 'System.Collections.Generic.List[object]'
     }
     process {
+        $storeQueryHandler = $storeQueryHandler | ResetQueryInstances
+        $storeQueryHandler.IsUnlimited = $true
         $conversationResults = $storeQueryHandler |
-            ResetQueryInstances |
             SetSelect -Value "FolderId" |
             SetFrom -Value "Folder" |
             SetWhere -Value "MailboxNumber = $mailboxNumber AND DisplayName = 'Conversations'" |


### PR DESCRIPTION
**Issue:**
Not finding the `conversations` folder causing when trying to find all messages by category to find all the messages in the `Conversations` folder first. 

**Reason:**
This isn't the intent, and we should skip over them. 

**Fix:**
Use the `unlimited` switch when doing the `Get-StoreQuery` trying to find the `Conversations` folder.

**Validation:**
Lab tested

