### PR TITLE
Clarify prompt

### DIFF
--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-DiskSpace.ps1
@@ -87,7 +87,7 @@ function Test-DiskSpace {
         foreach ($svr in $passedServers) {
             Write-Host $svr
         }
-        Enter-YesNoLoopAction -Question "Are yu sure you want to continue?" -YesAction {} -NoAction { exit }
+        Enter-YesNoLoopAction -Question "Collect data only from servers that passed the disk space check?" -YesAction {} -NoAction { exit }
     }
     Write-Verbose("Function Exit: Test-DiskSpace")
     return $passedServers


### PR DESCRIPTION
When some servers are low on disk space, ExchangeLogCollector produces a prompt, and it's not clear what the prompt is asking you to confirm:

![image](https://github.com/microsoft/CSS-Exchange/assets/4518572/25b82e73-653f-4df7-b903-af58f3845706)

Are you sure you want to perform _what_ action? It turns out, it's trying to highlight that some of the servers failed the disk space check, and do you want to continue collecting just from the others.

This PR attempts to clarify the language.