### PR TITLE
HealthChecker HSTS check

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -392,8 +392,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 if (($webSite.Hsts.NativeHstsSettings.enabled) -or
                     ($webSite.Hsts.HstsViaCustomHeader.enabled)) {
                     $params = $baseParams + @{
-                        Details          = "HSTS Enabled: $($webSite.Name)"
-                        DisplayWriteType = if ($isExchangeBackEnd) { "Red" } else { "Green" }
+                        Name                = "HSTS Enabled"
+                        Details             = "$($webSite.Name)"
+                        TestingName         = "hsts-Enabled-$($webSite.Name)"
+                        DisplayTestingValue = $true
+                        DisplayWriteType    = if ($isExchangeBackEnd) { "Red" } else { "Green" }
                     }
                     Add-AnalyzedResultInformation @params
 
@@ -402,6 +405,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                         $params = $baseParams + @{
                             Details                = "HSTS on 'Exchange Back End' is not supported and can cause issues"
                             DisplayWriteType       = "Red"
+                            TestingName            = "hsts-BackendNotSupported"
+                            DisplayTestingValue    = $true
                             DisplayCustomTabNumber = 2
                         }
                         Add-AnalyzedResultInformation @params
@@ -415,6 +420,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                             Details                = ("HSTS configured via customHeader and native IIS control - please remove one configuration" +
                                 "`r`n`t`tHSTS native IIS control has a higher weight than the customHeader and will be used")
                             DisplayWriteType       = "Yellow"
+                            TestingName            = "hsts-conflict"
+                            DisplayTestingValue    = $true
                             DisplayCustomTabNumber = 2
                         }
                         Add-AnalyzedResultInformation @params
@@ -436,18 +443,24 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                     $params = $baseParams + @{
                         Details                = "max-age: $maxAgeValue"
                         DisplayWriteType       = $hstsMaxAgeWriteType
+                        TestingName            = "hsts-max-age-$($webSite.Name)"
+                        DisplayTestingValue    = $maxAgeValue
                         DisplayCustomTabNumber = 2
                     }
                     Add-AnalyzedResultInformation @params
 
                     $params = $baseParams + @{
                         Details                = "includeSubDomains: $($hstsConfiguration.includeSubDomains)"
+                        TestingName            = "hsts-includeSubDomains-$($webSite.Name)"
+                        DisplayTestingValue    = $hstsConfiguration.includeSubDomains
                         DisplayCustomTabNumber = 2
                     }
                     Add-AnalyzedResultInformation @params
 
                     $params = $baseParams + @{
                         Details                = "preload: $($hstsConfiguration.preload)"
+                        TestingName            = "hsts-preload-$($webSite.Name)"
+                        DisplayTestingValue    = $hstsConfiguration.preload
                         DisplayCustomTabNumber = 2
                     }
                     Add-AnalyzedResultInformation @params
@@ -455,6 +468,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                     $redirectHttpToHttpsConfigured = $hstsConfiguration.redirectHttpToHttps
                     $params = $baseParams + @{
                         Details                = "redirectHttpToHttps: $redirectHttpToHttpsConfigured"
+                        TestingName            = "hsts-redirectHttpToHttps-$($webSite.Name)"
+                        DisplayTestingValue    = $redirectHttpToHttpsConfigured
                         DisplayCustomTabNumber = 2
                     }
                     if ($redirectHttpToHttpsConfigured) {
@@ -469,6 +484,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 $params = $baseParams + @{
                     Details                = "`r`n`t`tMore Information about HSTS: https://aka.ms/HC-HSTS"
                     DisplayWriteType       = "Yellow"
+                    TestingName            = 'hsts-MoreInfo'
+                    DisplayTestingValue    = $true
                     DisplayCustomTabNumber = 2
                 }
                 Add-AnalyzedResultInformation @params

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -236,6 +236,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                     }
                 }
             }
