### PR TITLE
Update Invoke-AnalyzerNicSettings.ps1

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
@@ -159,7 +159,7 @@ function Invoke-AnalyzerNicSettings {
         Add-AnalyzedResultInformation -Name "IPv4 Address" @baseParams
 
         foreach ($address in $adapter.IPv4Addresses) {
-            $displayValue = "{0}\{1}" -f $address.Address, $address.Subnet
+            $displayValue = "{0}/{1}" -f $address.Address, $address.Subnet
 
             if ($address.DefaultGateway -ne [string]::Empty) {
                 $displayValue += " Gateway: {0}" -f $address.DefaultGateway

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "RSS Enabled" $false -WriteType "Yellow"
             TestObjectMatch "Link Speed" "10000 Mbps"
             TestObjectMatch "IPv6 Enabled" "True"
-            TestObjectMatch "Address" "192.168.9.11\24 Gateway: 192.168.9.1"
+            TestObjectMatch "Address" "192.168.9.11/24 Gateway: 192.168.9.1"
             TestObjectMatch "Registered In DNS" "True"
             TestObjectMatch "Packets Received Discarded" 0 -WriteType "Green"
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "RSS Enabled" "True" -WriteType "Green"
             TestObjectMatch "Link Speed" "10000 Mbps"
             TestObjectMatch "IPv6 Enabled" "True"
-            TestObjectMatch "Address" "192.168.5.11\24 Gateway: 192.168.5.1"
+            TestObjectMatch "Address" "192.168.5.11/24 Gateway: 192.168.5.1"
             TestObjectMatch "Registered In DNS" "True"
             TestObjectMatch "Packets Received Discarded" 0 -WriteType "Green"
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "RSS Enabled" "True" -WriteType "Green"
             TestObjectMatch "Link Speed" "10000 Mbps"
             TestObjectMatch "IPv6 Enabled" "True"
-            TestObjectMatch "Address" "192.168.11.11\24 Gateway: 192.168.11.1"
+            TestObjectMatch "Address" "192.168.11.11/24 Gateway: 192.168.11.1"
             TestObjectMatch "Registered In DNS" "True"
             TestObjectMatch "Packets Received Discarded" 0 -WriteType "Green"
 


### PR DESCRIPTION
Change format of IP4 address.

**Issue:**
Output currently created by the tool looks like this:
`Address: 192.168.1.10\24 Gateway: 192.168.1.1`

**Reason:**
This subnet prefix formatting is backwards to any existing standard. Microsoft's own documentation here for example uses forward slashes:

https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges?view=o365-worldwide#exchange-online

The Wikipedia page describes the format as containing a slash, and not a backslash:

https://en.wikipedia.org/wiki/Subnet

**Fix:**
Change the slash direction

**Validation:**
Not much to validate on a single character change
