### PR TITLE
Exchange 2013 no longer considered secure

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityVulnerability.ps1
@@ -29,9 +29,12 @@ function Invoke-AnalyzerSecurityVulnerability {
     $allSecurityVulnerabilities = $AnalyzeResults.Value.DisplayResults[$keySecurityVulnerability]
     $securityVulnerabilities = $allSecurityVulnerabilities | Where-Object { $_.Name -ne "IIS module anomalies detected" }
     $iisModule = $allSecurityVulnerabilities | Where-Object { $_.Name -eq "IIS module anomalies detected" }
+    $buildVersion = $HealthServerObject.ExchangeInformation.BuildInformation.VersionInformation
+    $noLongerSecureExchange = ($buildVersion.ExtendedSupportDate -le ([DateTime]::Now)) -and $buildVersion.LatestSU -eq $false
 
     if ($null -eq $securityVulnerabilities -and
-        ($null -ne $iisModule -or $iisModule.DisplayValue -eq $false)) {
+        ($null -ne $iisModule -or $iisModule.DisplayValue -eq $false) -and
+        (-not $noLongerSecureExchange)) {
         $params = $baseParams + @{
             Details          = "All known security issues in this version of the script passed."
             DisplayWriteType = "Green"
@@ -40,7 +43,7 @@ function Invoke-AnalyzerSecurityVulnerability {
         Add-AnalyzedResultInformation @params
 
         $params = $baseParams + @{
-            Name                      = "Security Vulnerabilities"
+            Name                      = "Vulnerability Detected"
             Details                   = "None"
             AddDisplayResultsLineInfo = $false
             AddHtmlOverviewValues     = $true
@@ -66,13 +69,40 @@ function Invoke-AnalyzerSecurityVulnerability {
         }
         Add-AnalyzedResultInformation @params
 
+        # Only add this if on current supported and releasing SU for Exchange.
+        if (-not ($noLongerSecureExchange)) {
+
+            $params = $baseParams + @{
+                Name                      = "Vulnerability Detected"
+                Details                   = $true
+                AddDisplayResultsLineInfo = $false
+                DisplayWriteType          = "Red"
+                AddHtmlOverviewValues     = $true
+                AddHtmlDetailRow          = $false
+            }
+            Add-AnalyzedResultInformation @params
+        }
+    }
+
+    if ($noLongerSecureExchange) {
+        $friendlyName = ($buildVersion.FriendlyName.ToString()).Replace(($buildVersion.CU), " ").Trim()
+        $details = "`r`n`t$friendlyName is out of support and will not receive any further security updates." +
+        "`r`n`tWe do not perform any vulnerability testing against this version of Exchange any more." +
+        "`r`n`t$friendlyName is likely vulnerable to any vulnerabilities disclosed after $($buildVersion.ExtendedSupportDate.ToString("yyyy/MM/dd"))" +
+        "`r`n`tYou should migrate to the latest Exchange Server for On Prem or Exchange Online as soon as possible and decommission $friendlyName from your environment."
+        $params = $baseParams + @{
+            Details          = $details
+            DisplayWriteType = "Red"
+            AddHtmlDetailRow = $false
+        }
+        Add-AnalyzedResultInformation @params
+
         $params = $baseParams + @{
             Name                      = "Vulnerability Detected"
-            Details                   = $true
-            AddDisplayResultsLineInfo = $false
+            Details                   = "Expired Version of Exchange"
             DisplayWriteType          = "Red"
+            AddDisplayResultsLineInfo = $false
             AddHtmlOverviewValues     = $true
-            AddHtmlDetailRow          = $false
         }
         Add-AnalyzedResultInformation @params
     }

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -355,7 +355,6 @@ function Get-ExchangeBuildVersionInformation {
                     $cuReleaseDate = "06/18/2019"
                     $supportedBuildNumber = $true
                 }
-                (GetBuildVersion $ex13 "CU23" -SU "Mar23SU") { $latestSUBuild = $true }
                 (GetBuildVersion $ex13 "CU23" -SU "May22SU") { $mesoValue = 13238 }
                 { $_ -lt (GetBuildVersion $ex13 "CU23") } {
                     $cuLevel = "CU22"


### PR DESCRIPTION
**Reason:**
No longer want to state that 2013 is secure when we aren't releasing SU for 2013 any longer. 


**Validation:**
Lab tested

