### PR TITLE
Include W3wp process in the analysis.

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -416,9 +416,8 @@ $ModuleAllowList.add("SCCXT.dll")
 Write-SimpleLogFile -string ("Allow List Module Count: " + $ModuleAllowList.count) -Name $LogFile
 
 $UnexpectedModuleFound = 0
-
-
 $showWarning = $false
+
 # Gather each process and work thru their module list to remove any known modules.
 foreach ($process in $ServerProcess) {
 
@@ -440,13 +439,11 @@ foreach ($process in $ServerProcess) {
         }
 
         if ($ProcessModules.count -gt 0) {
-
             if ($UnexpectedModuleFound -eq 0) {
                 "`n####################################################################################################" | Out-File $OutputProcessPath  -Append
                 "$((Get-Date).ToString())" | Out-File $OutputProcessPath -Append
                 "####################################################################################################" | Out-File $OutputProcessPath -Append
             }
-
             Write-Warning ("Possible AV Modules found in process $($process.ProcessName)")
             $UnexpectedModuleFound++
             foreach ($module in $ProcessModules) {

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -383,20 +383,19 @@ $ServerProcess = Get-Process | Sort-Object -Property ProcessName
 $ModuleAllowList = New-Object Collections.Generic.List[string]
 
 # cSpell:disable
-$ModuleAllowList.add("Google.Protobuf.ni.dll")
-$ModuleAllowList.add("Microsoft.RightsManagementServices.Core.ni.dll")
-$ModuleAllowList.add("Newtonsoft.Json.ni.dll")
-$ModuleAllowList.add("Microsoft.Cloud.InstrumentationFramework.Events.ni.dll")
+$ModuleAllowList.add("Google.Protobuf.dll")
+$ModuleAllowList.add("Microsoft.RightsManagementServices.Core.dll")
+$ModuleAllowList.add("Newtonsoft.Json.dll")
+$ModuleAllowList.add("Microsoft.Cloud.InstrumentationFramework.Events.dll")
 $ModuleAllowList.add("HealthServicePerformance.dll")
 $ModuleAllowList.add("InterceptCounters.dll")
 $ModuleAllowList.add("MOMConnectorPerformance.dll")
 $ModuleAllowList.add("ExDbFailureItemApi.dll")
-$ModuleAllowList.add("Microsoft.Cloud.InstrumentationFramework.Metrics.ni.dll")
+$ModuleAllowList.add("Microsoft.Cloud.InstrumentationFramework.Metrics.dll")
 $ModuleAllowList.add("IfxMetrics.dll")
 $ModuleAllowList.add("ManagedBlingSigned.dll")
-$ModuleAllowList.add("ManagedBlingSigned.ni.dll")
 $ModuleAllowList.add("l3codecp.acm")
-$ModuleAllowList.add("System.IdentityModel.Tokens.jwt.ni.dll")
+$ModuleAllowList.add("System.IdentityModel.Tokens.jwt.dll")
 # Oracle modules associated with 'Outside In® Technology'
 $ModuleAllowList.add("wvcore.dll")
 $ModuleAllowList.add("sccut.dll")
@@ -418,6 +417,10 @@ Write-SimpleLogFile -string ("Allow List Module Count: " + $ModuleAllowList.coun
 
 $UnexpectedModuleFound = 0
 
+"`n####################################################################################################" | Out-File $OutputProcessPath
+"$((Get-Date).ToString())" | Out-File $OutputProcessPath -Append
+"####################################################################################################" | Out-File $OutputProcessPath -Append
+
 $showWarning = $false
 # Gather each process and work thru their module list to remove any known modules.
 foreach ($process in $ServerProcess) {
@@ -436,7 +439,7 @@ foreach ($process in $ServerProcess) {
 
         # Clear out modules from the allow list
         foreach ($module in $ModuleAllowList) {
-            $ProcessModules = $ProcessModules | Where-Object { $_.ModuleName -ne $module }
+            $ProcessModules = $ProcessModules | Where-Object { $_.ModuleName -ne $module -and $_.ModuleName -ne $($module.Replace(".dll", ".ni.dll")) }
         }
 
         if ($ProcessModules.count -gt 0) {

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -408,18 +408,15 @@ $ModuleAllowList.add("sccfmt.dll")
 $ModuleAllowList.add("sccind.dll")
 $ModuleAllowList.add("sccca.dll")
 $ModuleAllowList.add("scclo.dll")
-$ModuleAllowList.add("SCCOLE2.DLL")
-$ModuleAllowList.add("SCCSD.DLL")
-$ModuleAllowList.add("SCCXT.DLL")
+$ModuleAllowList.add("SCCOLE2.dll")
+$ModuleAllowList.add("SCCSD.dll")
+$ModuleAllowList.add("SCCXT.dll")
 # cSpell:enable
 
 Write-SimpleLogFile -string ("Allow List Module Count: " + $ModuleAllowList.count) -Name $LogFile
 
 $UnexpectedModuleFound = 0
 
-"`n####################################################################################################" | Out-File $OutputProcessPath
-"$((Get-Date).ToString())" | Out-File $OutputProcessPath -Append
-"####################################################################################################" | Out-File $OutputProcessPath -Append
 
 $showWarning = $false
 # Gather each process and work thru their module list to remove any known modules.
@@ -443,12 +440,19 @@ foreach ($process in $ServerProcess) {
         }
 
         if ($ProcessModules.count -gt 0) {
+
+            if ($UnexpectedModuleFound -eq 0) {
+                "`n####################################################################################################" | Out-File $OutputProcessPath  -Append
+                "$((Get-Date).ToString())" | Out-File $OutputProcessPath -Append
+                "####################################################################################################" | Out-File $OutputProcessPath -Append
+            }
+
             Write-Warning ("Possible AV Modules found in process $($process.ProcessName)")
             $UnexpectedModuleFound++
             foreach ($module in $ProcessModules) {
                 if ( $process.MainModule.ModuleName -eq "W3wp.exe" -and $showWarning -eq $false) {
-                    Write-Warning "W3wp.exe is not present in the recommended Exclusion list but we found 3rd Party modules on it and could affect Exchange performance."
-                    Write-SimpleLogFile -string "W3wp.exe is not present in the recommended Exclusion list but we found 3rd Party modules on it and could affect Exchange performance." -name $LogFile
+                    Write-Warning "W3wp.exe is not present in the recommended Exclusion list but we found 3rd Party modules on it and could affect Exchange performance or functionality."
+                    Write-SimpleLogFile -string "W3wp.exe is not present in the recommended Exclusion list but we found 3rd Party modules on it and could affect Exchange performance or functionality." -name $LogFile
                     $showWarning = $true
                 }
                 $OutString = ("[FAIL] - PROCESS: $($process.ProcessName) PID($($process.Id)) MODULE: $($module.ModuleName) COMPANY: $($module.Company)`n`t $($module.FileName)")
@@ -457,6 +461,10 @@ foreach ($process in $ServerProcess) {
             }
         }
     }
+}
+
+if ($UnexpectedModuleFound -gt 0) {
+    "`n####################################################################################################" | Out-File $OutputProcessPath  -Append
 }
 
 # Final output for process detection


### PR DESCRIPTION
**Issue:**
w3wp process is key in the Exchange system and it is interesting to know if a 3rd party module is included in the w3wp process including if it is not in the recommended exclusion list.

**Reason:**
Get report of the w3wp process modules

**Fix:**
Added w3wp process for analysis

**Validation:**

Test in lab:
![image](https://github.com/microsoft/CSS-Exchange/assets/103440830/ed1ff0e7-63f1-41c9-9f29-049660484565)

