### PR TITLE
Improve Credential Guard Running Check

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -44,6 +44,21 @@ function Get-OperatingSystemInformation {
             Invoke-CatchActions
         }
 
+        $credentialGuardCimInstance = $false
+        try {
+            $params = @{
+                ClassName    = "Win32_DeviceGuard"
+                Namespace    = "root\Microsoft\Windows\DeviceGuard"
+                ErrorAction  = "Stop"
+                ComputerName = $Server
+            }
+            $credentialGuardCimInstance = (Get-CimInstance @params).SecurityServicesRunning
+        } catch {
+            Write-Verbose "Failed to run Get-CimInstance for Win32_DeviceGuard"
+            Invoke-CatchActions
+            $credentialGuardCimInstance = "Unknown"
+        }
+
         $serverPendingReboot = (Get-ServerRebootPending -ServerName $Server -CatchActionFunction ${Function:Invoke-CatchActions})
         $timeZoneInformation = Get-TimeZoneInformation -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $tlsSettings = Get-AllTlsSettings -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
@@ -54,19 +69,20 @@ function Get-OperatingSystemInformation {
     } end {
         Write-Verbose "Exiting: $($MyInvocation.MyCommand)"
         return [PSCustomObject]@{
-            BuildInformation    = $buildInformation
-            NetworkInformation  = $networkInformation
-            PowerPlan           = $powerPlan
-            PageFile            = $pageFile
-            ServerPendingReboot = $serverPendingReboot
-            TimeZone            = $timeZoneInformation
-            TLSSettings         = $tlsSettings
-            ServerBootUp        = $serverBootUp
-            VcRedistributable   = [array]$vcRedistributable
-            RegistryValues      = $registryValues
-            Smb1ServerSettings  = $smb1ServerSettings
-            HotFixes            = $hotFixes
-            NETFramework        = $netFrameworkInformation
+            BuildInformation           = $buildInformation
+            NetworkInformation         = $networkInformation
+            PowerPlan                  = $powerPlan
+            PageFile                   = $pageFile
+            ServerPendingReboot        = $serverPendingReboot
+            TimeZone                   = $timeZoneInformation
+            TLSSettings                = $tlsSettings
+            ServerBootUp               = $serverBootUp
+            VcRedistributable          = [array]$vcRedistributable
+            RegistryValues             = $registryValues
+            Smb1ServerSettings         = $smb1ServerSettings
+            HotFixes                   = $hotFixes
+            NETFramework               = $netFrameworkInformation
+            CredentialGuardCimInstance = $credentialGuardCimInstance
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -34,6 +34,8 @@ Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "G
 # Handle IIS collection of files
 Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Getting applicationHost.config" } -MockWith { return Get-Content "$Script:MockDataCollectionRoot\Exchange\IIS\applicationHost.config" -Raw }
 
+Mock Get-CimInstance -ParameterFilter { $ClassName -eq "Win32_DeviceGuard" } -MockWith { return [PSCustomObject]@{ SecurityServicesRunning = @(0 , 0) } }
+
 # WebAdministration
 function Get-WebSite { param($Name) }
 Mock Get-WebSite -ParameterFilter { $null -eq $Name } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\IIS\GetWebSite.xml" }


### PR DESCRIPTION
**Issue:**
Issue described in #1867 

**Reason:**
Health Checker didn't properly determine if Credential Guard was enabled on a system. Adding another way to check to see if it is enabled.

**Fix:**
Add in option to check for the `Get-CimInstance` of the credential guard check described in article: 
https://learn.microsoft.com/en-us/windows/security/identity-protection/credential-guard/configure

Resolved #1867 

**Validation:**
Lab tested

