### PR TITLE
Addressed Pester Failure due to Expired Auth Cert

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -132,7 +132,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Pattern service" "Unreachable`r`n`t`tMore information: https://aka.ms/HelpConnectivityEEMS" -WriteType "Yellow"
             TestObjectMatch "Telemetry enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 96
+            $Script:ActiveGrouping.Count | Should -Be 97
         }
 
         It "Display Results - Security Vulnerability" {


### PR DESCRIPTION
**Issue:**
Pester testing was failing showing the count in the Security Section was off by 1.

**Reason:**
The testing data had a cert that expired a few days ago now. 

**Fix:**
Temp fix, increase the count for the section. 

**Validation:**
Pester tested.

