### PR TITLE
Fix bug with determining error indexing value

### DIFF
--- a/Shared/ErrorMonitorFunctions.ps1
+++ b/Shared/ErrorMonitorFunctions.ps1
@@ -27,11 +27,12 @@ function Get-UnhandledErrors {
                 Where-Object { $_.Equals($currentError) }
 
                 if ($null -eq $handledError) {
-                    return [PSCustomObject]@{
+                    [PSCustomObject]@{
                         ErrorInformation = $currentError
-                        Index            = $index++
+                        Index            = $index
                     }
                 }
+                $index++
             }
 }
 
@@ -46,11 +47,12 @@ function Get-HandledErrors {
                 Where-Object { $_.Equals($currentError) }
 
                 if ($null -ne $handledError) {
-                    return [PSCustomObject]@{
+                    [PSCustomObject]@{
                         ErrorInformation = $currentError
-                        Index            = $index++
+                        Index            = $index
                     }
                 }
+                $index++
             }
 }
 


### PR DESCRIPTION
**Issue:**
Incorrectly displays the indexing value for where the error is at in `$Error`. 

**Reason:**
Correctly display the indexing value so it is easier to find the error later for debugging. 

**Fix:**
Increase the index every type we loop through an error, not just when we find an error that we need to report. 

**Validation:**
Lab tested. 

Before: 

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/d4ef3971-ac98-47f7-bf6a-5b25a882249a)

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/79ce7064-c5c8-4bbc-8171-ba94f167441e)

After:

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/e364c15d-9c40-4b60-972a-5bca88728280)


