### PR TITLE
Replace wrong quotes in HC Get-HealthCheckerData function

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
@@ -34,8 +34,8 @@ function Get-HealthCheckerData {
             }
 
             Invoke-Command -ComputerName $ComputerName -ScriptBlock { Get-Date } -ErrorAction Stop | Out-Null
-            $reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey(“LocalMachine”, $ComputerName)
-            $reg.OpenSubKey(“SOFTWARE\Microsoft\Windows NT\CurrentVersion”) | Out-Null
+            $reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey("LocalMachine", $ComputerName)
+            $reg.OpenSubKey("SOFTWARE\Microsoft\Windows NT\CurrentVersion") | Out-Null
             Write-Verbose "Returning true back"
             return $true
         } catch {


### PR DESCRIPTION
**Issue:**
Issue #1788 reported, that we are using in the `TestComputerName` function, which is part of the `Get-HealthCheckerData`, the wrong quotes char:
<img width="148" alt="image" src="https://github.com/microsoft/CSS-Exchange/assets/40993616/7b55693d-9036-40ea-ab11-899160767007">


**Reason:**
N/A

**Fix:**
Quotes replaced with 
<img width="149" alt="image" src="https://github.com/microsoft/CSS-Exchange/assets/40993616/b6fcf4dd-9bcf-404a-b883-c6683775d42d">

**Validation:**
Lab

