### PR TITLE
No support for PowerShell Core with ExPerfAnalyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,6 @@
           "custom": true, // Enable the `custom` dictionary
           "internal-terms": false // Disable the `internal-terms` dictionary
     },
-    "cSpell.caseSensitive": true
+    "cSpell.caseSensitive": true,
+    "editor.detectIndentation": false
 }

--- a/Performance/ExPerfAnalyzer.ps1
+++ b/Performance/ExPerfAnalyzer.ps1
@@ -976,6 +976,12 @@ function Get-CountersFromXml {
 
 function Main {
 
+    # Currently no support for core with this script.
+    if ($PSVersionTable.PSEdition -eq "Core") {
+        Write-Error "Unable to use PowerShell Core with this script."
+        exit
+    }
+
     $script:processStartTime = [System.DateTime]::Now
 
     #determine the logic we want out of the script


### PR DESCRIPTION
**Issue:**
Prevent the script from running by checking to see if the type is core. 

**Reason:**
People may try to run the script with PS Core, now that more people are starting to use it. 

**Fix:**
Resolved #1731 

**Validation:**
NA

