### PR TITLE
Allow Get-EventLogLevel to force reconnect with loop

### DIFF
--- a/Shared/Confirm-ExchangeShell.ps1
+++ b/Shared/Confirm-ExchangeShell.ps1
@@ -40,7 +40,14 @@ function Confirm-ExchangeShell {
 
             try {
                 $currentErrors = $Error.Count
-                $eventLogLevel = Get-EventLogLevel -ErrorAction Stop | Select-Object -First 1
+                $attempts = 0
+                do {
+                    $eventLogLevel = Get-EventLogLevel -ErrorAction Stop | Select-Object -First 1
+                    $attempts++
+                    if ($attempts -ge 5) {
+                        throw "Failed to run Get-EventLogLevel too many times."
+                    }
+                } while ($null -eq $eventLogLevel)
                 $getEventLogLevelCallSuccessful = $true
                 foreach ($e in $eventLogLevel) {
                     Write-Verbose "Type is: $($e.GetType().Name) BaseType is: $($e.GetType().BaseType)"


### PR DESCRIPTION
**Issue:**
#1803 

**Reason:**
Getting a lot of emails reporting this issue. 

**Fix:**
Do a loop around `Get-EventLogLevel` and make sure we `throw` it out of the loop in case we get stuck in it.

Resolved #1803 

**Validation:**
Lab tested. 