+        $iisWebSitesWithHstsSettings = $iisWebSettings | Where-Object { $null -ne $_.hsts }
 
         if ($null -ne $missingWebApplicationConfigFile) {
             $params = $baseParams + @{
@@ -371,6 +372,107 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 DisplayCustomTabNumber = 2
             }
             Add-AnalyzedResultInformation @params
+        }
+
+        # TODO: Move this check to the new IIS section that we'll add to HC in near future - See issue: 1363
+        if (($iisWebSitesWithHstsSettings.Hsts.NativeHstsSettings.enabled -notcontains $true) -and
+            ($iisWebSitesWithHstsSettings.Hsts.HstsViaCustomHeader.enabled -notcontains $true)) {
+            $params = $baseParams + @{
+                Name    = "HSTS Enabled"
+                Details = $false
+            }
+            Add-AnalyzedResultInformation @params
+        } else {
+            $showAdditionalHstsInformation = $false
+            foreach ($webSite in $iisWebSitesWithHstsSettings) {
+                $hstsConfiguration = $null
+                $isExchangeBackEnd = $webSite.Name -eq "Exchange Back End"
+                $hstsMaxAgeWriteType = "Green"
+
+                if (($webSite.Hsts.NativeHstsSettings.enabled) -or
+                    ($webSite.Hsts.HstsViaCustomHeader.enabled)) {
+                    $params = $baseParams + @{
+                        Details          = "HSTS Enabled: $($webSite.Name)"
+                        DisplayWriteType = if ($isExchangeBackEnd) { "Red" } else { "Green" }
+                    }
+                    Add-AnalyzedResultInformation @params
+
+                    if ($isExchangeBackEnd) {
+                        $showAdditionalHstsInformation = $true
+                        $params = $baseParams + @{
+                            Details                = "HSTS on 'Exchange Back End' is not supported and can cause issues"
+                            DisplayWriteType       = "Red"
+                            DisplayCustomTabNumber = 2
+                        }
+                        Add-AnalyzedResultInformation @params
+                    }
+
+                    if (($webSite.Hsts.NativeHstsSettings.enabled) -and
+                    ($webSite.Hsts.HstsViaCustomHeader.enabled)) {
+                        $showAdditionalHstsInformation = $true
+                        Write-Verbose "HSTS conflict detected"
+                        $params = $baseParams + @{
+                            Details                = ("HSTS configured via customHeader and native IIS control - please remove one configuration" +
+                                "`r`n`t`tHSTS native IIS control has a higher weight than the customHeader and will be used")
+                            DisplayWriteType       = "Yellow"
+                            DisplayCustomTabNumber = 2
+                        }
+                        Add-AnalyzedResultInformation @params
+                    }
+
+                    if ($webSite.Hsts.NativeHstsSettings.enabled) {
+                        Write-Verbose "HSTS configured via native IIS control"
+                        $hstsConfiguration = $webSite.Hsts.NativeHstsSettings
+                    } else {
+                        Write-Verbose "HSTS configured via customHeader"
+                        $hstsConfiguration = $webSite.Hsts.HstsViaCustomHeader
+                    }
+
+                    $maxAgeValue = $hstsConfiguration.'max-age'
+                    if ($maxAgeValue -lt 31536000) {
+                        $showAdditionalHstsInformation = $true
+                        $hstsMaxAgeWriteType = "Yellow"
+                    }
+                    $params = $baseParams + @{
+                        Details                = "max-age: $maxAgeValue"
+                        DisplayWriteType       = $hstsMaxAgeWriteType
+                        DisplayCustomTabNumber = 2
+                    }
+                    Add-AnalyzedResultInformation @params
+
+                    $params = $baseParams + @{
+                        Details                = "includeSubDomains: $($hstsConfiguration.includeSubDomains)"
+                        DisplayCustomTabNumber = 2
+                    }
+                    Add-AnalyzedResultInformation @params
+
+                    $params = $baseParams + @{
+                        Details                = "preload: $($hstsConfiguration.preload)"
+                        DisplayCustomTabNumber = 2
+                    }
+                    Add-AnalyzedResultInformation @params
+
+                    $redirectHttpToHttpsConfigured = $hstsConfiguration.redirectHttpToHttps
+                    $params = $baseParams + @{
+                        Details                = "redirectHttpToHttps: $redirectHttpToHttpsConfigured"
+                        DisplayCustomTabNumber = 2
+                    }
+                    if ($redirectHttpToHttpsConfigured) {
+                        $showAdditionalHstsInformation = $true
+                        $params.Add("DisplayWriteType", "Red")
+                    }
+                    Add-AnalyzedResultInformation @params
+                }
+            }
+
+            if ($showAdditionalHstsInformation) {
+                $params = $baseParams + @{
+                    Details                = "`r`n`t`tMore Information about HSTS: https://aka.ms/HC-HSTS"
+                    DisplayWriteType       = "Yellow"
+                    DisplayCustomTabNumber = 2
+                }
+                Add-AnalyzedResultInformation @params
+            }
         }
     } elseif ($null -ne $exchangeInformation.IISSettings.ApplicationHostConfig) {
         Write-Verbose "Wasn't able find any other IIS settings, likely due to application host config file being messed up."

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -42,17 +42,88 @@ function Get-IISWebSite {
 
         $webConfigExists = Test-Path $configurationFilePath
         $webConfigContent = $null
+        $webConfigContentXml = $null
         $validWebConfig = $false
+        $customHeaderHstsObj = [PSCustomObject]@{
+            enabled             = $false
+            "max-age"           = 0
+            includeSubDomains   = $false
+            preload             = $false
+            redirectHttpToHttps = $false
+        }
+        $customHeaderHsts = $null
 
         if ($webConfigExists) {
             $webConfigContent = (Get-Content $configurationFilePath -Raw).Trim()
 
             try {
-                [xml]$webConfigContent | Out-Null
+                $webConfigContentXml = [xml]$webConfigContent
                 $validWebConfig = $true
             } catch {
                 # Inside of Invoke-Command, can't use Invoke-CatchActions
                 Write-Verbose "Failed to convert IIS web config '$configurationFilePath' to xml. Exception: $($_.Exception)"
+            }
+        }
+
+        if ($validWebConfig) {
+            <#
+                HSTS configuration can be done in different ways:
+                Via native HSTS control that comes with IIS 10.0 Version 1709.
+                See: https://learn.microsoft.com/iis/get-started/whats-new-in-iis-10-version-1709/iis-10-version-1709-hsts
+                The native control stores the HSTS configuration attributes in the <hsts> element which can be found under each <site> element.
+                These settings are returned when running the Get-WebSite cmdlet and there is no need to prepare the data as they are ready for use.
+
+                Via customHeader configuration (when running IIS older than the version mentioned before where the native HSTS config is not available
+                or when admins prefer to do it via customHeader as there is no requirement to do it via native HSTS control instead of using customHeader).
+                HSTS via customHeader configuration are stored under httpProtocol.customHeaders element. As we get the content in the previous
+                call, we can simply use these data to extract the customHeader with name Strict-Transport-Security (if exists) and can then prepare
+                the data for further processing.
+                The following code searches for a customHeader with name Strict-Transport-Security. If we find the header, we then extract the directive
+                and return them as PSCustomObject. We're looking for the following directive: max-age, includeSubDomains, preload, redirectHttpToHttps
+            #>
+            $customHeaderHsts = ($webConfigContentXml.configuration.'system.webServer'.httpProtocol.customHeaders.add | Where-Object {
+                ($_.name -eq "Strict-Transport-Security")
+                }).value
+            if ($null -ne $customHeaderHsts) {
+                Write-Verbose "Hsts via custom header configuration detected"
+                $customHeaderHstsObj.enabled = $true
+                # Make sure to ignore the case as per RFC 6797 the directives are case-insensitive
+                # We ignore any other directives as these MUST be ignored by the User Agent (UA) as per RFC 6797
+                # UAs MUST ignore any STS header field containing directives, or other header field value data,
+                # that does not conform to the syntax defined in this specification.
+                $maxAgeIndex = $customHeaderHsts.IndexOf("max-age=", [System.StringComparison]::OrdinalIgnoreCase)
+                $includeSubDomainsIndex = $customHeaderHsts.IndexOf("includeSubDomains", [System.StringComparison]::OrdinalIgnoreCase)
+                $preloadIndex = $customHeaderHsts.IndexOf("preload", [System.StringComparison]::OrdinalIgnoreCase)
+                $redirectHttpToHttpsIndex = $customHeaderHsts.IndexOf("redirectHttpToHttps", [System.StringComparison]::OrdinalIgnoreCase)
+                if ($maxAgeIndex -ne -1) {
+                    Write-Verbose "max-age directive found"
+                    $maxAgeValueIndex = $customHeaderHsts.IndexOf(";", $maxAgeIndex)
+                    # add 8 to find the start index after 'max-age='
+                    $maxAgeIndex = $maxAgeIndex + 8
+
+                    # subtract maxAgeIndex to get the length that we need to find the substring
+                    $maxAgeValueIndex = $maxAgeValueIndex - $maxAgeIndex
+                    $customHeaderHstsObj.'max-age' = $customHeaderHsts.Substring($maxAgeIndex, $maxAgeValueIndex)
+                } else {
+                    Write-Verbose "max-age directive not found"
+                }
+
+                if ($includeSubDomainsIndex -ne -1) {
+                    Write-Verbose "includeSubDomains directive found"
+                    $customHeaderHstsObj.includeSubDomains = $true
+                }
+
+                if ($preloadIndex -ne -1) {
+                    Write-Verbose "preload directive found"
+                    $customHeaderHstsObj.preload = $true
+                }
+
+                if ($redirectHttpToHttpsIndex -ne -1) {
+                    Write-Verbose "redirectHttpToHttps directive found"
+                    $customHeaderHstsObj.redirectHttpToHttps = $true
+                }
+            } else {
+                Write-Verbose "No Hsts via custom header configuration detected"
             }
         }
 
@@ -64,7 +135,10 @@ function Get-IISWebSite {
                 Limits                     = $site.Limits
                 LogFile                    = $site.logFile
                 TraceFailedRequestsLogging = $site.traceFailedRequestsLogging
-                Hsts                       = $site.hsts
+                Hsts                       = [PSCustomObject]@{
+                    NativeHstsSettings  = $site.hsts
+                    HstsViaCustomHeader = $customHeaderHstsObj
+                }
                 ApplicationDefaults        = $site.applicationDefaults
                 VirtualDirectoryDefaults   = $site.virtualDirectoryDefaults
                 Collection                 = $site.collection

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web2.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web2.config
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <location inheritInChildApplications="false">
+    <system.webServer>
+      <serverRuntime appConcurrentRequestLimit="65535" uploadReadAheadSize="0" />
+      <modules>
+        <!-- Standard set of module removes for reducing per-request memory footprint and to reduce native/managed context switches -->
+        <remove name="CustomErrorModule" />
+        <remove name="DefaultAuthentication" />
+        <remove name="DirectoryListingModule" />
+        <remove name="DynamicCompressionModule" />
+        <remove name="FileAuthorization" />
+        <remove name="FormsAuthentication" />
+        <remove name="HttpCacheModule" />
+        <remove name="OutputCache" />
+        <remove name="Profile" />
+        <remove name="ProtocolSupportModule" />
+        <remove name="RequestFilteringModule" />
+        <remove name="RoleManager" />
+        <remove name="ScriptModule-4.0" />
+        <remove name="ServiceModel" />
+        <remove name="ServiceModel-4.0" />
+        <remove name="Session" />
+        <remove name="StaticCompressionModule" />
+        <remove name="UrlAuthorization" />
+        <remove name="UrlMappingsModule" />
+        <remove name="UrlRoutingModule-4.0" />
+
+        <!-- Keep the HostHeaderValidationModule first - it prevents excessive and unnecessary Watsons that result from bogus host headers -->
+        <add name="HostHeaderValidationModule" type="Microsoft.Exchange.HttpUtilities.HostHeaderValidationModule, Microsoft.Exchange.HttpUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="OwaJavascriptRedirectModule" type="Microsoft.Exchange.HttpRedirect.OwaJavascriptRedirectModule, Microsoft.Exchange.HttpRedirectModules, Version=15.0.0.0,Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </modules>
+    </system.webServer>
+    <system.web>
+      <machineKey validationKey="AutoGenerate,IsolateApps" />
+      <compilation defaultLanguage="c#" debug="false">
+        <assemblies>
+          <add assembly="Microsoft.Exchange.HttpRedirectModules, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        </assemblies>
+      </compilation>
+    </system.web>
+  </location>
+  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    <linkedConfiguration href="file://C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\SharedWebConfig.config"/>
+  </assemblyBinding>
+      <system.webServer>
+        <httpProtocol>
+            <customHeaders>
+                <add name="Strict-Transport-Security" value="max-age=300; includeSubDomains" />
+            </customHeaders>
+        </httpProtocol>
+    </system.webServer>
+</configuration>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite1.xml
@@ -1,0 +1,15951 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Name">Default Web Site</S>
+      <I64 N="Id">1</I64>
+      <S N="State">Started</S>
+      <Obj N="Limits" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#limits</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="2">
+            <TN RefId="2">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE>
+              <Obj RefId="3">
+                <TN RefId="3">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxBandwidth</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="4">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxConnections</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="5">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">connectionTimeout</S>
+                  <S N="TypeName">System.TimeSpan</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <TS N="Value">PT2M</TS>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="6">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxUrlSegments</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">32</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">4</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="7">
+            <TN RefId="4">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationChildElementCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE />
+            <Props>
+              <I32 N="Count">0</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">limits</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="8">
+            <TN RefId="5">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="9">
+                <TN RefId="6">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">limits</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <I64 N="maxBandwidth">4294967295</I64>
+          <I64 N="maxConnections">4294967295</I64>
+          <TS N="connectionTimeout">PT2M</TS>
+          <I64 N="maxUrlSegments">32</I64>
+        </MS>
+      </Obj>
+      <Obj N="LogFile" RefId="10">
+        <TN RefId="7">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#logFile</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="11">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="12">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logExtFileFlags</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2478031</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="13">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customLogPluginClsid</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="14">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logFormat</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="15">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logTargetW3C</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="16">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\LogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="17">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">period</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="18">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">truncateSize</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">20971520</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="19">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">localTimeRollover</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="20">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="21">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logSiteId</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="22">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">flushByEntryCountW3CLog</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="23">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogLineLength</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">65536</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">12</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="24">
+            <TNRef RefId="4" />
+            <IE>
+              <Obj RefId="25">
+                <TN RefId="8">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollection</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollectionBase`1[[Microsoft.IIs.PowerShell.Framework.ConfigurationElement, Microsoft.IIS.PowerShell.Framework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE />
+                <Props>
+                  <B N="AllowsAdd">true</B>
+                  <B N="AllowsClear">true</B>
+                  <B N="AllowsRemove">false</B>
+                  <I32 N="Count">0</I32>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <Obj N="Attributes" RefId="26">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                    </IE>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">customFields</S>
+                  <Nil N="Methods" />
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">1</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">logFile</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="27">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="28">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Obj N="ChildElementSchemas" RefId="29">
+                <TN RefId="9">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">logFile</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="logExtFileFlags">Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus</S>
+          <S N="customLogPluginClsid"></S>
+          <S N="logFormat">W3C</S>
+          <S N="logTargetW3C">File</S>
+          <S N="directory">%SystemDrive%\inetpub\logs\LogFiles</S>
+          <S N="period">Daily</S>
+          <I64 N="truncateSize">20971520</I64>
+          <B N="localTimeRollover">false</B>
+          <B N="enabled">true</B>
+          <B N="logSiteId">true</B>
+          <I64 N="flushByEntryCountW3CLog">0</I64>
+          <I64 N="maxLogLineLength">65536</I64>
+          <Obj N="customFields" RefId="30">
+            <TN RefId="10">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#logFile#customFields</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="31">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="32">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">maxCustomFieldLength</S>
+                      <S N="TypeName">System.Int64</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I64 N="Value">4096</I64>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Ref N="ChildElements" RefId="7" />
+              <S N="ElementTagName">customFields</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="33">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="34">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Nil N="ChildElementSchemas" />
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">customFields</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <I64 N="maxCustomFieldLength">4096</I64>
+              <Obj N="Collection" RefId="35">
+                <TN RefId="11">
+                  <T>System.Management.Automation.PSObject[]</T>
+                  <T>System.Array</T>
+                  <T>System.Object</T>
+                </TN>
+                <LST />
+              </Obj>
+            </MS>
+          </Obj>
+        </MS>
+      </Obj>
+      <Obj N="TraceFailedRequestsLogging" RefId="36">
+        <TN RefId="12">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#traceFailedRequestsLogging</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="37">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="38">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="39">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="40">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFiles</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">50</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="41">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFileSizeKB</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">1024</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="42">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customActionsEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">traceFailedRequestsLogging</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="43">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="44">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">traceFailedRequestsLogging</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">false</B>
+          <S N="directory">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+          <I64 N="maxLogFiles">50</I64>
+          <I64 N="maxLogFileSizeKB">1024</I64>
+          <B N="customActionsEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="Hsts" RefId="45">
+        <TN RefId="13">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#hsts</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="46">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="47">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="48">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">max-age</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="49">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">includeSubDomains</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="50">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preload</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="51">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">redirectHttpToHttps</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">hsts</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="52">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="53">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">hsts</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">true</B>
+          <I64 N="max-age">0</I64>
+          <B N="includeSubDomains">false</B>
+          <B N="preload">false</B>
+          <B N="redirectHttpToHttps">false</B>
+        </MS>
+      </Obj>
+      <Obj N="ApplicationDefaults" RefId="54">
+        <TN RefId="14">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#applicationDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="55">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="56">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="57">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">applicationPool</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="58">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabledProtocols</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">http</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="59">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="60">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartProvider</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="61">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preloadEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">applicationDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="62">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="63">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">applicationDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="applicationPool"></S>
+          <S N="enabledProtocols">http</S>
+          <B N="serviceAutoStartEnabled">false</B>
+          <S N="serviceAutoStartProvider"></S>
+          <B N="preloadEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="VirtualDirectoryDefaults" RefId="64">
+        <TN RefId="15">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#virtualDirectoryDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="65">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="66">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="67">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">physicalPath</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="68">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">userName</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="69">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">password</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="70">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logonMethod</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">3</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="71">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">allowSubDirConfig</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">virtualDirectoryDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="72">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="73">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">virtualDirectoryDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="physicalPath"></S>
+          <S N="userName"></S>
+          <S N="password"></S>
+          <S N="logonMethod">ClearText</S>
+          <B N="allowSubDirConfig">true</B>
+        </MS>
+      </Obj>
+      <Obj N="Collection" RefId="74">
+        <TNRef RefId="11" />
+        <LST>
+          <Obj RefId="75">
+            <TN RefId="16">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#application</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="76">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="77">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="78">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="79">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="80">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="81">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="82">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="83">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="84">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="85">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="86">
+                    <TN RefId="17">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="87">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="88">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="89">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="90">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="91">
+                <TN RefId="18">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectoryDefaults</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="92">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="93">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="94">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="95">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="96">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="97">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="98">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="99">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="100">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="101">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="102">
+                    <TN RefId="19">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectory</T>
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="103">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="104">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="105">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%SystemDrive%\inetpub\wwwroot</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="106">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="107">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="108">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="109">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="110">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="111">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%SystemDrive%\inetpub\wwwroot</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="112">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="113">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="114">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="115">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="116">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="117">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="118">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="119">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="120">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="121">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="122">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="123">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="124">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="125">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="126">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="127">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="128">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="129">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="130">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="131">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="132">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="133">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="134">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="135">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="136">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="137">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="138">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="139">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="140">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="141">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="142">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="143">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="144">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="145">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="146">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="147">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="148">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="149">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="150">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="151">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Calendar</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="152">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWACalendarAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="153">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="154">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="155">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="156">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="157">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="158">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="159">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="160">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="161">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="162">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="163">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="164">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Calendar</S>
+              <S N="applicationPool">MSExchangeOWACalendarAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="165">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="166">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="167">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="168">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="169">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="170">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="171">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="172">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="173">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="174">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="175">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="176">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="177">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="178">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="179">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="180">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="181">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="182">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="183">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="184">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="185">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="186">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="187">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="188">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Integrated</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="189">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="190">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="191">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="192">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="193">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="194">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="195">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="196">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="197">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="198">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="199">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="200">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="201">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Integrated</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="202">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="203">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="204">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="205">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="206">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="207">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="208">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="209">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="210">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="211">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="212">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="213">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="214">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="215">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="216">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="217">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="218">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="219">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="220">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="221">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="222">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="223">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="224">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="225">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/oma</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="226">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="227">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="228">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="229">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="230">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="231">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="232">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="233">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="234">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="235">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="236">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="237">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="238">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/oma</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="239">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="240">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="241">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="242">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="243">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="244">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="245">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="246">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="247">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="248">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="249">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="250">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="251">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="252">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="253">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="254">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="255">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="256">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="257">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="258">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="259">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="260">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="261">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="262">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/ecp</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="263">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeECPAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="264">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="265">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="266">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="267">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="268">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="269">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="270">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="271">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="272">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="273">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="274">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="275">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/ecp</S>
+              <S N="applicationPool">MSExchangeECPAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="276">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="277">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="278">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="279">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="280">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="281">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="282">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="283">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="284">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="285">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="286">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="287">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="288">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="289">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="290">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\ecp</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="291">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="292">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="293">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="294">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="295">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="296">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\ecp</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="297">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="298">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="299">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="300">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="301">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="302">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="303">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="304">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="305">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="306">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="307">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="308">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="309">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="310">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="311">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="312">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="313">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="314">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="315">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="316">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="317">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="318">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="319">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="320">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="321">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="322">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="323">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="324">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="325">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="326">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="327">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\EWS</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="328">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="329">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="330">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="331">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="332">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="333">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\EWS</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="334">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="335">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="336">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/API</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="337">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRestFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="338">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="339">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="340">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="341">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="342">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="343">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="344">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="345">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="346">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="347">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="348">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="349">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/API</S>
+              <S N="applicationPool">MSExchangeRestFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="350">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="351">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="352">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="353">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="354">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="355">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="356">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="357">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="358">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="359">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="360">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="361">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="362">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="363">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="364">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Rest</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="365">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="366">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="367">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="368">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="369">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="370">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Rest</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="371">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="372">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="373">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Autodiscover</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="374">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeAutodiscoverAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="375">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="376">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="377">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="378">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="379">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="380">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="381">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="382">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="383">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="384">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="385">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="386">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Autodiscover</S>
+              <S N="applicationPool">MSExchangeAutodiscoverAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="387">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="388">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="389">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="390">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="391">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="392">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="393">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="394">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="395">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="396">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="397">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="398">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="399">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="400">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="401">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Autodiscover</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="402">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="403">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="404">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="405">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="406">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="407">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Autodiscover</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="408">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="409">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="410">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Microsoft-Server-ActiveSync</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="411">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeSyncAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="412">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="413">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="414">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="415">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="416">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="417">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="418">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="419">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="420">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="421">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="422">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="423">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Microsoft-Server-ActiveSync</S>
+              <S N="applicationPool">MSExchangeSyncAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="424">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="425">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="426">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="427">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="428">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="429">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="430">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="431">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="432">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="433">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="434">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="435">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="436">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="437">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="438">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\sync</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="439">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="440">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="441">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="442">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="443">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="444">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\sync</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="445">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="446">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="447">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/OAB</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="448">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOABAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="449">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="450">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="451">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="452">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="453">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="454">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="455">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="456">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="457">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="458">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="459">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="460">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/OAB</S>
+              <S N="applicationPool">MSExchangeOABAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="461">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="462">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="463">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="464">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="465">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="466">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="467">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="468">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="469">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="470">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="471">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="472">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="473">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="474">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="475">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\OAB</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="476">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="477">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="478">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="479">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="480">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="481">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\OAB</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="482">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="483">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="484">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PowerShell</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="485">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePowerShellFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="486">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="487">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="488">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="489">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="490">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="491">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="492">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="493">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="494">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="495">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="496">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="497">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PowerShell</S>
+              <S N="applicationPool">MSExchangePowerShellFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="498">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="499">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="500">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="501">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="502">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="503">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="504">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="505">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="506">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="507">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="508">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="509">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="510">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="511">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="512">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\PowerShell</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="513">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="514">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="515">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="516">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="517">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="518">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\PowerShell</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="519">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="520">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="521">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="522">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="523">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="524">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="525">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="526">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="527">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="528">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="529">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="530">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="531">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="532">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="533">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="534">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi</S>
+              <S N="applicationPool">MSExchangeMapiFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="535">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="536">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="537">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="538">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="539">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="540">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="541">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="542">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="543">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="544">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="545">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="546">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="547">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="548">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="549">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="550">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="551">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="552">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="553">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="554">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="555">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\mapi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="556">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="557">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="558">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Rpc</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="559">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="560">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="561">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="562">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="563">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="564">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="565">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="566">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="567">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="568">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="569">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="570">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="571">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Rpc</S>
+              <S N="applicationPool">MSExchangeRpcProxyFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="572">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="573">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="574">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="575">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="576">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="577">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="578">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="579">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="580">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="581">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="582">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="583">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="584">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="585">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="586">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\rpc</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="587">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="588">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="589">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="590">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="591">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="592">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\rpc</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+        </LST>
+      </Obj>
+      <S N="ApplicationPool">MSExchangeOWAAppPool</S>
+      <S N="EnabledProtocols">http</S>
+      <S N="PhysicalPath">C:\inetpub\wwwroot</S>
+    </MS>
+  </Obj>
+  <Obj RefId="593">
+    <TNRef RefId="0" />
+    <MS>
+      <S N="Name">Exchange Back End</S>
+      <I64 N="Id">2</I64>
+      <S N="State">Started</S>
+      <Obj N="Limits" RefId="594">
+        <TNRef RefId="1" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="595">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="596">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxBandwidth</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="597">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxConnections</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="598">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">connectionTimeout</S>
+                  <S N="TypeName">System.TimeSpan</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <TS N="Value">PT2M</TS>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="599">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxUrlSegments</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">32</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">4</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">limits</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="600">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="601">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">limits</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <I64 N="maxBandwidth">4294967295</I64>
+          <I64 N="maxConnections">4294967295</I64>
+          <TS N="connectionTimeout">PT2M</TS>
+          <I64 N="maxUrlSegments">32</I64>
+        </MS>
+      </Obj>
+      <Obj N="LogFile" RefId="602">
+        <TNRef RefId="7" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="603">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="604">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logExtFileFlags</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2478031</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="605">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customLogPluginClsid</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="606">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logFormat</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="607">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logTargetW3C</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="608">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\LogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="609">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">period</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="610">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">truncateSize</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">20971520</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="611">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">localTimeRollover</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="612">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="613">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logSiteId</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="614">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">flushByEntryCountW3CLog</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="615">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogLineLength</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">65536</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">12</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="616">
+            <TNRef RefId="4" />
+            <IE>
+              <Obj RefId="617">
+                <TNRef RefId="8" />
+                <IE />
+                <Props>
+                  <B N="AllowsAdd">true</B>
+                  <B N="AllowsClear">true</B>
+                  <B N="AllowsRemove">false</B>
+                  <I32 N="Count">0</I32>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <Obj N="Attributes" RefId="618">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                    </IE>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">customFields</S>
+                  <Nil N="Methods" />
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">1</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">logFile</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="619">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="620">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Obj N="ChildElementSchemas" RefId="621">
+                <TNRef RefId="9" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">logFile</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="logExtFileFlags">Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus</S>
+          <S N="customLogPluginClsid"></S>
+          <S N="logFormat">W3C</S>
+          <S N="logTargetW3C">File</S>
+          <S N="directory">%SystemDrive%\inetpub\logs\LogFiles</S>
+          <S N="period">Daily</S>
+          <I64 N="truncateSize">20971520</I64>
+          <B N="localTimeRollover">false</B>
+          <B N="enabled">true</B>
+          <B N="logSiteId">true</B>
+          <I64 N="flushByEntryCountW3CLog">0</I64>
+          <I64 N="maxLogLineLength">65536</I64>
+          <Obj N="customFields" RefId="622">
+            <TNRef RefId="10" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="623">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="624">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">maxCustomFieldLength</S>
+                      <S N="TypeName">System.Int64</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I64 N="Value">4096</I64>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Ref N="ChildElements" RefId="7" />
+              <S N="ElementTagName">customFields</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="625">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="626">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Nil N="ChildElementSchemas" />
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">customFields</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <I64 N="maxCustomFieldLength">4096</I64>
+              <Obj N="Collection" RefId="627">
+                <TNRef RefId="11" />
+                <LST />
+              </Obj>
+            </MS>
+          </Obj>
+        </MS>
+      </Obj>
+      <Obj N="TraceFailedRequestsLogging" RefId="628">
+        <TNRef RefId="12" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="629">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="630">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="631">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="632">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFiles</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">50</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="633">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFileSizeKB</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">1024</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="634">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customActionsEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">traceFailedRequestsLogging</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="635">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="636">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">traceFailedRequestsLogging</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">false</B>
+          <S N="directory">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+          <I64 N="maxLogFiles">50</I64>
+          <I64 N="maxLogFileSizeKB">1024</I64>
+          <B N="customActionsEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="Hsts" RefId="637">
+        <TNRef RefId="13" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="638">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="639">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="640">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">max-age</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="641">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">includeSubDomains</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="642">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preload</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="643">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">redirectHttpToHttps</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">hsts</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="644">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="645">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">hsts</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">false</B>
+          <I64 N="max-age">0</I64>
+          <B N="includeSubDomains">false</B>
+          <B N="preload">false</B>
+          <B N="redirectHttpToHttps">false</B>
+        </MS>
+      </Obj>
+      <Obj N="ApplicationDefaults" RefId="646">
+        <TNRef RefId="14" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="647">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="648">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="649">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">applicationPool</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="650">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabledProtocols</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">http</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="651">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="652">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartProvider</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="653">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preloadEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">applicationDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="654">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="655">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">applicationDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="applicationPool"></S>
+          <S N="enabledProtocols">http</S>
+          <B N="serviceAutoStartEnabled">false</B>
+          <S N="serviceAutoStartProvider"></S>
+          <B N="preloadEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="VirtualDirectoryDefaults" RefId="656">
+        <TNRef RefId="15" />
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="657">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="658">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="659">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">physicalPath</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="660">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">userName</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="661">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">password</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="662">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logonMethod</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">3</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="663">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">allowSubDirConfig</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">virtualDirectoryDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="664">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="665">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">virtualDirectoryDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="physicalPath"></S>
+          <S N="userName"></S>
+          <S N="password"></S>
+          <S N="logonMethod">ClearText</S>
+          <B N="allowSubDirConfig">true</B>
+        </MS>
+      </Obj>
+      <Obj N="Collection" RefId="666">
+        <TNRef RefId="11" />
+        <LST>
+          <Obj RefId="667">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="668">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="669">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="670">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">DefaultAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="671">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="672">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="673">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="674">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="675">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="676">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="677">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="678">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="679">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="680">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="681">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="682">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/</S>
+              <S N="applicationPool">DefaultAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="683">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="684">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="685">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="686">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="687">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="688">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="689">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="690">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="691">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="692">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="693">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="694">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="695">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="696">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="697">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="698">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="699">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="700">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="701">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="702">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="703">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="704">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="705">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="706">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="707">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="708">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="709">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="710">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="711">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="712">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="713">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/mapi</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="714">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="715">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="716">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Exchange</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="717">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="718">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="719">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="720">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="721">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="722">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="723">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Exchange</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="724">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="725">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="726">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Exchweb</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="727">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="728">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="729">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="730">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="731">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="732">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="733">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Exchweb</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="734">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="735">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="736">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Public</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="737">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="738">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="739">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="740">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="741">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="742">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="743">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Public</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="744">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="745">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="746">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PowerShell</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="747">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePowerShellAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="748">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="749">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="750">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="751">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="752">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="753">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="754">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="755">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="756">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="757">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="758">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="759">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PowerShell</S>
+              <S N="applicationPool">MSExchangePowerShellAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="760">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="761">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="762">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="763">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="764">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="765">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="766">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="767">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="768">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="769">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="770">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="771">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="772">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="773">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="774">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PowerShell-Proxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="775">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="776">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="777">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="778">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="779">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="780">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PowerShell-Proxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="781">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="782">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="783">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi/emsmdb</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="784">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiMailboxAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="785">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="786">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="787">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="788">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="789">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="790">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="791">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="792">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="793">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="794">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="795">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="796">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi/emsmdb</S>
+              <S N="applicationPool">MSExchangeMapiMailboxAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="797">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="798">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="799">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="800">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="801">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="802">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="803">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="804">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="805">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="806">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="807">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="808">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="809">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="810">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="811">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\emsmdb</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="812">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="813">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="814">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="815">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="816">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="817">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\emsmdb</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="818">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="819">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="820">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi/nspi</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="821">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiAddressBookAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="822">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="823">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="824">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="825">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="826">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="827">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="828">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="829">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="830">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="831">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="832">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="833">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi/nspi</S>
+              <S N="applicationPool">MSExchangeMapiAddressBookAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="834">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="835">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="836">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="837">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="838">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="839">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="840">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="841">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="842">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="843">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="844">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="845">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="846">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="847">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="848">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\nspi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="849">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="850">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="851">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="852">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="853">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="854">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\nspi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="855">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="856">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="857">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/API</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="858">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRestAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="859">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="860">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="861">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="862">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="863">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="864">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="865">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="866">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="867">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="868">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="869">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="870">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/API</S>
+              <S N="applicationPool">MSExchangeRestAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="871">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="872">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="873">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="874">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="875">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="876">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="877">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="878">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="879">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="880">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="881">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="882">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="883">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="884">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="885">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\rest</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="886">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="887">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="888">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="889">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="890">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="891">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\rest</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="892">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="893">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="894">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="895">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="896">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="897">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="898">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="899">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="900">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="901">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="902">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="903">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="904">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="905">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="906">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="907">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="908">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="909">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="910">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="911">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="912">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="913">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="914">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="915">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="916">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="917">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="918">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="919">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="920">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="921">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="922">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="923">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="924">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="925">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="926">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="927">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="928">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="929">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="930">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="931">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Calendar</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="932">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWACalendarAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="933">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="934">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="935">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="936">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="937">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="938">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="939">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="940">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="941">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="942">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="943">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="944">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Calendar</S>
+              <S N="applicationPool">MSExchangeOWACalendarAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="945">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="946">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="947">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="948">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="949">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="950">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="951">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="952">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="953">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="954">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="955">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="956">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="957">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="958">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="959">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="960">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="961">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="962">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="963">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="964">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="965">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="966">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="967">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="968">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/OAB</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="969">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOABAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="970">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="971">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="972">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="973">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="974">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="975">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="976">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="977">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="978">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="979">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="980">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="981">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/OAB</S>
+              <S N="applicationPool">MSExchangeOABAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="982">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="983">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="984">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="985">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="986">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="987">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="988">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="989">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="990">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="991">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="992">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="993">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="994">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="995">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="996">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\OAB</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="997">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="998">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="999">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1000">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1001">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1002">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\OAB</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1003">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1004">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1005">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/ecp</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1006">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeECPAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1007">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1008">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1009">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1010">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1011">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1012">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1013">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1014">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1015">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1016">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1017">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1018">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/ecp</S>
+              <S N="applicationPool">MSExchangeECPAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1019">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1020">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1021">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1022">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1023">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1024">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1025">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1026">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1027">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1028">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1029">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1030">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1031">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1032">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1033">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\ecp</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1034">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1035">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1036">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1037">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1038">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1039">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\ecp</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1040">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1041">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1042">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Autodiscover</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1043">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeAutodiscoverAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1044">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1045">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1046">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1047">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1048">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1049">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1050">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1051">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1052">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1053">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1054">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1055">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Autodiscover</S>
+              <S N="applicationPool">MSExchangeAutodiscoverAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1056">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1057">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1058">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1059">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1060">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1061">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1062">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1063">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1064">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1065">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1066">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1067">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1068">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1069">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1070">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\Autodiscover</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1071">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1072">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1073">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1074">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1075">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1076">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\Autodiscover</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1077">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1078">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1079">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Microsoft-Server-ActiveSync</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1080">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeSyncAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1081">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1082">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1083">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1084">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1085">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1086">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1087">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1088">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1089">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1090">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1091">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1092">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Microsoft-Server-ActiveSync</S>
+              <S N="applicationPool">MSExchangeSyncAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1093">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1094">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1095">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1096">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1097">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1098">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1099">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1100">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1101">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1102">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1103">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1104">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1105">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1106">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1107">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\sync</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1108">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1109">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1110">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1111">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1112">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1113">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\sync</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1114">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1115">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1116">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1117">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1118">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1119">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1120">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1121">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1122">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1123">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1124">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1125">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1126">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1127">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1128">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1129">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1130">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1131">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1132">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1133">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1134">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1135">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1136">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1137">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1138">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1139">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1140">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1141">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1142">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1143">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1144">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1145">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1146">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1147">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1148">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1149">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1150">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1151">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1152">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1153">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS/bin</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1154">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1155">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1156">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1157">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1158">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1159">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1160">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1161">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1162">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1163">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1164">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1165">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1166">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS/bin</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1167">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1168">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1169">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1170">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1171">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1172">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1173">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1174">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1175">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1176">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1177">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1178">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1179">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1180">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1181">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS\bin</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1182">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1183">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1184">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1185">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1186">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1187">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS\bin</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1188">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1189">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1190">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Rpc</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1191">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1192">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1193">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1194">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1195">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1196">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1197">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1198">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1199">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1200">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1201">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1202">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1203">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Rpc</S>
+              <S N="applicationPool">MSExchangeRpcProxyAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1204">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1205">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1206">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1207">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1208">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1209">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1210">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1211">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1212">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1213">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1214">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1215">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1216">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1217">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1218">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%windir%\System32\RpcProxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1219">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1220">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1221">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1222">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1223">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1224">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%windir%\System32\RpcProxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1225">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1226">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1227">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/RpcWithCert</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1228">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1229">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1230">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1231">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1232">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1233">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1234">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1235">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1236">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1237">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1238">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1239">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1240">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/RpcWithCert</S>
+              <S N="applicationPool">MSExchangeRpcProxyAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1241">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1242">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1243">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1244">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1245">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1246">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1247">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1248">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1249">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1250">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1251">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1252">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1253">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1254">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1255">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%windir%\System32\RpcProxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1256">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1257">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1258">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1259">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1260">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1261">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%windir%\System32\RpcProxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="1262">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="1263">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="1264">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PushNotifications</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1265">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePushNotificationsAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1266">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http,net.pipe</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1267">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1268">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1269">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1270">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="1271">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="1272">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="1273">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1274">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="1275">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="1276">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="1277">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PushNotifications</S>
+              <S N="applicationPool">MSExchangePushNotificationsAppPool</S>
+              <S N="enabledProtocols">http,net.pipe</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="1278">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="1279">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="1280">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1281">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1282">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1283">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1284">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="1285">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="1286">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="1287">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="1288">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="1289">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="1290">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="1291">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1292">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PushNotifications</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1293">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1294">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1295">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="1296">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="1297">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="1298">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PushNotifications</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+        </LST>
+      </Obj>
+      <S N="ApplicationPool">DefaultAppPool</S>
+      <S N="EnabledProtocols">http</S>
+      <S N="PhysicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite_DefaultWebSite1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite_DefaultWebSite1.xml
@@ -1,0 +1,7311 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Name">Default Web Site</S>
+      <I64 N="Id">1</I64>
+      <S N="State">Started</S>
+      <Obj N="Limits" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#limits</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="2">
+            <TN RefId="2">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE>
+              <Obj RefId="3">
+                <TN RefId="3">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxBandwidth</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="4">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxConnections</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="5">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">connectionTimeout</S>
+                  <S N="TypeName">System.TimeSpan</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <TS N="Value">PT2M</TS>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="6">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxUrlSegments</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">32</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">4</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="7">
+            <TN RefId="4">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationChildElementCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE />
+            <Props>
+              <I32 N="Count">0</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">limits</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="8">
+            <TN RefId="5">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="9">
+                <TN RefId="6">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">limits</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <I64 N="maxBandwidth">4294967295</I64>
+          <I64 N="maxConnections">4294967295</I64>
+          <TS N="connectionTimeout">PT2M</TS>
+          <I64 N="maxUrlSegments">32</I64>
+        </MS>
+      </Obj>
+      <Obj N="LogFile" RefId="10">
+        <TN RefId="7">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#logFile</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="11">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="12">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logExtFileFlags</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2478031</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="13">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customLogPluginClsid</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="14">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logFormat</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="15">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logTargetW3C</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="16">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\LogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="17">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">period</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="18">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">truncateSize</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">20971520</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="19">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">localTimeRollover</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="20">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="21">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logSiteId</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="22">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">flushByEntryCountW3CLog</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="23">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogLineLength</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">65536</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">12</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="24">
+            <TNRef RefId="4" />
+            <IE>
+              <Obj RefId="25">
+                <TN RefId="8">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollection</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollectionBase`1[[Microsoft.IIs.PowerShell.Framework.ConfigurationElement, Microsoft.IIS.PowerShell.Framework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE />
+                <Props>
+                  <B N="AllowsAdd">true</B>
+                  <B N="AllowsClear">true</B>
+                  <B N="AllowsRemove">false</B>
+                  <I32 N="Count">0</I32>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <Obj N="Attributes" RefId="26">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                    </IE>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">customFields</S>
+                  <Nil N="Methods" />
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">1</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">logFile</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="27">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="28">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Obj N="ChildElementSchemas" RefId="29">
+                <TN RefId="9">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">logFile</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="logExtFileFlags">Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus</S>
+          <S N="customLogPluginClsid"></S>
+          <S N="logFormat">W3C</S>
+          <S N="logTargetW3C">File</S>
+          <S N="directory">%SystemDrive%\inetpub\logs\LogFiles</S>
+          <S N="period">Daily</S>
+          <I64 N="truncateSize">20971520</I64>
+          <B N="localTimeRollover">false</B>
+          <B N="enabled">true</B>
+          <B N="logSiteId">true</B>
+          <I64 N="flushByEntryCountW3CLog">0</I64>
+          <I64 N="maxLogLineLength">65536</I64>
+          <Obj N="customFields" RefId="30">
+            <TN RefId="10">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#logFile#customFields</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="31">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="32">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">maxCustomFieldLength</S>
+                      <S N="TypeName">System.Int64</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I64 N="Value">4096</I64>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Ref N="ChildElements" RefId="7" />
+              <S N="ElementTagName">customFields</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="33">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="34">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Nil N="ChildElementSchemas" />
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">customFields</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <I64 N="maxCustomFieldLength">4096</I64>
+              <Obj N="Collection" RefId="35">
+                <TN RefId="11">
+                  <T>System.Management.Automation.PSObject[]</T>
+                  <T>System.Array</T>
+                  <T>System.Object</T>
+                </TN>
+                <LST />
+              </Obj>
+            </MS>
+          </Obj>
+        </MS>
+      </Obj>
+      <Obj N="TraceFailedRequestsLogging" RefId="36">
+        <TN RefId="12">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#traceFailedRequestsLogging</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="37">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="38">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="39">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="40">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFiles</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">50</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="41">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFileSizeKB</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">1024</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="42">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customActionsEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">traceFailedRequestsLogging</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="43">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="44">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">traceFailedRequestsLogging</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">false</B>
+          <S N="directory">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+          <I64 N="maxLogFiles">50</I64>
+          <I64 N="maxLogFileSizeKB">1024</I64>
+          <B N="customActionsEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="Hsts" RefId="45">
+        <TN RefId="13">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#hsts</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="46">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="47">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="48">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">max-age</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">300</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="49">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">includeSubDomains</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="50">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preload</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="51">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">redirectHttpToHttps</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">hsts</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="52">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="53">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">hsts</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">true</B>
+          <I64 N="max-age">300</I64>
+          <B N="includeSubDomains">false</B>
+          <B N="preload">false</B>
+          <B N="redirectHttpToHttps">false</B>
+        </MS>
+      </Obj>
+      <Obj N="ApplicationDefaults" RefId="54">
+        <TN RefId="14">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#applicationDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="55">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="56">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="57">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">applicationPool</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="58">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabledProtocols</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">http</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="59">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="60">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartProvider</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="61">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preloadEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">applicationDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="62">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="63">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">applicationDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="applicationPool"></S>
+          <S N="enabledProtocols">http</S>
+          <B N="serviceAutoStartEnabled">false</B>
+          <S N="serviceAutoStartProvider"></S>
+          <B N="preloadEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="VirtualDirectoryDefaults" RefId="64">
+        <TN RefId="15">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#virtualDirectoryDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="65">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="66">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="67">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">physicalPath</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="68">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">userName</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="69">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">password</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="70">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logonMethod</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">3</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="71">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">allowSubDirConfig</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">virtualDirectoryDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="72">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="73">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">virtualDirectoryDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="physicalPath"></S>
+          <S N="userName"></S>
+          <S N="password"></S>
+          <S N="logonMethod">ClearText</S>
+          <B N="allowSubDirConfig">true</B>
+        </MS>
+      </Obj>
+      <Obj N="Collection" RefId="74">
+        <TNRef RefId="11" />
+        <LST>
+          <Obj RefId="75">
+            <TN RefId="16">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#application</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="76">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="77">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="78">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="79">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="80">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="81">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="82">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="83">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="84">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="85">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="86">
+                    <TN RefId="17">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="87">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="88">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="89">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="90">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="91">
+                <TN RefId="18">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectoryDefaults</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="92">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="93">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="94">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="95">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="96">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="97">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="98">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="99">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="100">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="101">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="102">
+                    <TN RefId="19">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectory</T>
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="103">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="104">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="105">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%SystemDrive%\inetpub\wwwroot</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="106">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="107">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="108">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="109">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="110">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="111">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%SystemDrive%\inetpub\wwwroot</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="112">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="113">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="114">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="115">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="116">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="117">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="118">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="119">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="120">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="121">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="122">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="123">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="124">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="125">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="126">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="127">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="128">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="129">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="130">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="131">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="132">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="133">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="134">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="135">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="136">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="137">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="138">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="139">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="140">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="141">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="142">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="143">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="144">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="145">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="146">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="147">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="148">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="149">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="150">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="151">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Calendar</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="152">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWACalendarAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="153">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="154">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="155">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="156">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="157">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="158">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="159">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="160">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="161">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="162">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="163">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="164">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Calendar</S>
+              <S N="applicationPool">MSExchangeOWACalendarAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="165">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="166">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="167">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="168">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="169">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="170">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="171">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="172">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="173">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="174">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="175">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="176">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="177">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="178">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="179">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="180">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="181">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="182">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="183">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="184">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="185">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="186">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="187">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="188">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Integrated</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="189">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="190">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="191">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="192">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="193">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="194">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="195">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="196">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="197">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="198">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="199">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="200">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="201">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Integrated</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="202">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="203">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="204">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="205">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="206">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="207">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="208">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="209">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="210">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="211">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="212">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="213">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="214">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="215">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="216">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="217">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="218">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="219">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="220">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="221">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="222">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="223">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="224">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="225">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/oma</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="226">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="227">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="228">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="229">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="230">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="231">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="232">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="233">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="234">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="235">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="236">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="237">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="238">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/oma</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="239">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="240">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="241">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="242">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="243">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="244">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="245">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="246">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="247">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="248">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="249">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="250">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="251">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="252">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="253">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="254">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="255">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="256">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="257">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="258">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="259">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="260">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="261">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="262">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/ecp</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="263">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeECPAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="264">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="265">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="266">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="267">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="268">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="269">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="270">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="271">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="272">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="273">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="274">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="275">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/ecp</S>
+              <S N="applicationPool">MSExchangeECPAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="276">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="277">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="278">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="279">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="280">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="281">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="282">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="283">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="284">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="285">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="286">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="287">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="288">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="289">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="290">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\ecp</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="291">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="292">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="293">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="294">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="295">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="296">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\ecp</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="297">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="298">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="299">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="300">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="301">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="302">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="303">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="304">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="305">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="306">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="307">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="308">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="309">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="310">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="311">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="312">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="313">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="314">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="315">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="316">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="317">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="318">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="319">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="320">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="321">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="322">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="323">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="324">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="325">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="326">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="327">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\EWS</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="328">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="329">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="330">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="331">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="332">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="333">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\EWS</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="334">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="335">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="336">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/API</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="337">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRestFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="338">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="339">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="340">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="341">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="342">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="343">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="344">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="345">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="346">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="347">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="348">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="349">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/API</S>
+              <S N="applicationPool">MSExchangeRestFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="350">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="351">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="352">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="353">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="354">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="355">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="356">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="357">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="358">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="359">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="360">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="361">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="362">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="363">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="364">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Rest</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="365">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="366">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="367">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="368">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="369">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="370">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Rest</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="371">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="372">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="373">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Autodiscover</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="374">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeAutodiscoverAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="375">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="376">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="377">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="378">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="379">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="380">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="381">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="382">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="383">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="384">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="385">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="386">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Autodiscover</S>
+              <S N="applicationPool">MSExchangeAutodiscoverAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="387">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="388">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="389">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="390">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="391">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="392">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="393">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="394">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="395">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="396">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="397">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="398">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="399">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="400">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="401">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Autodiscover</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="402">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="403">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="404">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="405">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="406">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="407">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\Autodiscover</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="408">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="409">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="410">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Microsoft-Server-ActiveSync</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="411">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeSyncAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="412">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="413">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="414">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="415">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="416">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="417">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="418">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="419">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="420">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="421">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="422">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="423">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Microsoft-Server-ActiveSync</S>
+              <S N="applicationPool">MSExchangeSyncAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="424">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="425">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="426">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="427">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="428">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="429">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="430">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="431">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="432">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="433">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="434">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="435">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="436">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="437">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="438">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\sync</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="439">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="440">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="441">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="442">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="443">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="444">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\sync</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="445">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="446">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="447">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/OAB</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="448">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOABAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="449">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="450">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="451">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="452">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="453">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="454">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="455">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="456">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="457">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="458">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="459">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="460">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/OAB</S>
+              <S N="applicationPool">MSExchangeOABAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="461">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="462">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="463">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="464">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="465">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="466">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="467">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="468">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="469">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="470">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="471">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="472">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="473">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="474">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="475">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\OAB</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="476">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="477">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="478">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="479">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="480">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="481">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\OAB</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="482">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="483">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="484">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PowerShell</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="485">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePowerShellFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="486">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="487">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="488">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="489">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="490">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="491">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="492">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="493">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="494">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="495">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="496">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="497">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PowerShell</S>
+              <S N="applicationPool">MSExchangePowerShellFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="498">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="499">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="500">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="501">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="502">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="503">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="504">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="505">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="506">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="507">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="508">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="509">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="510">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="511">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="512">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\PowerShell</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="513">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="514">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="515">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="516">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="517">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="518">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\PowerShell</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="519">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="520">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="521">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="522">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="523">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="524">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="525">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="526">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="527">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="528">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="529">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="530">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="531">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="532">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="533">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="534">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi</S>
+              <S N="applicationPool">MSExchangeMapiFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="535">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="536">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="537">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="538">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="539">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="540">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="541">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="542">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="543">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="544">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="545">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="546">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="547">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="548">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="549">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="550">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="551">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="552">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="553">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="554">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="555">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\mapi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="556">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="557">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="558">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Rpc</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="559">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyFrontEndAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="560">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="561">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="562">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="563">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="564">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="565">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="566">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="567">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="568">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="569">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="570">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="571">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Rpc</S>
+              <S N="applicationPool">MSExchangeRpcProxyFrontEndAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="572">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="573">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="574">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="575">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="576">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="577">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="578">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="579">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="580">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="581">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="582">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="583">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="584">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="585">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="586">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\rpc</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="587">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="588">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="589">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="590">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="591">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="592">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\rpc</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+        </LST>
+      </Obj>
+      <S N="ApplicationPool">MSExchangeOWAAppPool</S>
+      <S N="EnabledProtocols">http</S>
+      <S N="PhysicalPath">C:\inetpub\wwwroot</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite_ExchangeBackEnd1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/GetWebSite_ExchangeBackEnd1.xml
@@ -1,0 +1,8723 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Name">Exchange Back End</S>
+      <I64 N="Id">2</I64>
+      <S N="State">Started</S>
+      <Obj N="Limits" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#limits</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="2">
+            <TN RefId="2">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE>
+              <Obj RefId="3">
+                <TN RefId="3">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxBandwidth</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="4">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxConnections</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">4294967295</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="5">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">connectionTimeout</S>
+                  <S N="TypeName">System.TimeSpan</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <TS N="Value">PT2M</TS>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="6">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxUrlSegments</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">32</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">4</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="7">
+            <TN RefId="4">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationChildElementCollection</T>
+              <T>System.Object</T>
+            </TN>
+            <IE />
+            <Props>
+              <I32 N="Count">0</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">limits</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="8">
+            <TN RefId="5">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="9">
+                <TN RefId="6">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">limits</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <I64 N="maxBandwidth">4294967295</I64>
+          <I64 N="maxConnections">4294967295</I64>
+          <TS N="connectionTimeout">PT2M</TS>
+          <I64 N="maxUrlSegments">32</I64>
+        </MS>
+      </Obj>
+      <Obj N="LogFile" RefId="10">
+        <TN RefId="7">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#logFile</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="11">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="12">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logExtFileFlags</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2478031</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="13">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customLogPluginClsid</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="14">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logFormat</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">2</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="15">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logTargetW3C</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="16">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\LogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="17">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">period</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">1</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="18">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">truncateSize</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">20971520</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="19">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">localTimeRollover</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="20">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="21">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logSiteId</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="22">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">flushByEntryCountW3CLog</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">0</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="23">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogLineLength</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">65536</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">12</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Obj N="ChildElements" RefId="24">
+            <TNRef RefId="4" />
+            <IE>
+              <Obj RefId="25">
+                <TN RefId="8">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollection</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementCollectionBase`1[[Microsoft.IIs.PowerShell.Framework.ConfigurationElement, Microsoft.IIS.PowerShell.Framework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE />
+                <Props>
+                  <B N="AllowsAdd">true</B>
+                  <B N="AllowsClear">true</B>
+                  <B N="AllowsRemove">false</B>
+                  <I32 N="Count">0</I32>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <Obj N="Attributes" RefId="26">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                    </IE>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">customFields</S>
+                  <Nil N="Methods" />
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">1</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <S N="ElementTagName">logFile</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="27">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="28">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Obj N="ChildElementSchemas" RefId="29">
+                <TN RefId="9">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchemaCollection</T>
+                  <T>System.Object</T>
+                </TN>
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">logFile</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="logExtFileFlags">Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus</S>
+          <S N="customLogPluginClsid"></S>
+          <S N="logFormat">W3C</S>
+          <S N="logTargetW3C">File</S>
+          <S N="directory">%SystemDrive%\inetpub\logs\LogFiles</S>
+          <S N="period">Daily</S>
+          <I64 N="truncateSize">20971520</I64>
+          <B N="localTimeRollover">false</B>
+          <B N="enabled">true</B>
+          <B N="logSiteId">true</B>
+          <I64 N="flushByEntryCountW3CLog">0</I64>
+          <I64 N="maxLogLineLength">65536</I64>
+          <Obj N="customFields" RefId="30">
+            <TN RefId="10">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#logFile#customFields</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="31">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="32">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">maxCustomFieldLength</S>
+                      <S N="TypeName">System.Int64</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I64 N="Value">4096</I64>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Ref N="ChildElements" RefId="7" />
+              <S N="ElementTagName">customFields</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="33">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="34">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Nil N="ChildElementSchemas" />
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">customFields</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <I64 N="maxCustomFieldLength">4096</I64>
+              <Obj N="Collection" RefId="35">
+                <TN RefId="11">
+                  <T>System.Management.Automation.PSObject[]</T>
+                  <T>System.Array</T>
+                  <T>System.Object</T>
+                </TN>
+                <LST />
+              </Obj>
+            </MS>
+          </Obj>
+        </MS>
+      </Obj>
+      <Obj N="TraceFailedRequestsLogging" RefId="36">
+        <TN RefId="12">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#traceFailedRequestsLogging</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="37">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="38">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="39">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">false</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">directory</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="40">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFiles</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">50</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="41">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">maxLogFileSizeKB</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">1024</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="42">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">customActionsEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">traceFailedRequestsLogging</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="43">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="44">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">traceFailedRequestsLogging</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">false</B>
+          <S N="directory">%SystemDrive%\inetpub\logs\FailedReqLogFiles</S>
+          <I64 N="maxLogFiles">50</I64>
+          <I64 N="maxLogFileSizeKB">1024</I64>
+          <B N="customActionsEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="Hsts" RefId="45">
+        <TN RefId="13">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#hsts</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="46">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="47">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="48">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">max-age</S>
+                  <S N="TypeName">System.Int64</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I64 N="Value">31536000</I64>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="49">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">includeSubDomains</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="50">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preload</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="51">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">redirectHttpToHttps</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">5</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">hsts</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="52">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="53">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">false</B>
+              <S N="Name">hsts</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <B N="enabled">true</B>
+          <I64 N="max-age">31536000</I64>
+          <B N="includeSubDomains">false</B>
+          <B N="preload">false</B>
+          <B N="redirectHttpToHttps">true</B>
+        </MS>
+      </Obj>
+      <Obj N="ApplicationDefaults" RefId="54">
+        <TN RefId="14">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#applicationDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="55">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="56">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="57">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">applicationPool</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="58">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">enabledProtocols</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value">http</S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="59">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="60">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">serviceAutoStartProvider</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="61">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">preloadEnabled</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">false</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">applicationDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="62">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="63">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">applicationDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="applicationPool"></S>
+          <S N="enabledProtocols">http</S>
+          <B N="serviceAutoStartEnabled">false</B>
+          <S N="serviceAutoStartProvider"></S>
+          <B N="preloadEnabled">false</B>
+        </MS>
+      </Obj>
+      <Obj N="VirtualDirectoryDefaults" RefId="64">
+        <TN RefId="15">
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#virtualDirectoryDefaults</T>
+          <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+        <Props>
+          <Obj N="Attributes" RefId="65">
+            <TNRef RefId="2" />
+            <IE>
+              <Obj RefId="66">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">path</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="67">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">physicalPath</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="68">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">userName</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="69">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">password</S>
+                  <S N="TypeName">System.String</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S N="Value"></S>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="70">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">logonMethod</S>
+                  <S N="TypeName">System.UInt32</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <I32 N="Value">3</I32>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+              <Obj RefId="71">
+                <TNRef RefId="3" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                <Props>
+                  <B N="IsInheritedFromDefaultValue">true</B>
+                  <B N="IsProtected">false</B>
+                  <S N="Name">allowSubDirConfig</S>
+                  <S N="TypeName">System.Boolean</S>
+                  <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <B N="Value">true</B>
+                  <B N="IsExtended">false</B>
+                </Props>
+              </Obj>
+            </IE>
+            <Props>
+              <I32 N="Count">6</I32>
+              <S N="SyncRoot">System.Object</S>
+              <B N="IsSynchronized">false</B>
+            </Props>
+          </Obj>
+          <Ref N="ChildElements" RefId="7" />
+          <S N="ElementTagName">virtualDirectoryDefaults</S>
+          <Nil N="Methods" />
+          <Obj N="Schema" RefId="72">
+            <TNRef RefId="5" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+            <Props>
+              <B N="AllowUnrecognizedAttributes">false</B>
+              <Obj N="AttributeSchemas" RefId="73">
+                <TNRef RefId="6" />
+                <IE>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                  <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                </IE>
+              </Obj>
+              <Nil N="ChildElementSchemas" />
+              <Nil N="CollectionSchema" />
+              <B N="IsCollectionDefault">true</B>
+              <S N="Name">virtualDirectoryDefaults</S>
+            </Props>
+          </Obj>
+        </Props>
+        <MS>
+          <S N="path"></S>
+          <S N="physicalPath"></S>
+          <S N="userName"></S>
+          <S N="password"></S>
+          <S N="logonMethod">ClearText</S>
+          <B N="allowSubDirConfig">true</B>
+        </MS>
+      </Obj>
+      <Obj N="Collection" RefId="74">
+        <TNRef RefId="11" />
+        <LST>
+          <Obj RefId="75">
+            <TN RefId="16">
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#site#application</T>
+              <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="76">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="77">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="78">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">DefaultAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="79">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="80">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="81">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="82">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="83">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="84">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="85">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="86">
+                    <TN RefId="17">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="87">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="88">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="89">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="90">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/</S>
+              <S N="applicationPool">DefaultAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="91">
+                <TN RefId="18">
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectoryDefaults</T>
+                  <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                  <T>System.Object</T>
+                </TN>
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="92">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="93">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="94">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="95">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="96">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="97">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="98">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="99">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="100">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="101">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="102">
+                    <TN RefId="19">
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement#application#virtualDirectory</T>
+                      <T>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</T>
+                      <T>System.Object</T>
+                    </TN>
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="103">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="104">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="105">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="106">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="107">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="108">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="109">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="110">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="111">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="112">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="113">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="114">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="115">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="116">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="117">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="118">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="119">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="120">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="121">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/mapi</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="122">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="123">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="124">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Exchange</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="125">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="126">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="127">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="128">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="129">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="130">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="131">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Exchange</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="132">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="133">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="134">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Exchweb</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="135">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="136">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="137">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="138">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="139">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="140">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="141">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Exchweb</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                  <Obj RefId="142">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="143">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="144">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/Public</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="145">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="146">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="147">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="148">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="149">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="150">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="151">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/Public</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="152">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="153">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="154">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PowerShell</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="155">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePowerShellAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="156">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="157">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="158">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="159">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="160">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="161">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="162">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="163">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="164">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="165">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="166">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="167">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PowerShell</S>
+              <S N="applicationPool">MSExchangePowerShellAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="168">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="169">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="170">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="171">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="172">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="173">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="174">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="175">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="176">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="177">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="178">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="179">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="180">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="181">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="182">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PowerShell-Proxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="183">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="184">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="185">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="186">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="187">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="188">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PowerShell-Proxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="189">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="190">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="191">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi/emsmdb</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="192">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiMailboxAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="193">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="194">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="195">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="196">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="197">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="198">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="199">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="200">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="201">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="202">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="203">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="204">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi/emsmdb</S>
+              <S N="applicationPool">MSExchangeMapiMailboxAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="205">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="206">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="207">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="208">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="209">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="210">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="211">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="212">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="213">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="214">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="215">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="216">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="217">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="218">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="219">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\emsmdb</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="220">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="221">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="222">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="223">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="224">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="225">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\emsmdb</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="226">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="227">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="228">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/mapi/nspi</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="229">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeMapiAddressBookAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="230">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="231">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="232">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="233">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="234">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="235">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="236">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="237">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="238">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="239">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="240">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="241">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/mapi/nspi</S>
+              <S N="applicationPool">MSExchangeMapiAddressBookAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="242">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="243">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="244">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="245">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="246">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="247">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="248">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="249">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="250">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="251">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="252">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="253">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="254">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="255">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="256">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\nspi</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="257">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="258">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="259">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="260">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="261">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="262">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\mapi\nspi</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="263">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="264">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="265">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/API</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="266">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRestAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="267">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="268">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="269">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="270">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="271">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="272">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="273">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="274">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="275">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="276">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="277">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="278">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/API</S>
+              <S N="applicationPool">MSExchangeRestAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="279">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="280">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="281">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="282">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="283">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="284">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="285">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="286">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="287">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="288">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="289">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="290">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="291">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="292">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="293">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\rest</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="294">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="295">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="296">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="297">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="298">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="299">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\rest</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="300">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="301">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="302">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="303">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWAAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="304">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="305">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="306">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="307">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="308">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="309">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="310">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="311">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="312">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="313">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="314">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="315">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa</S>
+              <S N="applicationPool">MSExchangeOWAAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="316">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="317">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="318">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="319">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="320">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="321">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="322">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="323">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="324">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="325">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="326">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="327">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="328">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="329">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="330">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="331">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="332">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="333">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="334">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="335">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="336">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="337">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="338">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="339">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/owa/Calendar</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="340">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOWACalendarAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="341">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="342">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="343">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="344">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="345">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="346">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="347">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="348">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="349">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="350">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="351">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="352">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/owa/Calendar</S>
+              <S N="applicationPool">MSExchangeOWACalendarAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="353">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="354">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="355">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="356">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="357">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="358">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="359">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="360">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="361">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="362">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="363">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="364">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="365">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="366">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="367">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="368">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="369">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="370">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="371">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="372">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="373">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\owa</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="374">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="375">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="376">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/OAB</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="377">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeOABAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="378">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="379">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="380">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="381">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="382">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="383">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="384">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="385">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="386">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="387">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="388">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="389">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/OAB</S>
+              <S N="applicationPool">MSExchangeOABAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="390">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="391">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="392">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="393">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="394">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="395">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="396">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="397">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="398">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="399">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="400">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="401">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="402">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="403">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="404">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\OAB</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="405">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="406">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="407">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="408">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="409">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="410">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\OAB</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="411">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="412">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="413">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/ecp</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="414">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeECPAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="415">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="416">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="417">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="418">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="419">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="420">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="421">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="422">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="423">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="424">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="425">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="426">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/ecp</S>
+              <S N="applicationPool">MSExchangeECPAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="427">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="428">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="429">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="430">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="431">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="432">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="433">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="434">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="435">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="436">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="437">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="438">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="439">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="440">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="441">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\ecp</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="442">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="443">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="444">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="445">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="446">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="447">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\ecp</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="448">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="449">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="450">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Autodiscover</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="451">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeAutodiscoverAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="452">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="453">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="454">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="455">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="456">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="457">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="458">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="459">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="460">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="461">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="462">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="463">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Autodiscover</S>
+              <S N="applicationPool">MSExchangeAutodiscoverAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="464">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="465">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="466">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="467">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="468">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="469">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="470">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="471">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="472">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="473">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="474">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="475">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="476">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="477">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="478">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\Autodiscover</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="479">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="480">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="481">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="482">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="483">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="484">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\Autodiscover</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="485">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="486">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="487">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Microsoft-Server-ActiveSync</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="488">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeSyncAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="489">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="490">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="491">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="492">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="493">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="494">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="495">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="496">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="497">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="498">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="499">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="500">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Microsoft-Server-ActiveSync</S>
+              <S N="applicationPool">MSExchangeSyncAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="501">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="502">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="503">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="504">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="505">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="506">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="507">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="508">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="509">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="510">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="511">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="512">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="513">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="514">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="515">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\sync</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="516">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="517">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="518">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="519">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="520">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="521">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\sync</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="522">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="523">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="524">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="525">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="526">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="527">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="528">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="529">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="530">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="531">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="532">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="533">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="534">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="535">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="536">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="537">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="538">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="539">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="540">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="541">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="542">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="543">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="544">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="545">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="546">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="547">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="548">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="549">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="550">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="551">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="552">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="553">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="554">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="555">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="556">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="557">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="558">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="559">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="560">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="561">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/EWS/bin</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="562">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeServicesAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="563">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="564">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="565">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="566">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="567">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="568">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="569">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="570">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="571">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="572">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="573">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="574">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/EWS/bin</S>
+              <S N="applicationPool">MSExchangeServicesAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="575">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="576">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="577">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="578">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="579">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="580">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="581">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="582">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="583">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="584">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="585">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="586">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="587">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="588">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="589">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS\bin</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="590">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="591">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="592">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="593">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="594">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="595">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\exchweb\EWS\bin</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="596">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="597">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="598">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/Rpc</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="599">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="600">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="601">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="602">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="603">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="604">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="605">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="606">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="607">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="608">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="609">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="610">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="611">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/Rpc</S>
+              <S N="applicationPool">MSExchangeRpcProxyAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="612">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="613">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="614">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="615">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="616">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="617">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="618">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="619">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="620">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="621">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="622">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="623">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="624">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="625">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="626">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%windir%\System32\RpcProxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="627">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="628">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="629">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="630">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="631">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="632">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%windir%\System32\RpcProxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="633">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="634">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="635">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/RpcWithCert</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="636">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangeRpcProxyAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="637">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="638">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="639">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="640">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="641">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="642">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="643">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="644">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="645">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="646">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="647">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="648">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/RpcWithCert</S>
+              <S N="applicationPool">MSExchangeRpcProxyAppPool</S>
+              <S N="enabledProtocols">http</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="649">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="650">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="651">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="652">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="653">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="654">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="655">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="656">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="657">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="658">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="659">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="660">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="661">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="662">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="663">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">%windir%\System32\RpcProxy</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="664">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="665">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="666">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="667">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="668">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="669">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">%windir%\System32\RpcProxy</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+          <Obj RefId="670">
+            <TNRef RefId="16" />
+            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+            <Props>
+              <Obj N="Attributes" RefId="671">
+                <TNRef RefId="2" />
+                <IE>
+                  <Obj RefId="672">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">path</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">/PushNotifications</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="673">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">applicationPool</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">MSExchangePushNotificationsAppPool</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="674">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">false</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">enabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value">http,net.pipe</S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="675">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="676">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartProvider</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="677">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">preloadEnabled</S>
+                      <S N="TypeName">System.Boolean</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <B N="Value">false</B>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="678">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">previouslyEnabledProtocols</S>
+                      <S N="TypeName">System.String</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S N="Value"></S>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                  <Obj RefId="679">
+                    <TNRef RefId="3" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                    <Props>
+                      <B N="IsInheritedFromDefaultValue">true</B>
+                      <B N="IsProtected">false</B>
+                      <S N="Name">serviceAutoStartMode</S>
+                      <S N="TypeName">System.UInt32</S>
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <I32 N="Value">0</I32>
+                      <B N="IsExtended">false</B>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">8</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <Obj N="ChildElements" RefId="680">
+                <TNRef RefId="4" />
+                <IE>
+                  <Obj RefId="681">
+                    <TNRef RefId="17" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="682">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</S>
+                        </IE>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectoryDefaults</S>
+                      <Nil N="Methods" />
+                      <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </Props>
+                  </Obj>
+                </IE>
+                <Props>
+                  <I32 N="Count">1</I32>
+                  <S N="SyncRoot">System.Object</S>
+                  <B N="IsSynchronized">false</B>
+                </Props>
+              </Obj>
+              <S N="ElementTagName">application</S>
+              <Nil N="Methods" />
+              <Obj N="Schema" RefId="683">
+                <TNRef RefId="5" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                <Props>
+                  <B N="AllowUnrecognizedAttributes">false</B>
+                  <Obj N="AttributeSchemas" RefId="684">
+                    <TNRef RefId="6" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                    </IE>
+                  </Obj>
+                  <Obj N="ChildElementSchemas" RefId="685">
+                    <TNRef RefId="9" />
+                    <IE>
+                      <S>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</S>
+                    </IE>
+                  </Obj>
+                  <S N="CollectionSchema">Microsoft.IIs.PowerShell.Framework.ConfigurationCollectionSchema</S>
+                  <B N="IsCollectionDefault">false</B>
+                  <S N="Name">application</S>
+                </Props>
+              </Obj>
+            </Props>
+            <MS>
+              <S N="path">/PushNotifications</S>
+              <S N="applicationPool">MSExchangePushNotificationsAppPool</S>
+              <S N="enabledProtocols">http,net.pipe</S>
+              <B N="serviceAutoStartEnabled">false</B>
+              <S N="serviceAutoStartProvider"></S>
+              <B N="preloadEnabled">false</B>
+              <S N="previouslyEnabledProtocols"></S>
+              <S N="serviceAutoStartMode">All</S>
+              <Obj N="virtualDirectoryDefaults" RefId="686">
+                <TNRef RefId="18" />
+                <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                <Props>
+                  <Obj N="Attributes" RefId="687">
+                    <TNRef RefId="2" />
+                    <IE>
+                      <Obj RefId="688">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">path</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="689">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">physicalPath</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="690">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">userName</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="691">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">password</S>
+                          <S N="TypeName">System.String</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S N="Value"></S>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="692">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">logonMethod</S>
+                          <S N="TypeName">System.UInt32</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <I32 N="Value">3</I32>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                      <Obj RefId="693">
+                        <TNRef RefId="3" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                        <Props>
+                          <B N="IsInheritedFromDefaultValue">true</B>
+                          <B N="IsProtected">false</B>
+                          <S N="Name">allowSubDirConfig</S>
+                          <S N="TypeName">System.Boolean</S>
+                          <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <B N="Value">true</B>
+                          <B N="IsExtended">false</B>
+                        </Props>
+                      </Obj>
+                    </IE>
+                    <Props>
+                      <I32 N="Count">6</I32>
+                      <S N="SyncRoot">System.Object</S>
+                      <B N="IsSynchronized">false</B>
+                    </Props>
+                  </Obj>
+                  <Ref N="ChildElements" RefId="7" />
+                  <S N="ElementTagName">virtualDirectoryDefaults</S>
+                  <Nil N="Methods" />
+                  <Obj N="Schema" RefId="694">
+                    <TNRef RefId="5" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                    <Props>
+                      <B N="AllowUnrecognizedAttributes">false</B>
+                      <Obj N="AttributeSchemas" RefId="695">
+                        <TNRef RefId="6" />
+                        <IE>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                          <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                        </IE>
+                      </Obj>
+                      <Nil N="ChildElementSchemas" />
+                      <Nil N="CollectionSchema" />
+                      <B N="IsCollectionDefault">true</B>
+                      <S N="Name">virtualDirectoryDefaults</S>
+                    </Props>
+                  </Obj>
+                </Props>
+                <MS>
+                  <S N="path"></S>
+                  <S N="physicalPath"></S>
+                  <S N="userName"></S>
+                  <S N="password"></S>
+                  <S N="logonMethod">ClearText</S>
+                  <B N="allowSubDirConfig">true</B>
+                </MS>
+              </Obj>
+              <Obj N="Collection" RefId="696">
+                <TNRef RefId="11" />
+                <LST>
+                  <Obj RefId="697">
+                    <TNRef RefId="19" />
+                    <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElement</ToString>
+                    <Props>
+                      <Obj N="Attributes" RefId="698">
+                        <TNRef RefId="2" />
+                        <IE>
+                          <Obj RefId="699">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">path</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">/</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="700">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">physicalPath</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PushNotifications</S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="701">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">userName</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="702">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">password</S>
+                              <S N="TypeName">System.String</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S N="Value"></S>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="703">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">true</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">logonMethod</S>
+                              <S N="TypeName">System.UInt32</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <I32 N="Value">3</I32>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                          <Obj RefId="704">
+                            <TNRef RefId="3" />
+                            <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute</ToString>
+                            <Props>
+                              <B N="IsInheritedFromDefaultValue">false</B>
+                              <B N="IsProtected">false</B>
+                              <S N="Name">allowSubDirConfig</S>
+                              <S N="TypeName">System.Boolean</S>
+                              <S N="Schema">Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <B N="Value">true</B>
+                              <B N="IsExtended">false</B>
+                            </Props>
+                          </Obj>
+                        </IE>
+                        <Props>
+                          <I32 N="Count">6</I32>
+                          <S N="SyncRoot">System.Object</S>
+                          <B N="IsSynchronized">false</B>
+                        </Props>
+                      </Obj>
+                      <Ref N="ChildElements" RefId="7" />
+                      <S N="ElementTagName">virtualDirectory</S>
+                      <Nil N="Methods" />
+                      <Obj N="Schema" RefId="705">
+                        <TNRef RefId="5" />
+                        <ToString>Microsoft.IIs.PowerShell.Framework.ConfigurationElementSchema</ToString>
+                        <Props>
+                          <B N="AllowUnrecognizedAttributes">false</B>
+                          <Obj N="AttributeSchemas" RefId="706">
+                            <TNRef RefId="6" />
+                            <IE>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                              <S>Microsoft.IIs.PowerShell.Framework.ConfigurationAttributeSchema</S>
+                            </IE>
+                          </Obj>
+                          <Nil N="ChildElementSchemas" />
+                          <Nil N="CollectionSchema" />
+                          <B N="IsCollectionDefault">false</B>
+                          <S N="Name">virtualDirectory</S>
+                        </Props>
+                      </Obj>
+                    </Props>
+                    <MS>
+                      <S N="path">/</S>
+                      <S N="physicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\PushNotifications</S>
+                      <S N="userName"></S>
+                      <S N="password"></S>
+                      <S N="logonMethod">ClearText</S>
+                      <B N="allowSubDirConfig">true</B>
+                    </MS>
+                  </Obj>
+                </LST>
+              </Obj>
+              <Nil N="PhysicalPath" />
+            </MS>
+          </Obj>
+        </LST>
+      </Obj>
+      <S N="ApplicationPool">DefaultAppPool</S>
+      <S N="EnabledProtocols">http</S>
+      <S N="PhysicalPath">C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -116,8 +116,9 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "HSTS Enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 9
+            $Script:ActiveGrouping.Count | Should -Be 10
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -116,8 +116,9 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "HSTS Enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 9
+            $Script:ActiveGrouping.Count | Should -Be 10
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -117,8 +117,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "HSTS Enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 9
+            $Script:ActiveGrouping.Count | Should -Be 10
         }
 
         It "Display Results - Security Settings" {


### PR DESCRIPTION
**Description:**
Exchange Server 2016 and 2019 do support HSTS now. This PR will add the first version of a HC HSTS check to detect misconfigurations that can lead to issues on Exchange Server.

Update Pester testing for the following:
- [x] Basic Hsts settings both being used (custom and native) 
- [x] Hsts Setting and Custom Header value
- [x] When Hsts is enabled on the `Exchange Back End `
- [x] When the value for `max-age` is at a lower value than expected and configured correctly
- [x] When `redirectHttpToHttps` is set to `$true`

**Validated:**
E19 and E16 lab

Resolve #1748 