### PR TITLE
RBA Script - Add Teams Warning

### DIFF
--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -310,7 +310,7 @@ function RBADelegateSettings {
     Write-Host "`t ForwardRequestsToDelegates:      "$RbaSettings.ForwardRequestsToDelegates
     Write-Host
 
-    # Warnings:
+    # Check for know configuration issues to warn about:
     if ($RbaSettings.ResourceDelegates.Count -gt 0) {
         if ($RbaSettings.AddNewRequestsTentatively -eq $true) {
             Write-Host "In-policy meetings will be marked tentative and the meeting request will be sent to the Resource Delegates to be accepted or rejected. Default"
@@ -363,7 +363,7 @@ function RBAPostProcessing {
     `t AddAdditionalResponse:                $($RbaSettings.AddAdditionalResponse)
 "@
 
-    # Warnings:
+    # Warning about the DeleteComments setting and Teams:
     if ($RbaSettings.DeleteComments -eq $true) {
         Write-Host -ForegroundColor Yellow "Warning: DeleteComments is set to true. This will remove the Teams information which is in the meeting body."
     }

--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -310,7 +310,7 @@ function RBADelegateSettings {
     Write-Host "`t ForwardRequestsToDelegates:      "$RbaSettings.ForwardRequestsToDelegates
     Write-Host
 
-    # Check for know configuration issues to warn about:
+    # Check for known configuration issues to warn about:
     if ($RbaSettings.ResourceDelegates.Count -gt 0) {
         if ($RbaSettings.AddNewRequestsTentatively -eq $true) {
             Write-Host "In-policy meetings will be marked tentative and the meeting request will be sent to the Resource Delegates to be accepted or rejected. Default"

--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -310,6 +310,7 @@ function RBADelegateSettings {
     Write-Host "`t ForwardRequestsToDelegates:      "$RbaSettings.ForwardRequestsToDelegates
     Write-Host
 
+# Warnings:
     if ($RbaSettings.ResourceDelegates.Count -gt 0) {
         if ($RbaSettings.AddNewRequestsTentatively -eq $true) {
             Write-Host "In-policy meetings will be marked tentative and the meeting request will be sent to the Resource Delegates to be accepted or rejected. Default"
@@ -364,7 +365,7 @@ function RBAPostProcessing {
 
 # Warnings:
     if ($RbaSettings.DeleteComments -eq $true) {
-        write-host -ForegroundColor Yellow "Warning: DeleteComments is set to true. This will remove the Teams information which is in the meeting body."
+        Write-Host -ForegroundColor Yellow "Warning: DeleteComments is set to true. This will remove the Teams information which is in the meeting body."
     }
 }
 

--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -361,6 +361,11 @@ function RBAPostProcessing {
     `t EnableAutoRelease:                    $($RbaSettings.EnableAutoRelease)
     `t AddAdditionalResponse:                $($RbaSettings.AddAdditionalResponse)
 "@
+
+# Warnings:
+    if ($RbaSettings.DeleteComments -eq $true) {
+        write-host -ForegroundColor Yellow "Warning: DeleteComments is set to true. This will remove the Teams information which is in the meeting body."
+    }
 }
 
 # RBA Verbose PostProcessing Steps

--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -310,7 +310,7 @@ function RBADelegateSettings {
     Write-Host "`t ForwardRequestsToDelegates:      "$RbaSettings.ForwardRequestsToDelegates
     Write-Host
 
-# Warnings:
+    # Warnings:
     if ($RbaSettings.ResourceDelegates.Count -gt 0) {
         if ($RbaSettings.AddNewRequestsTentatively -eq $true) {
             Write-Host "In-policy meetings will be marked tentative and the meeting request will be sent to the Resource Delegates to be accepted or rejected. Default"
@@ -363,7 +363,7 @@ function RBAPostProcessing {
     `t AddAdditionalResponse:                $($RbaSettings.AddAdditionalResponse)
 "@
 
-# Warnings:
+    # Warnings:
     if ($RbaSettings.DeleteComments -eq $true) {
         Write-Host -ForegroundColor Yellow "Warning: DeleteComments is set to true. This will remove the Teams information which is in the meeting body."
     }


### PR DESCRIPTION
**Issue:**
Issue came to PG where teams info was deleted by RBA. 

**Reason:**
This was by design as they set the RBA to delete the body

**Fix:**
Explicit warning that this will removed Teams info

**Validation:**
Provide if applicable

