### PR TITLE
Include .NET 4.8.1 detection

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -156,6 +156,20 @@ function Invoke-AnalyzerOsInformation {
             AddHtmlOverviewValues  = $true
         }
         Add-AnalyzedResultInformation @params
+
+        if ($osInformation.NETFramework.MajorVersion -gt $recommendedNetVersion) {
+            # Generic information stating we are looking into supporting this version of .NET
+            # But don't use it till we update the supportability matrix
+            $displayValue = "Microsoft is working on .NET $($osInformation.NETFramework.FriendlyName) validation with Exchange" +
+            " and the recommendation is to not use .NET $($osInformation.NETFramework.FriendlyName) until it is officially added to the supportability matrix."
+
+            $params = $baseParams + @{
+                Details                = $displayValue
+                DisplayWriteType       = "Yellow"
+                DisplayCustomTabNumber = 2
+            }
+            Add-AnalyzedResultInformation @params
+        }
     }
 
     $displayValue = [string]::Empty

--- a/Shared/Get-NETFrameworkVersion.ps1
+++ b/Shared/Get-NETFrameworkVersion.ps1
@@ -71,9 +71,12 @@ function Get-NETFrameworkVersion {
         } elseif ($NetVersionKey -lt $netVersionDictionary["Net4d8"]) {
             $friendlyName = "4.7.2"
             $minValue = $netVersionDictionary["Net4d7d2"]
-        } elseif ($NetVersionKey -ge $netVersionDictionary["Net4d8"]) {
+        } elseif ($NetVersionKey -lt $netVersionDictionary["Net4d8d1"]) {
             $friendlyName = "4.8"
             $minValue = $netVersionDictionary["Net4d8"]
+        } elseif ($NetVersionKey -ge $netVersionDictionary["Net4d8d1"]) {
+            $friendlyName = "4.8.1"
+            $minValue = $netVersionDictionary["Net4d8d1"]
         }
     }
     end {
@@ -100,6 +103,7 @@ function GetNetVersionDictionary {
         "Net4d7d1"     = 461308
         "Net4d7d2"     = 461808
         "Net4d8"       = 528040
+        "Net4d8d1"     = 533320
     }
 }
 

--- a/Shared/Tests/Get-NETFrameworkVersion.Tests.ps1
+++ b/Shared/Tests/Get-NETFrameworkVersion.Tests.ps1
@@ -98,6 +98,14 @@ Describe "Testing $scriptName" {
             $result.MinimumValue | Should -Be $value
             $result.RegistryValue | Should -Be ($value + 1)
         }
+
+        It ".NET 4.8.1" {
+            $value = 533320
+            $result = Get-NETFrameworkVersion -NetVersionKey ($value + 1)
+            $result.FriendlyName | Should -Be "4.8.1"
+            $result.MinimumValue | Should -Be $value
+            $result.RegistryValue | Should -Be ($value + 1)
+        }
     }
 
     Context "Get Local .NET Version and debug" {
@@ -188,6 +196,11 @@ Describe "Testing $scriptName" {
         It "NET 4.8" {
             $result = Get-NETFrameworkVersion -NetVersionShortName "Net4d8"
             $result.FriendlyName = "4.8"
+        }
+
+        It "NET 4.8.1" {
+            $result = Get-NETFrameworkVersion -NetVersionShortName "Net4d8d1"
+            $result.FriendlyName = "4.8.1"
         }
     }
 }


### PR DESCRIPTION
**Reason:**
Noticed that we released [.NET Framework 4.8.1](https://devblogs.microsoft.com/dotnet/announcing-dotnet-framework-481/) last year and wasn't made aware. Adding the code to detect the latest version of .NET properly. 

**Fix:**
Add detection for the latest version of .NET and pester testing around it. 

**Validation:**
Lab tested and Pester tested. 


![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/f977bc96-5d23-4e1f-9741-eb0a146e5aa6)


Because it has been out for a year. Want to verify that PG is aware and to make sure we don't support this, even though the documentation does state that we don't support this at this time. 
