### PR TITLE
Proxy type check improved to prevent false-positives

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -253,7 +253,7 @@ function Invoke-AnalyzerExchangeInformation {
 
     if ([string]::IsNullOrEmpty($internetProxy)) {
         $params.Details = "Not Set"
-    } elseif ($internetProxy -notmatch "(http:\/\/)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]") {
+    } elseif ($internetProxy.Scheme -ne "http") {
         <#
         We use the WebProxy class WebProxy(Uri, Boolean, String[]) constructor when running Set-ExchangeServer -InternetWebProxy,
         which throws an UriFormatException if the URI provided cannot be parsed.


### PR DESCRIPTION
**Issue:**
HC reports that a proxy configuration like `http://proxy.contoso.lab:8080` is invalid

**Reason:**
RegEx did not take into account that a port can be used.

**Fix:**
Validate if `$internetProxy.Scheme` is `http` instead of doing RegEx testing

**Validation:**
Lab

