### PR TITLE
Improve OS detection when running on Server Core

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemBuildInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemBuildInformation.ps1
@@ -14,12 +14,14 @@ function Get-OperatingSystemBuildInformation {
     process {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $win32_OperatingSystem = Get-WmiObjectCriticalHandler -ComputerName $Server -Class Win32_OperatingSystem -CatchActionFunction ${Function:Invoke-CatchActions}
+        $serverOsVersionInformation = Get-ServerOperatingSystemVersion -ComputerName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
     } end {
         return [PSCustomObject]@{
-            BuildVersion    = [System.Version]$win32_OperatingSystem.Version
-            MajorVersion    = (Get-ServerOperatingSystemVersion -OsCaption $win32_OperatingSystem.Caption)
-            FriendlyName    = $win32_OperatingSystem.Caption
-            OperatingSystem = $win32_OperatingSystem
+            BuildVersion     = [System.Version]$win32_OperatingSystem.Version
+            MajorVersion     = $serverOsVersionInformation.MajorVersion
+            InstallationType = $serverOsVersionInformation.InstallationType
+            FriendlyName     = $serverOsVersionInformation.FriendlyName
+            OperatingSystem  = $win32_OperatingSystem
         }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerOperatingSystemVersion.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-ServerOperatingSystemVersion.ps1
@@ -1,25 +1,43 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\..\..\..\..\Shared\Get-WmiObjectHandler.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
 function Get-ServerOperatingSystemVersion {
     [CmdletBinding()]
-    [OutputType("System.String")]
+    [OutputType("System.Object")]
     param(
-        [string]$OsCaption
+        [string]$ComputerName = $env:COMPUTERNAME,
+
+        [ScriptBlock]$CatchActionFunction
     )
     begin {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $osReturnValue = [string]::Empty
     }
     process {
-        if ([string]::IsNullOrEmpty($OsCaption)) {
-            Write-Verbose "Getting the local machine version build number"
-            $OsCaption = (Get-WmiObjectHandler -Class "Win32_OperatingSystem").Caption
+        Write-Verbose "Getting the version build information for computer: $ComputerName"
+        $baseParams = @{
+            MachineName         = $ComputerName
+            CatchActionFunction = $CatchActionFunction
         }
-        Write-Verbose "OsCaption: '$OsCaption'"
 
-        switch -Wildcard ($OsCaption) {
+        # Get ProductName via registry call as this is more accurate when running on Server Core
+        $productNameParams = $baseParams + @{
+            SubKey   = "SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+            GetValue = "ProductName"
+        }
+
+        # Find out if we're running on Server Core to output on the 'Operating System Information' page
+        $installationTypeParams = $baseParams + @{
+            SubKey   = "SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+            GetValue = "InstallationType"
+        }
+
+        $osCaption = Get-RemoteRegistryValue @productNameParams
+        $installationType = Get-RemoteRegistryValue @installationTypeParams
+        Write-Verbose "OsCaption: '$osCaption' InstallationType: '$installationType'"
+
+        switch -Wildcard ($osCaption) {
             "*Server 2008 R2*" { $osReturnValue = "Windows2008R2"; break }
             "*Server 2008*" { $osReturnValue = "Windows2008" }
             "*Server 2012 R2*" { $osReturnValue = "Windows2012R2"; break }
@@ -27,13 +45,15 @@ function Get-ServerOperatingSystemVersion {
             "*Server 2016*" { $osReturnValue = "Windows2016" }
             "*Server 2019*" { $osReturnValue = "Windows2019" }
             "*Server 2022*" { $osReturnValue = "Windows2022" }
-            "Microsoft Windows Server Standard" { $osReturnValue = "WindowsCore" }
-            "Microsoft Windows Server Datacenter" { $osReturnValue = "WindowsCore" }
             default { $osReturnValue = "Unknown" }
         }
     }
     end {
-        Write-Verbose "Returned: '$osReturnValue'"
-        return [string]$osReturnValue
+        Write-Verbose "OsReturnValue: '$osReturnValue'"
+        return [PSCustomObject]@{
+            MajorVersion     = $osReturnValue
+            InstallationType = $installationType
+            FriendlyName     = if ($installationType -eq "Server Core") { "$osCaption ($installationType)" } else { $osCaption }
+        }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/RemoteRegistryValueInstallationType.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/RemoteRegistryValueInstallationType.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Server</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/RemoteRegistryValueProductName.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/RemoteRegistryValueProductName.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Windows Server 2012 R2 Datacenter</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/RemoteRegistryValueInstallationType.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/RemoteRegistryValueInstallationType.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Server</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/RemoteRegistryValueProductName.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/RemoteRegistryValueProductName.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Windows Server 2016 Datacenter</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/RemoteRegistryValueInstallationType.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/RemoteRegistryValueInstallationType.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Server Core</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/RemoteRegistryValueProductName.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/RemoteRegistryValueProductName.xml
@@ -1,0 +1,3 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <S>Windows Server 2019 Datacenter</S>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
         It "Display Results - Operating System Information" {
             SetActiveDisplayGrouping "Operating System Information"
 
-            TestObjectMatch "Version" "Microsoft Windows Server 2012 R2 Datacenter"
+            TestObjectMatch "Version" "Windows Server 2012 R2 Datacenter"
             TestObjectMatch "Time Zone" "Pacific Standard Time"
             TestObjectMatch "Dynamic Daylight Time Enabled" "True"
             TestObjectMatch ".NET Framework" "4.8" -WriteType "Green"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
         It "Display Results - Operating System Information" {
             SetActiveDisplayGrouping "Operating System Information"
 
-            TestObjectMatch "Version" "Microsoft Windows Server 2016 Datacenter"
+            TestObjectMatch "Version" "Windows Server 2016 Datacenter"
             TestObjectMatch "Time Zone" "Pacific Standard Time"
             TestObjectMatch "Dynamic Daylight Time Enabled" "True"
             TestObjectMatch ".NET Framework" "4.8" -WriteType "Green"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
         It "Display Results - Operating System Information" {
             SetActiveDisplayGrouping "Operating System Information"
 
-            TestObjectMatch "Version" "Microsoft Windows Server 2019 Datacenter"
+            TestObjectMatch "Version" "Windows Server 2019 Datacenter (Server Core)"
             TestObjectMatch "Time Zone" "Pacific Standard Time"
             TestObjectMatch "Dynamic Daylight Time Enabled" "True"
             TestObjectMatch ".NET Framework" "4.8" -WriteType "Green"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
             Assert-MockCalled Get-WmiObjectHandler -Exactly 6
             Assert-MockCalled Invoke-ScriptBlockHandler -Exactly 4
-            Assert-MockCalled Get-RemoteRegistryValue -Exactly 21
+            Assert-MockCalled Get-RemoteRegistryValue -Exactly 23
             Assert-MockCalled Get-NETFrameworkVersion -Exactly 1
             Assert-MockCalled Get-DotNetDllFileVersions -Exactly 1
             Assert-MockCalled Get-NicPnpCapabilitiesSetting -Exactly 1

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -96,6 +96,8 @@ Mock Get-RemoteRegistryValue {
         "MinimumConnectionTimeout" { return 0 }
         "LmCompatibilityLevel" { return $null }
         "UBR" { return 720 }
+        "ProductName" { return Import-Clixml "$Script:MockDataCollectionRoot\OS\RemoteRegistryValueProductName.xml" }
+        "InstallationType" { return Import-Clixml "$Script:MockDataCollectionRoot\OS\RemoteRegistryValueInstallationType.xml" }
         "DisableCompression" { return 0 }
         "CtsProcessorAffinityPercentage" { return 0 }
         "Enabled" { return 0 }


### PR DESCRIPTION
**Description:**
OS detection via `Get-ServerOperatingSystemVersion` function wasn't working well in case that the script was executed on or against an Exchange Server that is running on Windows Server Core.

With this PR we change the way of how `Get-ServerOperatingSystemVersion` queries the OS information for proper OS and installation type detection from `wmi` call to a registry call.

**Validation:**
Lab / Pester

