### PR TITLE
CVE-2023-23397.ps1 VersionsUrl wasn't called in each case when performing an auto-update 

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -981,7 +981,7 @@ begin {
     }
 
     if ((-not($SkipVersionCheck)) -and
-        (Test-ScriptVersion -AutoUpdate -Confirm:$false)) {
+        (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/CVE-2023-23397-VersionsUrl" -Confirm:$false)) {
         Write-Host ("Script was updated. Please rerun the command") -ForegroundColor Yellow
         return
     }


### PR DESCRIPTION
The customized versions url wasn't called in each case when `Test-ScriptVersion` was called within the script. 


