### PR TITLE
updated language around finding modules.

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -397,7 +397,7 @@ foreach ($process in $ServerProcess) {
 # Final output for process detection
 if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile -string ("Found $($UnexpectedModuleFound) processes with unexpected modules loaded") -Name $LogFile -OutHost
-    Write-SimpleLogFile ("AV Modules loaded in Exchange processess generally indicates that exclusions are not set properly.") -Name $LogFile -OutHost
+    Write-SimpleLogFile ("AV Modules loaded in Exchange processes generally indicates that exclusions are not set properly.") -Name $LogFile -OutHost
     Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes maybe expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
 

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -11,7 +11,7 @@
 
 .SYNOPSIS
 Uses EICAR files to verify that all Exchange paths that should be excluded from AV scanning are excluded.
-Checks Exchange processes for "unknown" modules being loaded into them.
+Checks Exchange processes for Non-Default modules being loaded into them.
 
 .DESCRIPTION
 Writes an EICAR test file https://en.wikipedia.org/wiki/EICAR_test_file to all paths specified by
@@ -25,9 +25,9 @@ IF the file is not removed then it should be properly excluded.
 Once the files are created it will wait 300 seconds for AV to "see" and remove the file.
 
 Pulls all Exchange processes and their modules.
-Excludes known modules and reports all unknown modules.
+Excludes known modules and reports all Non-Default modules.
 
-Unknown modules should be reviewed to ensure they are expected.
+Non-Default modules should be reviewed to ensure they are expected.
 AV Modules loaded into Exchange Processes indicate that AV Process Exclusions are NOT properly configured.
 
 .PARAMETER Recurse
@@ -41,8 +41,8 @@ $env:LOCALAPPDATA\ExchAvExclusions.log
 List of Scanned Folders:
 $env:LOCALAPPDATA\BadExclusions.txt
 
-List of Unknown Processes
-$env:LOCALAPPDATA UnknownModules.txt
+List of Non-Default Processes
+$env:LOCALAPPDATA NonDefaultModules.txt
 
 .EXAMPLE
 .\Test-ExchAVExclusions.ps1
@@ -374,8 +374,8 @@ foreach ($process in $ServerProcess) {
         # Remove Microsoft modules
         $ProcessModules = $ProcessModules | Where-Object { $_.FileVersionInfo.CompanyName -ne "Microsoft Corporation." -and $_.FileVersionInfo.CompanyName -ne "Microsoft" -and $_.FileVersionInfo.CompanyName -ne "Microsoft Corporation" }
 
-        # Generate and output path for an unknown modules file:
-        $OutputProcessPath = Join-Path $env:LOCALAPPDATA UnknownModules.txt
+        # Generate and output path for an Non-Default modules file:
+        $OutputProcessPath = Join-Path $env:LOCALAPPDATA NonDefaultModules.txt
 
         # Clear out modules from the allow list
         foreach ($module in $ModuleAllowList) {
@@ -401,5 +401,5 @@ if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes maybe expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
 } else {
-    Write-SimpleLogFile -string ("No Unexpected modules found loaded.") -Name $LogFile -OutHost
+    Write-SimpleLogFile -string ("No Non-Default modules found loaded.") -Name $LogFile -OutHost
 }

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -28,7 +28,7 @@ Pulls all Exchange processes and their modules.
 Excludes known modules and reports all Non-Default modules.
 
 Non-Default modules should be reviewed to ensure they are expected.
-AV Modules loaded into Exchange Processes indicate that AV Process Exclusions are NOT properly configured.
+AV Modules loaded into Exchange Processes may indicate that AV Process Exclusions are NOT properly configured.
 
 .PARAMETER Recurse
 Will test not just the root folders but all SubFolders.
@@ -397,8 +397,8 @@ foreach ($process in $ServerProcess) {
 # Final output for process detection
 if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile -string ("Found $($UnexpectedModuleFound) processes with unexpected modules loaded") -Name $LogFile -OutHost
-    Write-SimpleLogFile ("AV Modules loaded in Exchange processes generally indicates that exclusions are not set properly.") -Name $LogFile -OutHost
-    Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes maybe expected depending on applications installed.") -Name $LogFile -OutHost
+    Write-SimpleLogFile ("AV Modules loaded in Exchange processes may indicate that exclusions are not properly configured.") -Name $LogFile -OutHost
+    Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes may be expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
 } else {
     Write-SimpleLogFile -string ("No Non-Default modules found loaded.") -Name $LogFile -OutHost

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -400,7 +400,6 @@ if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile ("AV Modules loaded in Exchange processes generally indicates that exclusions are not set properly.") -Name $LogFile -OutHost
     Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes maybe expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
-
 } else {
     Write-SimpleLogFile -string ("No Unexpected modules found loaded.") -Name $LogFile -OutHost
 }

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -27,6 +27,9 @@ Once the files are created it will wait 300 seconds for AV to "see" and remove t
 Pulls all Exchange processes and their modules.
 Excludes known modules and reports all unknown modules.
 
+Unknown modules should be reviewed to ensure they are expected.
+AV Modules loaded into Exchange Processes indicate that AV Process Exclusions are NOT properly configured.
+
 .PARAMETER Recurse
 Will test not just the root folders but all SubFolders.
 Generally should not be needed unless all folders pass without -Recuse but AV is still suspected.
@@ -394,8 +397,10 @@ foreach ($process in $ServerProcess) {
 # Final output for process detection
 if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile -string ("Found $($UnexpectedModuleFound) processes with unexpected modules loaded") -Name $LogFile -OutHost
+    Write-SimpleLogFile ("AV Modules loaded in Exchange processess generally indicates that exclusions are not set properly.") -Name $LogFile -OutHost
+    Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes maybe expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
-    Write-SimpleLogFile ("If a module is labeled `"Unexpected`" in error please submit the log file to ExToolsFeedback@microsoft.com" ) -Name $LogFile -OutHost
+
 } else {
     Write-SimpleLogFile -string ("No Unexpected modules found loaded.") -Name $LogFile -OutHost
 }

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -401,5 +401,5 @@ if ($UnexpectedModuleFound -gt 0) {
     Write-SimpleLogFile ("Non AV Modules loaded into Exchange processes may be expected depending on applications installed.") -Name $LogFile -OutHost
     Write-Warning ("Review " + $OutputProcessPath + " For more information.")
 } else {
-    Write-SimpleLogFile -string ("No Non-Default modules found loaded.") -Name $LogFile -OutHost
+    Write-SimpleLogFile -string ("Did not find any Non-Default modules loaded.") -Name $LogFile -OutHost
 }

--- a/docs/Diagnostics/Test-ExchAVExclusions.md
+++ b/docs/Diagnostics/Test-ExchAVExclusions.md
@@ -5,6 +5,7 @@ Download the latest release: [Test-ExchAVExclusions.ps1](https://github.com/micr
 Assists with testing Exchange Servers to determine if AV Exclusions have been properly set according to our documentation.
 
 [AV Exclusions Exchange 2016/2019](https://docs.microsoft.com/en-us/Exchange/antispam-and-antimalware/windows-antivirus-software?view=exchserver-2019)
+
 [AV Exclusions Exchange 2013](https://docs.microsoft.com/en-us/exchange/anti-virus-software-in-the-operating-system-on-exchange-servers-exchange-2013-help)
 
 ## Usage
@@ -17,12 +18,34 @@ IF the file is not removed then it should be properly excluded.
 Once the files are created it will wait 5 minutes for AV to "see" and remove the file.
 
 After finishing testing directories it will test Exchange Processes.
-We pull all Exchange processes and the modules loaded into them.
-Those are then compared to a list of known modules and anything "unknown" is reported.
+Pulls all Exchange processes and their modules.
+Excludes known modules and reports all Non-Default modules.
+
+Non-Default modules should be reviewed to ensure they are expected.
+AV Modules loaded into Exchange Processes indicate that AV Process Exclusions are NOT properly configured.
 
 ...
 .\Test-ExchAVExclusions.ps1
 ...
+
+## Understanding the Output
+
+### File Output
+Review the BadExclusions.txt file to see any file paths were identified as being scanned by AV.
+Work with the AV Vendor to determine the best way to exclude these file paths according to our documentation:
+
+[AV Exclusions Exchange 2016/2019](https://docs.microsoft.com/en-us/Exchange/antispam-and-antimalware/windows-antivirus-software?view=exchserver-2019)
+
+### Process Output
+Review NonDefaultModules.txt to determine if any Non-Default modules are loaded into Exchange processes.  The output should have sufficient information to identity the souce of the flagged modules.
+
+```[FAIL] - PROCESS: msexchangerepl MODULE: scanner.dll COMPANY: Contoso Security LTT.```
+
+If the Module is from an AV or Security software vendor it is a strong indication that process exclusions are not properly configured on the Exchange server.  Please work with the security software vendor to ensure that they are properly configured according to:
+
+[AV Exclusions Exchange 2016/2019](https://docs.microsoft.com/en-us/Exchange/antispam-and-antimalware/windows-antivirus-software?view=exchserver-2019)
+
+[AV Exclusions Update](https://techcommunity.microsoft.com/t5/exchange-team-blog/update-on-the-exchange-server-antivirus-exclusions/ba-p/3751464)
 
 
 ## Parameters
@@ -40,5 +63,5 @@ $env:LOCALAPPDATA\ExchAvExclusions.log
 List of Folders and extensions Scanned by AV:
 $env:LOCALAPPDATA\BadExclusions.txt
 
-List of Unknown Processes:
-$env:LOCALAPPDATA UnknownModules.txt
+List of Non-Default Processes:
+$env:LOCALAPPDATA\NonDefaultModules.txt

--- a/docs/Diagnostics/Test-ExchAVExclusions.md
+++ b/docs/Diagnostics/Test-ExchAVExclusions.md
@@ -41,7 +41,7 @@ Review NonDefaultModules.txt to determine if any Non-Default modules are loaded 
 
 ```[FAIL] - PROCESS: ExchangeTransport MODULE: scanner.dll COMPANY: Contoso Security LTT.```
 
-If the Module is from an AV or Security software vendor it is a strong indication that process exclusions are not properly configured on the Exchange server.  Please work with the security software vendor to ensure that they are properly configured according to:
+If the Module is from an AV or Security software vendor it is a strong indication that process exclusions are not properly configured on the Exchange server.  Please work with the vendor to ensure that they are properly configured according to:
 
 [AV Exclusions Exchange 2016/2019](https://docs.microsoft.com/en-us/Exchange/antispam-and-antimalware/windows-antivirus-software?view=exchserver-2019)
 

--- a/docs/Diagnostics/Test-ExchAVExclusions.md
+++ b/docs/Diagnostics/Test-ExchAVExclusions.md
@@ -37,9 +37,9 @@ Work with the AV Vendor to determine the best way to exclude these file paths ac
 [AV Exclusions Exchange 2016/2019](https://docs.microsoft.com/en-us/Exchange/antispam-and-antimalware/windows-antivirus-software?view=exchserver-2019)
 
 ### Process Output
-Review NonDefaultModules.txt to determine if any Non-Default modules are loaded into Exchange processes.  The output should have sufficient information to identity the souce of the flagged modules.
+Review NonDefaultModules.txt to determine if any Non-Default modules are loaded into Exchange processes.  The output should have sufficient information to identity the source of the flagged modules.
 
-```[FAIL] - PROCESS: msexchangerepl MODULE: scanner.dll COMPANY: Contoso Security LTT.```
+```[FAIL] - PROCESS: ExchangeTransport MODULE: scanner.dll COMPANY: Contoso Security LTT.```
 
 If the Module is from an AV or Security software vendor it is a strong indication that process exclusions are not properly configured on the Exchange server.  Please work with the security software vendor to ensure that they are properly configured according to:
 


### PR DESCRIPTION
**Issue:**
Updating language around finding unknown modules, to no longer direct that customers to send support the files.

**Reason:**
Directions were unclear.  We only wanted modules in error ... customers are going to believe all modules are in error and submit them.

**Fix:**
Updated language to more clearly call out "FAIL" condition and next steps.

**Validation:**
Provide if applicable

