### PR TITLE
Handle Write-Error in Get-WmiObjectCriticalHandler to avoid reports

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
@@ -113,6 +113,8 @@ function Get-HealthCheckerData {
         } catch {
             Write-Red "Failed to Health Checker against $serverName"
             $failedServerList.Add($serverName)
+            # Try to handle the issue so we don't get a false positive report.
+            Invoke-CatchActions
             continue
         }
 

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -172,6 +172,7 @@ begin {
     . $PSScriptRoot\..\..\Shared\LoggerFunctions.ps1
     . $PSScriptRoot\..\..\Shared\OutputOverrides\Write-Host.ps1
     . $PSScriptRoot\..\..\Shared\OutputOverrides\Write-Verbose.ps1
+    . $PSScriptRoot\..\..\Shared\OutputOverrides\Write-Warning.ps1
     . $PSScriptRoot\..\..\Shared\ScriptUpdateFunctions\Test-ScriptVersion.ps1
 
     $BuildVersion = ""
@@ -192,6 +193,7 @@ begin {
         -ErrorAction SilentlyContinue
     SetProperForegroundColor
     SetWriteVerboseAction ${Function:Write-DebugLog}
+    SetWriteWarningAction ${Function:Write-DebugLog}
 } process {
     $Server | ForEach-Object { $Script:ServerNameList.Add($_.ToUpper()) }
 } end {


### PR DESCRIPTION
**Issue:**
We are failing on purpose in `Get-WmiObjectCriticalHandler` 

**Reason:**
We don't need to have the reports coming in for the script to address. 

**Fix:**
Add in logging for `Write-Warning` and include `Invoke-CatchActions` in main loop to collect the data. 

**Validation:**
Lab tested

Resolved #1691 
