### PR TITLE
Fix PSUseCorrectCasing errors

### DIFF
--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Get-IISLogDirectory.ps1
@@ -8,7 +8,7 @@ function Get-IISLogDirectory {
 
     function Get-IISDirectoryFromGetWebSite {
         Write-Verbose("Get-WebSite command exists")
-        return Get-WebSite |
+        return Get-Website |
             ForEach-Object {
                 $logFile = "$($_.LogFile.Directory)\W3SVC$($_.id)".Replace("%SystemDrive%", $env:SystemDrive)
                 Write-Verbose("Found Directory: $logFile")

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -10,10 +10,10 @@ function Get-IISWebSite {
     $webSites = New-Object 'System.Collections.Generic.List[object]'
 
     if ($null -eq $WebSitesToProcess) {
-        $webSites.AddRange((Get-WebSite))
+        $webSites.AddRange((Get-Website))
     } else {
         foreach ($iisWebSite in $WebSitesToProcess) {
-            $webSites.Add((Get-WebSite -Name $($iisWebSite)))
+            $webSites.Add((Get-Website -Name $($iisWebSite)))
         }
     }
 

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -338,15 +338,15 @@ function Run-Mitigate {
                 Clear-WebConfiguration -Filter $filter2 -PSPath $site
             }
 
-            Add-WebConfigurationProperty -PSPath $site -filter $root -name '.' -value @{name = $name; patternSyntax = 'Regular Expressions'; stopProcessing = 'False' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/match" -name 'url' -value $inbound
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/conditions" -name '.' -value @{input = $HttpCookieInput; matchType = '0'; pattern = $pattern; ignoreCase = 'True'; negate = 'False' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/action" -name 'type' -value 'AbortRequest'
+            Add-WebConfigurationProperty -PSPath $site -Filter $root -Name '.' -Value @{name = $name; patternSyntax = 'Regular Expressions'; stopProcessing = 'False' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/match" -Name 'url' -Value $inbound
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/conditions" -Name '.' -Value @{input = $HttpCookieInput; matchType = '0'; pattern = $pattern; ignoreCase = 'True'; negate = 'False' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/action" -Name 'type' -Value 'AbortRequest'
 
-            Add-WebConfigurationProperty -PSPath $site -filter $root -name '.' -value @{name = $name2; patternSyntax = 'Regular Expressions'; stopProcessing = 'True' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter2/match" -name 'url' -value $inbound
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter2/conditions" -name '.' -value @{input = $HttpCookieInput; matchType = '0'; pattern = $pattern2; ignoreCase = 'True'; negate = 'False' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter2/action" -name 'type' -value 'AbortRequest'
+            Add-WebConfigurationProperty -PSPath $site -Filter $root -Name '.' -Value @{name = $name2; patternSyntax = 'Regular Expressions'; stopProcessing = 'True' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter2/match" -Name 'url' -Value $inbound
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter2/conditions" -Name '.' -Value @{input = $HttpCookieInput; matchType = '0'; pattern = $pattern2; ignoreCase = 'True'; negate = 'False' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter2/action" -Name 'type' -Value 'AbortRequest'
 
             $Message = "Mitigation complete on $env:COMPUTERNAME :: $WebSiteName"
             $RegMessage = "Mitigation complete"

--- a/Security/src/EOMTv2.ps1
+++ b/Security/src/EOMTv2.ps1
@@ -351,10 +351,10 @@ function Run-Mitigate {
                 Clear-WebConfiguration -Filter $filter -PSPath $site
             }
 
-            Add-WebConfigurationProperty -PSPath $site -filter $root -name '.' -value @{name = $name; patternSyntax = 'Regular Expressions'; stopProcessing = 'True' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/match" -name 'url' -value $inbound
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/conditions" -name '.' -value @{input = $HttpRequestInput; matchType = '0'; pattern = $pattern; ignoreCase = 'True'; negate = 'False' }
-            Set-WebConfigurationProperty -PSPath $site -filter "$filter/action" -name 'type' -value 'AbortRequest'
+            Add-WebConfigurationProperty -PSPath $site -Filter $root -Name '.' -Value @{name = $name; patternSyntax = 'Regular Expressions'; stopProcessing = 'True' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/match" -Name 'url' -Value $inbound
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/conditions" -Name '.' -Value @{input = $HttpRequestInput; matchType = '0'; pattern = $pattern; ignoreCase = 'True'; negate = 'False' }
+            Set-WebConfigurationProperty -PSPath $site -Filter "$filter/action" -Name 'type' -Value 'AbortRequest'
 
             $Message = "Mitigation complete on $env:COMPUTERNAME :: $WebSiteName"
             $RegMessage = "Mitigation complete"

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureMitigation.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureMitigation.ps1
@@ -97,7 +97,7 @@ function Invoke-ConfigureMitigation {
                 $backupPath = "$($env:WINDIR)\System32\inetSrv\config\IpFilteringRules_" + $SiteVDirLocation.Replace('/', '-') + "_$([DateTime]::Now.ToString("yyyyMMddHHMMss")).bak"
                 $Filter = 'system.webServer/security/ipSecurity'
                 $IISPath = 'IIS:\'
-                $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -name collection)
+                $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -Name collection)
                 $state.IsBackUpSuccessful = BackupCurrentIPFilteringRules -BackupPath $backupPath -Filter $Filter -IISPath $IISPath -SiteVDirLocation $SiteVDirLocation -ExistingRules $ExistingRules
 
                 $RulesToBeAdded = @()

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
@@ -100,7 +100,7 @@ function Invoke-RollbackIPFiltering {
                     [Parameter(Mandatory = $true)]
                     [string]$SiteVDirLocation
                 )
-                $ExtendedProtection = Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -name "extendedProtection.tokenChecking"
+                $ExtendedProtection = Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -Name "extendedProtection.tokenChecking"
                 if ($ExtendedProtection -ne "Require") {
                     Set-WebConfigurationProperty -Filter $Filter -PSPath $IISPath -Location $SiteVDirLocation -Name "extendedProtection.tokenChecking" -Value "Require"
                 }
@@ -127,7 +127,7 @@ function Invoke-RollbackIPFiltering {
                     $state.TurnOnEPSuccessful = $true
 
                     $state.BackUpPath = "$($env:WINDIR)\System32\inetSrv\config\IpFilteringRules_" + $SiteVDirLocation.Replace('/', '-') + "_$([DateTime]::Now.ToString("yyyyMMddHHMMss")).bak"
-                    $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -name collection)
+                    $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -Name collection)
                     $state.BackupCurrentSuccessful = BackupCurrentIPFilteringRules -BackupPath $state.BackUpPath -Filter $Filter -IISPath $IISPath -SiteVDirLocation $SiteVDirLocation -ExistingRules $ExistingRules
 
                     $originalIpFilteringConfigurations = (Get-Content $state.RestorePath | Out-String | ConvertFrom-Json)

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ValidateMitigation.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ValidateMitigation.ps1
@@ -62,7 +62,7 @@ function Invoke-ValidateMitigation {
 
                 $Filter = 'system.webServer/security/authentication/windowsAuthentication/extendedProtection'
 
-                $ExtendedProtection = Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -name tokenChecking
+                $ExtendedProtection = Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -Name tokenChecking
                 return $ExtendedProtection
             }
 
@@ -87,7 +87,7 @@ function Invoke-ValidateMitigation {
                 $Filter = 'system.webServer/security/ipSecurity'
                 $IISPath = 'IIS:\'
 
-                $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -name collection)
+                $ExistingRules = @(Get-WebConfigurationProperty -Filter $Filter -Location $SiteVDirLocation -Name collection)
 
                 foreach ($IpFilteringRule in $IpFilteringRules) {
                     $ExistingIPSubnetRule = $ExistingRules | Where-Object {


### PR DESCRIPTION
It appears that the ADO pipeline now has the WebAdministration module installed as autoloadable somehow (which I have not been able to do on my lab machines), but the result is that PSUseCorrectCasing is now being enforced in the pipeline. This is now blocking #1853, which causes a recheck of the formatting of all files due to the change in CodeFormatter.