### PR TITLE
Add example command to delete a previously created data collector set

### DIFF
--- a/Diagnostics/ExTRA/ExTRA.ps1
+++ b/Diagnostics/ExTRA/ExTRA.ps1
@@ -8,7 +8,11 @@ param(
 . $PSScriptRoot\GetTagsFromFileContent.ps1
 
 function ShowCommandToHost {
-    Write-Host "The trace can be created, started, and stopped from the command line or PowerShell"
+    Write-Host "The trace can be created, deleted, started, and stopped from the command line or PowerShell"
+    Write-Host
+    Write-Host "To delete a previously created data collector set:"
+    Write-Host
+    Write-Host "logman delete ExchangeDebugTraces" -ForegroundColor Green
     Write-Host
     Write-Host "To create a data collector which is non-circular and stops at 1 GB:"
     Write-Host

--- a/Diagnostics/ExTRA/ui.html
+++ b/Diagnostics/ExTRA/ui.html
@@ -89,7 +89,11 @@
 
         </div>
         <div class="row hidden" id="syntaxDiv">
-            <p>The trace can be created, started, and stopped from the command line or PowerShell.</p>
+            <p>The trace can be created, deleted, started, and stopped from the command line or PowerShell.</p>
+            <p>To delete a previously existing data collector set:</p>
+            <p class="black green-text code">
+                <code>logman delete ExchangeDebugTraces</code>
+            </p>
             <p>To create a data collector which is non-circular and stops at 1 GB:</p>
             <p class="black green-text code">
                 <code>logman create trace ExchangeDebugTraces -p "{79bb49e6-2a2c-46e4-9167-fa122525d540}" -o c:\tracing\trace.etl -ow -f bin -max 1024 -mode globalsequence</code>


### PR DESCRIPTION
Add example command for deleting a previously existing data collector set - this will be an issue if tracing has been run previously on the server.

**Issue:**
If EXTRA tracing has been run previously on this server, the ExchangeDebugTraces data collector set will already exist. The create commands will fail with an error, and it may not be immediately obvious how to address that error to some users.

**Reason:**
If EXTRA tracing has been run previously on this server, the ExchangeDebugTraces data collector set will already exist. The create commands will fail with an error, and it may not be immediately obvious how to address that error to some users.

**Fix:**
Added an example command to delete a previously created data collector set to the page with example commands.

**Validation:**
n/a

