### PR TITLE
Make sure the return results is an array to allow .Count to work

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -493,7 +493,7 @@ begin {
                     $counter = 0
                     $totalCount = $ExchangeServers.Count
                     $outlookAnywhereCount = 0
-                    $outlookAnywhereServers = $ExchangeServersPrerequisitesCheckSettingsCheck | Where-Object { $_.IsClientAccessServer -eq $true }
+                    $outlookAnywhereServers = @($ExchangeServersPrerequisitesCheckSettingsCheck | Where-Object { $_.IsClientAccessServer -eq $true })
                     $outlookAnywhereTotalCount = $outlookAnywhereServers.Count
 
                     $progressParams = @{


### PR DESCRIPTION
**Issue:**

Customer reported the following error:

```
ForEach-Object : Attempted to divide by zero.
At \\Exchange\Logs\ExchangePS\ExchangeExtendedProtectionManagement.ps1:5300 char:25
+                         ForEach-Object {
+                         ~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [ForEach-Object], RuntimeException
    + FullyQualifiedErrorId : RuntimeException,Microsoft.PowerShell.Commands.ForEachObjectCommand
```

We did return a value for `$outlookAnywhereServers`, but it would appear that `$outlookAnywhereServers.count` didn't have a value of 1, thus causing the problem. 

**Reason:**
Unable to divide by 0 when there is only 1 object when running from a tools box, likely due to the mismatch in version. 

**Fix:**
![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/6f19341d-6464-4576-958f-0b9e56940f23)


**Validation:**
NA
