### PR TITLE
Improve IIS module handling on legacy OS

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityIISModules.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityIISModules.ps1
@@ -42,7 +42,8 @@ function Invoke-AnalyzerSecurityIISModules {
                             Status = "Not signed"
                         })
                 } elseif (($m.SignatureDetails.IsMicrosoftSigned -eq $false) -or
-                    ($m.SignatureDetails.SignatureStatus -ne 0)) {
+                    ($m.SignatureDetails.SignatureStatus -ne 0) -and
+                    ($m.SignatureDetails.SignatureStatus -ne -1)) {
                     if ($modulesWriteType -ne "Red") {
                         $modulesWriteType = "Yellow"
                     }

--- a/Shared/Tests/Get-IISModules.Tests.ps1
+++ b/Shared/Tests/Get-IISModules.Tests.ps1
@@ -175,15 +175,27 @@ Describe "Testing Get-IISModules.ps1" {
             $iisModules.GetType() | Should -Be PSCustomObject
             $iisModules.ModuleList.GetType() | Should -Be System.Object[]
             $iisModules.Count | Should -Be 1
-            $iisModules.ModuleList.Count | Should -Be 4
+            $iisModules.ModuleList.Count | Should -Be 31
         }
 
-        It "Should Not Contain Default Modules Which Are Excluded" {
-            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetSrv\protSup.dll") | Should -Be $false
-            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetSrv\iisFreb.dll") | Should -Be $false
-            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetSrv\protSup.dll") | Should -Be $false
-            $iisModules.ModuleList.Path.Contains("C:\windows\system32\inetSrv\isApi.dll") | Should -Be $false
-            $iisModules.ModuleList.Path.Contains("C:\windows\system32\rpcProxy\rpcProxy.dll") | Should -Be $false
+        It "Should Contain Default Modules Which Are Excluded" {
+            $iisModules.ModuleList.Path -contains "C:\Windows\system32\inetSrv\protSup.dll" | Should -Be $true
+            $iisModules.ModuleList.Path -contains "C:\Windows\system32\inetSrv\iisFreb.dll" | Should -Be $true
+            $iisModules.ModuleList.Path -contains "C:\Windows\system32\inetSrv\isApi.dll" | Should -Be $true
+            $iisModules.ModuleList.Path -contains "C:\Windows\system32\rpcProxy\rpcProxy.dll" | Should -Be $true
+            $iisModules.ModuleList.Path -contains "C:\Windows\system32\inetSrv\cachtokn.dll" | Should -Be $true
+        }
+
+        It "Should Contain Default Signature Information For Modules That Are Skipped" {
+            foreach ($m in $iisModules.ModuleList) {
+                if (($m.Name -eq "TokenCacheModule") -or
+                    ($m.Name -eq "ProtocolSupportModule")) {
+                    $m.Signed | Should -Be $null
+                    $m.SignatureDetails.SignatureStatus | Should -Be -1
+                    $m.SignatureDetails.Signer | Should -Be $null
+                    $m.SignatureDetails.IsMicrosoftSigned | Should -Be $null
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Issue:**
On Windows Server versions < 2016, the default modules that come with IIS are not signed by Microsoft. We therefore skip the signature status check for those modules and don't return them when doing a `Get-IISModules` call. However, this leads to false-positives when performing additional checks (for example, the TokenCacheModule vulnerability check) as we never report that these modules are loaded by IIS.

**Reason:**
Resolve #1854 

**Fix:**
We now return all modules that are loaded by IIS via `Get-IISModules` call. For modules that are on the skip list, we return the default `ModuleSigned` status which is `$null` (otherwise `$true` or `$false`). We also return a `SignatureStatus` of `-1`.

**Validation:**
Lab

