### PR TITLE
Update Test-ExchAVExclusions.ps1

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -341,6 +341,8 @@ $ModuleAllowList.add("ExDbFailureItemApi.dll")
 $ModuleAllowList.add("Microsoft.Cloud.InstrumentationFramework.Metrics.ni.dll")
 $ModuleAllowList.add("IfxMetrics.dll")
 $ModuleAllowList.add("ManagedBlingSigned.dll")
+$ModuleAllowList.add("l3codecp.acm")
+$ModuleAllowList.add("System.IdentityModel.Tokens.jwt.ni.dll")
 # Oracle modules associated with 'Outside In® Technology'
 $ModuleAllowList.add("wvcore.dll")
 $ModuleAllowList.add("sccut.dll")


### PR DESCRIPTION
Included l3codecp.acm from UM role in E16 and System.IdentityModel.Tokens.jwt.ni.dll that is sometimes in use by Exchange.

Issue:
Describe what the issue is you are addressing

Reason:
l3codecp.acm is used by UM in E16 and System.IdentityModel.Tokens.jwt.ni.dll in E16 and E19

Fix:
Just Add both to the list of modules in Exchange

Validation:
Test In lab
