### PR TITLE
Don't use semicolons as line terminators enabled for code formatter.

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -91,7 +91,7 @@ $unreferencedScriptFiles = @($allScriptFiles | Where-Object {
         }
 
         return $true
-    });
+    })
 
 $unreferencedSharedScriptFiles = @($unreferencedScriptFiles | Where-Object {
         $_.StartsWith("$repoRoot\Shared\")

--- a/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
+++ b/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
@@ -38,7 +38,7 @@ function CheckScriptFileHasBOM {
                     Write-Host "Added BOM: $($FileInfo.FullName)"
                     $false
                 } catch {
-                    Write-Warning "File has no BOM and couldn't be fixed automatically: $($FileInfo.FullName). Exception: $($_.Exception)";
+                    Write-Warning "File has no BOM and couldn't be fixed automatically: $($FileInfo.FullName). Exception: $($_.Exception)"
                     $true
                 }
             } else {

--- a/Admin/Find-AmbiguousSids.ps1
+++ b/Admin/Find-AmbiguousSids.ps1
@@ -61,8 +61,8 @@ begin {
     Write-Host "Using GC $GCName"
     $ldapConn = New-Object System.DirectoryServices.Protocols.LdapConnection("$($GCName):3268")
     $searchReq = New-Object System.DirectoryServices.Protocols.SearchRequest("", $filter, "Subtree", $null)
-    $prc = New-Object System.DirectoryServices.Protocols.PageResultRequestControl($pageSize);
-    [void]$searchReq.Controls.Add($prc);
+    $prc = New-Object System.DirectoryServices.Protocols.PageResultRequestControl($pageSize)
+    [void]$searchReq.Controls.Add($prc)
 
     $sidProperties = @("objectSid", "sidHistory", "msExchMasterAccountSid")
     $containersToIgnore = @(",CN=WellKnown Security Principals,", ",CN=Builtin,", ",CN=ForeignSecurityPrincipals,")
@@ -99,7 +99,7 @@ process {
 
             $objectsProcessed++
         }
-    } while ($prc.Cookie.Length -gt 0);
+    } while ($prc.Cookie.Length -gt 0)
 }
 
 end {

--- a/Admin/Update-Engines.ps1
+++ b/Admin/Update-Engines.ps1
@@ -108,7 +108,7 @@ function ExtractCab($sourceCabPath, $destinationDirectory) {
         # Process each item in the cab. Determine if the destination
         # is a sub directory and create if necessary.
         for ($i=0; $i -lt $itemCount; $i++) {
-            $lastPathIndex = $source.item($i).Path.LastIndexOf("\");
+            $lastPathIndex = $source.item($i).Path.LastIndexOf("\")
 
             # If the file inside the zip file should be extracted
             # to a subfolder, then we need to reset the destination

--- a/Calendar/Check-SharingStatus.ps1
+++ b/Calendar/Check-SharingStatus.ps1
@@ -49,7 +49,7 @@ function ProcessCalendarSharingInviteLogs {
 
     # Define the header row
     $header = "Timestamp", "Mailbox", "Entry MailboxOwner", "Recipient", "RecipientType", "SharingType", "DetailLevel"
-    $csvString = @();
+    $csvString = @()
     $csvString = $header -join ","
     $csvString += "`n"
 
@@ -74,7 +74,7 @@ function ProcessCalendarSharingInviteLogs {
         return
     }
 
-    $logLines =@();
+    $logLines =@()
     # Split the output into an array of lines
     $logLines = $logOutput.MailboxLog -split "`r`n"
 
@@ -125,7 +125,7 @@ function ProcessCalendarSharingAcceptLogs {
 
     # Define the header row
     $header = "Timestamp", "Mailbox", "SharedCalendarOwner", "FolderName"
-    $csvString = @();
+    $csvString = @()
     $csvString = $header -join ","
     $csvString += "`n"
 
@@ -150,7 +150,7 @@ function ProcessCalendarSharingAcceptLogs {
         return
     }
 
-    $logLines =@();
+    $logLines =@()
     # Split the output into an array of lines
     $logLines = $logOutput.MailboxLog -split "`r`n"
 
@@ -225,7 +225,7 @@ function GetOwnerInformation {
     if ($script:OwnerMB.DisplayName -like "Redacted*") {
         Write-Host -ForegroundColor Yellow "Do Not have PII information for the Owner."
         Write-Host -ForegroundColor Yellow "Get PII Access for $($script:OwnerMB.Database)."
-        $script:PIIAccess = $false;
+        $script:PIIAccess = $false
     }
 
     Write-Host  -ForegroundColor DarkYellow  "Owner Calendar Folder Statistics:"

--- a/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
+++ b/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
@@ -75,9 +75,9 @@ $CustomPropertyNameList =
 "MapiStartTime",
 "NormalizedSubject",
 "SentRepresentingDisplayName",
-"SentRepresentingEmailAddress";
+"SentRepresentingEmailAddress"
 
-$LogLimit = 2000;
+$LogLimit = 2000
 
 $WellKnownCN_CA = "MICROSOFT SYSTEM ATTENDANT"
 $CalAttendant = "Calendar Assistant"
@@ -163,12 +163,12 @@ function GetCalendarDiagnosticObjects {
 
         # No Results, do a Deep search with ExactMatch.
         if ($CalLogs.count -lt 1) {
-            $CalLogs = Get-CalendarDiagnosticObjects @Params -Subject $Subject -ExactMatch $true;
+            $CalLogs = Get-CalendarDiagnosticObjects @Params -Subject $Subject -ExactMatch $true
         }
     }
 
     Write-Host "Found $($CalLogs.count) Calendar Logs for [$Identity]"
-    return $CalLogs;
+    return $CalLogs
 }
 
 function FindMatch {
@@ -177,7 +177,7 @@ function FindMatch {
     )
     foreach ($Val in $PassedHash.keys) {
         if ($KeyInput -like "*$Val*") {
-            return $PassedHash[$Val];
+            return $PassedHash[$Val]
         }
     }
 }
@@ -203,19 +203,19 @@ function GetMailbox {
         if ($Identity -and $Organization) {
             if ($script:MSSupport) {
                 Write-Verbose "Using Organization parameter"
-                $GetMailboxOutput = Get-Mailbox -Identity $Identity -Organization $Organization -ErrorAction SilentlyContinue;
+                $GetMailboxOutput = Get-Mailbox -Identity $Identity -Organization $Organization -ErrorAction SilentlyContinue
             } else {
                 Write-Verbose "Using -OrganizationalUnit parameter"
-                $GetMailboxOutput = Get-Mailbox -Identity $Identity -OrganizationalUnit $Organization -ErrorAction SilentlyContinue;
+                $GetMailboxOutput = Get-Mailbox -Identity $Identity -OrganizationalUnit $Organization -ErrorAction SilentlyContinue
             }
         } else {
-            $GetMailboxOutput = Get-Mailbox -Identity $Identity -ErrorAction SilentlyContinue;
+            $GetMailboxOutput = Get-Mailbox -Identity $Identity -ErrorAction SilentlyContinue
         }
 
         if (!$GetMailboxOutput) {
             Write-Host "Unable to find [$Identity]$(if ($Organization -ne `"`" ) {" in Organization:[$Organization]"})."
             Write-Host "Trying to find a Group Mailbox for [$Identity]..."
-            $GetMailboxOutput = Get-Mailbox -Identity $Identity -ErrorAction SilentlyContinue -GroupMailbox;
+            $GetMailboxOutput = Get-Mailbox -Identity $Identity -ErrorAction SilentlyContinue -GroupMailbox
             if (!$GetMailboxOutput) {
                 Write-Host "Unable to find a Group Mailbox for [$Identity] either."
                 return $null
@@ -231,9 +231,9 @@ function GetMailbox {
         } else {
             Write-Verbose "Found [$($GetMailboxOutput.DisplayName)]"
         }
-        return $GetMailboxOutput;
+        return $GetMailboxOutput
     } catch {
-        Write-Error "An error occurred while running Get-Mailbox: [$_]";
+        Write-Error "An error occurred while running Get-Mailbox: [$_]"
     }
 }
 
@@ -243,32 +243,32 @@ function Convert-Data {
         [string[]] $ArrayNames,
         [switch ] $NoWarnings = $False
     )
-    $ValidArrays = @();
-    $ItemCounts = @();
-    $VariableLookup = @{};
+    $ValidArrays = @()
+    $ItemCounts = @()
+    $VariableLookup = @{}
     foreach ($Array in $ArrayNames) {
         try {
-            $VariableData = Get-Variable -Name $Array -ErrorAction Stop;
-            $VariableLookup[$Array] = $VariableData.Value;
-            $ValidArrays += $Array;
-            $ItemCounts += ($VariableData.Value | Measure-Object).Count;
+            $VariableData = Get-Variable -Name $Array -ErrorAction Stop
+            $VariableLookup[$Array] = $VariableData.Value
+            $ValidArrays += $Array
+            $ItemCounts += ($VariableData.Value | Measure-Object).Count
         } catch {
             if (!$NoWarnings) {
-                Write-Warning -Message "No variable found for [$Array]";
+                Write-Warning -Message "No variable found for [$Array]"
             }
         }
     }
-    $MaxItemCount = ($ItemCounts | Measure-Object -Maximum).Maximum;
-    $FinalArray = @();
+    $MaxItemCount = ($ItemCounts | Measure-Object -Maximum).Maximum
+    $FinalArray = @()
     for ($Inc = 0; $Inc -lt $MaxItemCount; $Inc++) {
-        $FinalObj = New-Object PsObject;
+        $FinalObj = New-Object PsObject
         foreach ($Item in $ValidArrays) {
-            $FinalObj | Add-Member -MemberType NoteProperty -Name $Item -Value $VariableLookup[$Item][$Inc];
+            $FinalObj | Add-Member -MemberType NoteProperty -Name $Item -Value $VariableLookup[$Item][$Inc]
         }
-        $FinalArray += $FinalObj;
+        $FinalArray += $FinalObj
     }
-    return $FinalArray;
-    $FinalArray = @();
+    return $FinalArray
+    $FinalArray = @()
 }
 
 <#
@@ -304,7 +304,7 @@ function GetMailboxProp {
             }
             default {
                 if ($null -ne $script:MailboxList[$PassedCN]) {
-                    $ReturnValue = $script:MailboxList[$PassedCN].$Prop;
+                    $ReturnValue = $script:MailboxList[$PassedCN].$Prop
 
                     if ($null -eq $ReturnValue) {
                         Write-Error "`t GetMailboxProp:$Prop :NotFound for ::[$PassedCN]"
@@ -316,7 +316,7 @@ function GetMailboxProp {
                         Write-Verbose "No PII Access for [$ReturnValue]"
                         return BetterThanNothingCNConversion($PassedCN)
                     }
-                    return $ReturnValue;
+                    return $ReturnValue
                 } else {
                     Write-Verbose "`t GetMailboxProp:$Prop :NotFound::$PassedCN"
                     return BetterThanNothingCNConversion($PassedCN)
@@ -350,19 +350,19 @@ function BetterThanNothingCNConversion {
     }
 
     if ($PassedCN -match 'cn=([\w,\s.@-]*[^/])$') {
-        $cNameMatch = $PassedCN -split "cn=";
+        $cNameMatch = $PassedCN -split "cn="
 
         # Normally a readable name is sectioned off with a "-" at the end.
         # example /o=ExchangeLabs/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=d61149258ba04404adda42f336b504ed-Delegate
         if ($cNameMatch[-1] -match "-[\w* -.]*") {
             Write-Verbose "BetterThanNothingCNConversion: Returning : [$($cNameMatch[-1])]"
-            return $cNameMatch.split('-')[-1];
+            return $cNameMatch.split('-')[-1]
         }
         # Sometimes we do not have the "-" in front of the Name.
         # example: "/o=ExchangeLabs/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user123"
         if ($cNameMatch[-1] -match "[\w* -.]*") {
             Write-Verbose "BetterThanNothingCNConversion: Returning : [$($cNameMatch[-1])]"
-            return $cNameMatch.split('-')[-1];
+            return $cNameMatch.split('-')[-1]
         }
     }
 }
@@ -466,7 +466,7 @@ Creates a list of CN that are used in the Calendar Logs, Looks up the Mailboxes 
 #>
 function ConvertCNtoSMTP {
     # Creates a list of CN's that we will do MB look up on
-    $CNEntries = @();
+    $CNEntries = @()
     $CNEntries += ($script:GCDO.SentRepresentingEmailAddress.ToUpper() | Select-Object -Unique)
     $CNEntries += ($script:GCDO.ResponsibleUserName.ToUpper() | Select-Object -Unique)
     $CNEntries += ($script:GCDO.SenderEmailAddress.ToUpper() | Select-Object -Unique)
@@ -474,7 +474,7 @@ function ConvertCNtoSMTP {
     Write-Verbose "`t Have $($CNEntries.count) CNEntries to look for..."
     Write-Verbose "CNEntries: "; foreach ($CN in $CNEntries) { Write-Verbose $CN }
 
-    $Org = $script:MB.OrganizationalUnit.split('/')[-1];
+    $Org = $script:MB.OrganizationalUnit.split('/')[-1]
 
     # Creates a Dictionary of MB's that we will use to look up the CN's
     Write-Verbose "Converting CN entries into SMTP Addresses..."
@@ -485,7 +485,7 @@ function ConvertCNtoSMTP {
             } elseif ($CNEntry -match $WellKnownCN_Trans) {
                 $MailboxList[$CNEntry] = $Transport
             } else {
-                $MailboxList[$CNEntry] = (GetMailbox -Identity $CNEntry -Organization $Org);
+                $MailboxList[$CNEntry] = (GetMailbox -Identity $CNEntry -Organization $Org)
             }
         }
     }
@@ -504,23 +504,23 @@ function CreateShortClientName {
     param(
         $ClientInfoString
     )
-    $ShortClientName= @();
+    $ShortClientName= @()
 
     # Map ClientInfoString to ShortClientName
     if (!$ClientInfoString) {
-        $ShortClientName = "NotFound";
+        $ShortClientName = "NotFound"
     }
 
     if ($ClientInfoString -like "Client=EBA*" -or $ClientInfoString -like "Client=TBA*") {
         if ($ClientInfoString -like "*ResourceBookingAssistant*") {
-            $ShortClientName = "ResourceBookingAssistant";
+            $ShortClientName = "ResourceBookingAssistant"
         } elseif ($ClientInfoString -like "*CalendarRepairAssistant*") {
-            $ShortClientName = "CalendarRepairAssistant";
+            $ShortClientName = "CalendarRepairAssistant"
         } else {
-            $client = $ClientInfoString.Split(';')[0].Split('=')[-1];
-            $Action = $ClientInfoString.Split(';')[1].Split('=')[-1];
-            $Data = $ClientInfoString.Split(';')[-1];
-            $ShortClientName = $client+":"+$Action+";"+$Data;
+            $client = $ClientInfoString.Split(';')[0].Split('=')[-1]
+            $Action = $ClientInfoString.Split(';')[1].Split('=')[-1]
+            $Data = $ClientInfoString.Split(';')[-1]
+            $ShortClientName = $client+":"+$Action+";"+$Data
         }
     } elseif ($ClientInfoString -like "Client=ActiveSync*") {
         if ($ClientInfoString -match 'UserAgent=(\w*-\w*)') {
@@ -532,44 +532,44 @@ function CreateShortClientName {
         }
     } elseif ($ClientInfoString -like "Client=Rest*") {
         if ($ClientInfoString -like "*LocationAssistantProcessor*") {
-            $ShortClientName = "LocationProcessor";
+            $ShortClientName = "LocationProcessor"
         } elseif ($ClientInfoString -like "*AppId=6326e366-9d6d-4c70-b22a-34c7ea72d73d*") {
-            $ShortClientName = "CalendarReplication";
+            $ShortClientName = "CalendarReplication"
         } elseif ($ClientInfoString -like "*AppId=1e3faf23-d2d2-456a-9e3e-55db63b869b0*") {
-            $ShortClientName = "CiscoWebex";
+            $ShortClientName = "CiscoWebex"
         } elseif ($ClientInfoString -like "*AppId=1c3a76cc-470a-46d7-8ba9-713cfbb2c01f*") {
-            $ShortClientName = "TimeService";
+            $ShortClientName = "TimeService"
         } elseif ($ClientInfoString -like "*AppId=48af08dc-f6d2-435f-b2a7-069abd99c086*") {
-            $ShortClientName = "RestConnector";
+            $ShortClientName = "RestConnector"
         } elseif ($ClientInfoString -like "*GriffinRestClient*") {
-            $ShortClientName = "GriffinRestClient";
+            $ShortClientName = "GriffinRestClient"
         } elseif ($ClientInfoString -like "*NoUserAgent*") {
-            $ShortClientName = "RestUnknown";
+            $ShortClientName = "RestUnknown"
         } elseif ($ClientInfoString -like "*MacOutlook*") {
-            $ShortClientName = "MacOutlookRest";
+            $ShortClientName = "MacOutlookRest"
         } elseif ($ClientInfoString -like "*Microsoft Outlook 16*") {
-            $ShortClientName = "Outlook-ModernCalendarSharing";
+            $ShortClientName = "Outlook-ModernCalendarSharing"
         } else {
-            $ShortClientName = "Rest";
+            $ShortClientName = "Rest"
         }
     } else {
-        $ShortClientName = findMatch -PassedHash $ShortClientNameProcessor;
+        $ShortClientName = findMatch -PassedHash $ShortClientNameProcessor
     }
 
     if ($ClientInfoString -like "*InternalCalendarSharing*" -and $ClientInfoString -like "*OWA*") {
-        $ShortClientName = "Owa-ModernCalendarSharing";
+        $ShortClientName = "Owa-ModernCalendarSharing"
     }
     if ($ClientInfoString -like "*InternalCalendarSharing*" -and $ClientInfoString -like "*MacOutlook*") {
-        $ShortClientName = "MacOutlook-ModernCalendarSharing";
+        $ShortClientName = "MacOutlook-ModernCalendarSharing"
     }
     if ($ClientInfoString -like "*InternalCalendarSharing*" -and $ClientInfoString -like "*Outlook*") {
-        $ShortClientName = "Outlook-ModernCalendarSharing";
+        $ShortClientName = "Outlook-ModernCalendarSharing"
     }
     if ($ClientInfoString -like "Client=ActiveSync*" -and $ClientInfoString -like "*Outlook*") {
-        $ShortClientName = "Outlook-ModernCalendarSharing";
+        $ShortClientName = "Outlook-ModernCalendarSharing"
     }
 
-    return $ShortClientName;
+    return $ShortClientName
 }
 
 <#
@@ -593,9 +593,9 @@ function SetIsIgnorable {
             -or $CalendarItemTypes.($CalLog.ItemClass) -eq "SharingDelete" `
             -or $CalendarItemTypes.($CalLog.ItemClass) -eq "AttendeeList" `
             -or $CalendarItemTypes.($CalLog.ItemClass) -eq "RespAny") {
-        return "True";
+        return "True"
     } else {
-        return "False";
+        return "False"
     }
 }
 
@@ -661,43 +661,43 @@ function BuildCSV {
     )
 
     Write-Host "Starting to Process Calendar Logs..."
-    $GCDOResults = @();
-    $IsFromSharedCalendar = @();
-    $IsIgnorable = @();
-    $script:MailboxList = @{};
+    $GCDOResults = @()
+    $IsFromSharedCalendar = @()
+    $IsIgnorable = @()
+    $script:MailboxList = @{}
     Write-Host "Creating Map of Mailboxes to CN's..."
-    CreateExternalMasterIDMap;
+    CreateExternalMasterIDMap
 
-    $ThisMeetingID = $script:GCDO.CleanGlobalObjectId | Select-Object -Unique;
-    $ShortMeetingID = $ThisMeetingID.Substring($ThisMeetingID.length - 6);
+    $ThisMeetingID = $script:GCDO.CleanGlobalObjectId | Select-Object -Unique
+    $ShortMeetingID = $ThisMeetingID.Substring($ThisMeetingID.length - 6)
 
-    ConvertCNtoSMTP;
+    ConvertCNtoSMTP
 
     Write-Host "Making Calendar Logs more readable..."
-    $Index = 0;
+    $Index = 0
     foreach ($CalLog in $script:GCDO) {
-        $CalLogACP = $CalLog.AppointmentCounterProposal.ToString();
-        $Index++;
-        $ItemType = $CalendarItemTypes.($CalLog.ItemClass);
-        $ShortClientName = @();
-        $script:KeyInput = $CalLog.ClientInfoString;
-        $ResponseType = $ResponseTypeOptions.($CalLog.ResponseType.ToString());
+        $CalLogACP = $CalLog.AppointmentCounterProposal.ToString()
+        $Index++
+        $ItemType = $CalendarItemTypes.($CalLog.ItemClass)
+        $ShortClientName = @()
+        $script:KeyInput = $CalLog.ClientInfoString
+        $ResponseType = $ResponseTypeOptions.($CalLog.ResponseType.ToString())
 
-        $ShortClientName = CreateShortClientName($CalLog.ClientInfoString);
+        $ShortClientName = CreateShortClientName($CalLog.ClientInfoString)
 
         $IsIgnorable = SetIsIgnorable($CalLog)
 
         # CleanNotFounds;
         $PropsToClean = "FreeBusyStatus", "ClientIntent", "AppointmentLastSequenceNumber", "RecurrencePattern", "AppointmentAuxiliaryFlags", "IsOrganizerProperty", "EventEmailReminderTimer", "IsSeriesCancelled", "AppointmentCounterProposal", "MeetingRequestType"
         foreach ($Prop in $PropsToClean) {
-            $CalLog.$Prop = ReplaceNotFound($CalLog.$Prop);
+            $CalLog.$Prop = ReplaceNotFound($CalLog.$Prop)
         }
 
         if ($CalLogACP -eq "NotFound") {
-            $CalLogACP = '';
+            $CalLogACP = ''
         }
 
-        $IsFromSharedCalendar = ($null -ne $CalLog.externalSharingMasterId -and $CalLog.externalSharingMasterId -ne "NotFound");
+        $IsFromSharedCalendar = ($null -ne $CalLog.externalSharingMasterId -and $CalLog.externalSharingMasterId -ne "NotFound")
 
         # Need to ask about this
         $GetIsOrganizer = ($CalendarItemTypes.($CalLog.ItemClass) -eq "IpmAppointment" -and
@@ -766,7 +766,7 @@ function BuildCSV {
             'CleanGlobalObjectId'           = $CalLog.CleanGlobalObjectId
         }
     }
-    $script:Results = $GCDOResults;
+    $script:Results = $GCDOResults
 
     # Automation won't have access to this file - will add code in next version to save contents to a variable
     #$Filename = "$($Results[0].ReceivedBy)_$ShortMeetingID.csv";
@@ -775,17 +775,17 @@ function BuildCSV {
         $ShortName = $Identity.Split('@')[0]
     }
     $ShortName = $ShortName.Substring(0, [System.Math]::Min(20, $ShortName.Length))
-    $Filename = "$($ShortName)_$ShortMeetingID.csv";
+    $Filename = "$($ShortName)_$ShortMeetingID.csv"
     Write-Host -ForegroundColor Cyan -NoNewline "Calendar Logs for [$Identity] have been saved to :"
     Write-Host -ForegroundColor Yellow "$Filename"
     $GCDOResults | Export-Csv -Path $Filename -NoTypeInformation -Encoding UTF8
 
-    $MeetingTimeLine = $Results | Where-Object { $_.IsIgnorable -eq "False" } ;
+    $MeetingTimeLine = $Results | Where-Object { $_.IsIgnorable -eq "False" }
     Write-Host "`n`n`nThis is the meetingID $ThisMeetingID`nThis is Short MeetingID $ShortMeetingID"
     if ($MeetingTimeLine.count -eq 0) {
         Write-Host "All CalLogs are Ignorable, nothing to create a timeline with, displaying initial values."
     } else {
-        Write-Host "Found $($script:GCDO.count) Log entries, only the $($MeetingTimeLine.count) Non-Ignorable entries will be analyzed in the TimeLine.";
+        Write-Host "Found $($script:GCDO.count) Log entries, only the $($MeetingTimeLine.count) Non-Ignorable entries will be analyzed in the TimeLine."
     }
 }
 
@@ -801,53 +801,53 @@ function MeetingSummary {
         [switch] $ShortVersion
     )
 
-    $InitialSubject = "Subject: " + $Entry.NormalizedSubject;
-    $InitialOrganizer = "Organizer: " + $Entry.SentRepresentingDisplayName;
-    $InitialSender = "Sender: " + $Entry.SentRepresentingDisplayName;
-    $InitialToList = "To List: " + $Entry.DisplayAttendeesAll;
-    $InitialLocation = "Location: " + $Entry.Location;
+    $InitialSubject = "Subject: " + $Entry.NormalizedSubject
+    $InitialOrganizer = "Organizer: " + $Entry.SentRepresentingDisplayName
+    $InitialSender = "Sender: " + $Entry.SentRepresentingDisplayName
+    $InitialToList = "To List: " + $Entry.DisplayAttendeesAll
+    $InitialLocation = "Location: " + $Entry.Location
 
     if ($ShortVersion -or $LongVersion) {
-        $InitialStartTime = "StartTime: " + $Entry.StartTime.ToString();
-        $InitialEndTime = "EndTime: " + $Entry.EndTime.ToString();
+        $InitialStartTime = "StartTime: " + $Entry.StartTime.ToString()
+        $InitialEndTime = "EndTime: " + $Entry.EndTime.ToString()
     }
 
     if ($longVersion -and ($Entry.Timezone -ne "")) {
-        $InitialTimeZone = "Time Zone: " + $Entry.Timezone;
+        $InitialTimeZone = "Time Zone: " + $Entry.Timezone
     } else {
         $InitialTimeZone = "Time Zone: Not Populated"
     }
 
     if ($Entry.AppointmentRecurring) {
-        $InitialRecurring = "Recurring: Yes - Recurring";
+        $InitialRecurring = "Recurring: Yes - Recurring"
     } else {
-        $InitialRecurring = "Recurring: No - Single instance";
+        $InitialRecurring = "Recurring: No - Single instance"
     }
 
     if ($longVersion -and $Entry.AppointmentRecurring) {
-        $InitialRecurrencePattern = "RecurrencePattern: " + $Entry.RecurrencePattern;
-        $InitialSeriesStartTime = "Series StartTime: " + $Entry.StartTime.ToString() + "Z";
-        $InitialSeriesEndTime = "Series EndTime: " + $Entry.StartTime.ToString() + "Z";
+        $InitialRecurrencePattern = "RecurrencePattern: " + $Entry.RecurrencePattern
+        $InitialSeriesStartTime = "Series StartTime: " + $Entry.StartTime.ToString() + "Z"
+        $InitialSeriesEndTime = "Series EndTime: " + $Entry.StartTime.ToString() + "Z"
         if (!$Entry.ViewEndTime) {
-            $InitialEndDate = "Meeting Series does not have an End Date.";
+            $InitialEndDate = "Meeting Series does not have an End Date."
         }
     }
 
     if (!$Time) {
-        $Time = $CalLog.LastModifiedTime.ToString();
+        $Time = $CalLog.LastModifiedTime.ToString()
     }
 
     if (!$MeetingChanges) {
-        $MeetingChanges = @();
-        $MeetingChanges += $InitialSubject, $InitialOrganizer, $InitialSender, $InitialToList, $InitialLocation, $InitialStartTime, $InitialEndTime, $InitialTimeZone, $InitialRecurring, $InitialRecurrencePattern, $InitialSeriesStartTime , $InitialSeriesEndTime , $InitialEndDate;
+        $MeetingChanges = @()
+        $MeetingChanges += $InitialSubject, $InitialOrganizer, $InitialSender, $InitialToList, $InitialLocation, $InitialStartTime, $InitialEndTime, $InitialTimeZone, $InitialRecurring, $InitialRecurrencePattern, $InitialSeriesStartTime , $InitialSeriesEndTime , $InitialEndDate
     }
 
     if ($ShortVersion) {
-        $MeetingChanges = @();
-        $MeetingChanges += $InitialToList, $InitialLocation, $InitialStartTime, $InitialEndTime, $InitialRecurring;
+        $MeetingChanges = @()
+        $MeetingChanges += $InitialToList, $InitialLocation, $InitialStartTime, $InitialEndTime, $InitialRecurring
     }
 
-    Convert-Data -ArrayNames "Time", "MeetingChanges";
+    Convert-Data -ArrayNames "Time", "MeetingChanges"
 }
 
 # ===================================================================================================
@@ -884,14 +884,14 @@ function BuildTimeline {
     "  Subject: $($script:GCDO[0].NormalizedSubject)",
     "  Organizer: $($script:GCDO[0].SentRepresentingDisplayName)",
     "  MeetingID: $($script:GCDO[0].CleanGlobalObjectId)"
-    [Array]$Header = ("Subject: " + ($script:GCDO[0].NormalizedSubject) + " | MeetingID: "+ ($script:GCDO[0].CleanGlobalObjectId));
-    MeetingSummary -Time "Calendar Log Timeline for Meeting with" -MeetingChanges $Header;
-    MeetingSummary -Time "Initial Message Values" -Entry $script:GCDO[0] -LongVersion;
-    $MeetingTimeLine = $Results | Where-Object { $_.IsIgnorable -eq "False" };
+    [Array]$Header = ("Subject: " + ($script:GCDO[0].NormalizedSubject) + " | MeetingID: "+ ($script:GCDO[0].CleanGlobalObjectId))
+    MeetingSummary -Time "Calendar Log Timeline for Meeting with" -MeetingChanges $Header
+    MeetingSummary -Time "Initial Message Values" -Entry $script:GCDO[0] -LongVersion
+    $MeetingTimeLine = $Results | Where-Object { $_.IsIgnorable -eq "False" }
 
     foreach ($CalLog in $MeetingTimeLine) {
-        [bool] $MeetingSummaryNeeded = $False;
-        [bool] $AddChangedProperties = $False;
+        [bool] $MeetingSummaryNeeded = $False
+        [bool] $AddChangedProperties = $False
 
         <#
         .SYNOPSIS
@@ -906,23 +906,23 @@ function BuildTimeline {
             if ($CalLog.Client -ne "LocationProcessor" -or $CalLog.Client -notlike "EBA:*" -or $CalLog.Client -notlike "TBA:*") {
                 if ($PreviousCalLog -and $AddChangedProperties) {
                     if ($CalLog.MapiStartTime.ToString() -ne $PreviousCalLog.MapiStartTime.ToString()) {
-                        [Array]$TimeLineText = "The StartTime changed from [$($PreviousCalLog.MapiStartTime)] to: [$($CalLog.MapiStartTime)]";
-                        MeetingSummary -Time " " -MeetingChanges $TimeLineText;
+                        [Array]$TimeLineText = "The StartTime changed from [$($PreviousCalLog.MapiStartTime)] to: [$($CalLog.MapiStartTime)]"
+                        MeetingSummary -Time " " -MeetingChanges $TimeLineText
                     }
 
                     if ($CalLog.MapiEndTime.ToString() -ne $PreviousCalLog.MapiEndTime.ToString()) {
-                        [Array]$TimeLineText = "The EndTime changed from [$($PreviousCalLog.MapiEndTime)] to: [$($CalLog.MapiEndTime)]";
-                        MeetingSummary -Time " " -MeetingChanges $TimeLineText;
+                        [Array]$TimeLineText = "The EndTime changed from [$($PreviousCalLog.MapiEndTime)] to: [$($CalLog.MapiEndTime)]"
+                        MeetingSummary -Time " " -MeetingChanges $TimeLineText
                     }
 
                     if ($CalLog.SubjectProperty -ne $PreviousCalLog.SubjectProperty) {
                         [Array]$TimeLineText = "The EndTime changed from [$($PreviousCalLog.SubjectProperty)] to: [$($CalLog.SubjectProperty)]"
-                        MeetingSummary -Time " " -MeetingChanges $TimeLineText;
+                        MeetingSummary -Time " " -MeetingChanges $TimeLineText
                     }
 
                     if ($CalLog.NormalizedSubject -ne $PreviousCalLog.NormalizedSubject) {
                         [Array]$TimeLineText = "The EndTime changed from [$($PreviousCalLog.NormalizedSubject)] to: [$($CalLog.NormalizedSubject)]"
-                        MeetingSummary -Time " " -MeetingChanges $TimeLineText;
+                        MeetingSummary -Time " " -MeetingChanges $TimeLineText
                     }
                     if ($CalLog.Location -ne $PreviousCalLog.Location) {
                         [Array]$TimeLineText = "The Location changed from [$($PreviousCalLog.Location)] to: [$($CalLog.Location)]"
@@ -1037,40 +1037,40 @@ function BuildTimeline {
                     Create {
                         if ($CalLog.IsOrganizer) {
                             if ($CalLog.IsException) {
-                                $Output1 = "A new Exception $($CalLog.MeetingRequestType.Value) Meeting Request was created with $($CalLog.Client)";
+                                $Output1 = "A new Exception $($CalLog.MeetingRequestType.Value) Meeting Request was created with $($CalLog.Client)"
                             } else {
-                                $Output1 = "A new $($CalLog.MeetingRequestType.Value) Meeting Request was created with $($CalLog.Client)";
+                                $Output1 = "A new $($CalLog.MeetingRequestType.Value) Meeting Request was created with $($CalLog.Client)"
                             }
 
                             if ($CalLog.SentRepresentingEmailAddress -eq $CalLog.SenderEmailAddress) {
-                                $Output2 = " by the Organizer $($CalLog.ResponsibleUser).";
+                                $Output2 = " by the Organizer $($CalLog.ResponsibleUser)."
                             } else {
-                                $Output2 = " by the Delegate.";
+                                $Output2 = " by the Delegate."
                             }
 
-                            [array] $Output = $Output1+$Output2;
-                            [bool] $MeetingSummaryNeeded = $True;
+                            [array] $Output = $Output1+$Output2
+                            [bool] $MeetingSummaryNeeded = $True
                         } else {
                             if ($CalLog.DisplayAttendeesTo -ne $PreviousCalLog.DisplayAttendeesTo -or $CalLog.DisplayAttendeesCc -ne $PreviousCalLog.DisplayAttendeesCc) {
-                                [array] $Output = "The user Forwarded a Meeting Request with $($CalLog.Client).";
+                                [array] $Output = "The user Forwarded a Meeting Request with $($CalLog.Client)."
                             } else {
                                 if ($CalLog.Client -eq "Transport") {
-                                    [array] $Output = "Transport delivered a new Meeting Request from $($CalLog.SentRepresentingDisplayName).";
-                                    [bool] $MeetingSummaryNeeded = $True;
+                                    [array] $Output = "Transport delivered a new Meeting Request from $($CalLog.SentRepresentingDisplayName)."
+                                    [bool] $MeetingSummaryNeeded = $True
                                 } else {
-                                    [array] $Output = "$($CalLog.ResponsibleUserName) sent a $($CalLog.MeetingRequestType.Value) update for the Meeting Request and was processed by $($CalLog.Client).";
+                                    [array] $Output = "$($CalLog.ResponsibleUserName) sent a $($CalLog.MeetingRequestType.Value) update for the Meeting Request and was processed by $($CalLog.Client)."
                                 }
                             }
                         }
                     }
                     Update {
-                        [array] $Output = "$($CalLog.ResponsibleUserName) updated on the $($CalLog.MeetingRequestType) Meeting Request with $($CalLog.Client).";
+                        [array] $Output = "$($CalLog.ResponsibleUserName) updated on the $($CalLog.MeetingRequestType) Meeting Request with $($CalLog.Client)."
                     }
                     MoveToDeletedItems {
-                        [array] $Output = "$($CalLog.ResponsibleUserName) deleted the Meeting Request with $($CalLog.Client).";
+                        [array] $Output = "$($CalLog.ResponsibleUserName) deleted the Meeting Request with $($CalLog.Client)."
                     }
                     default {
-                        [array] $Output = "$($CalLog.TriggerAction) was performed on the $($CalLog.MeetingRequestType) Meeting Request by $($CalLog.ResponsibleUserName) with $($CalLog.Client).";
+                        [array] $Output = "$($CalLog.TriggerAction) was performed on the $($CalLog.MeetingRequestType) Meeting Request by $($CalLog.ResponsibleUserName) with $($CalLog.Client)."
                     }
                 }
             }
@@ -1082,7 +1082,7 @@ function BuildTimeline {
                 }
 
                 if ($CalLog.AppointmentCounterProposal -eq "True") {
-                    [array] $Output = "$($CalLog.SentRepresentingDisplayName) send a $($MeetingRespType) response message with a New Time Proposal: $($CalLog.MapiStartTime) to $($CalLog.MapiEndTime)";
+                    [array] $Output = "$($CalLog.SentRepresentingDisplayName) send a $($MeetingRespType) response message with a New Time Proposal: $($CalLog.MapiStartTime) to $($CalLog.MapiEndTime)"
                 } else {
                     switch -Wildcard ($CalLog.TriggerAction) {
                         "Update" { $Action = "updated" }
@@ -1101,34 +1101,34 @@ function BuildTimeline {
                     }
 
                     if ($CalLog.IsOrganizer) {
-                        [array] $Output = "$($CalLog.SentRepresentingDisplayName) $($Action) a $($MeetingRespType) Meeting Response message$($Extra).";
+                        [array] $Output = "$($CalLog.SentRepresentingDisplayName) $($Action) a $($MeetingRespType) Meeting Response message$($Extra)."
                     } else {
                         switch ($CalLog.Client) {
                             RBA {
-                                [array] $Output = "RBA $($Action) a $($MeetingRespType) Meeting Response message.";
+                                [array] $Output = "RBA $($Action) a $($MeetingRespType) Meeting Response message."
                             }
                             Transport {
-                                [array] $Output = "$($CalLog.SentRepresentingDisplayName) $($Action) $($MeetingRespType) Meeting Response message.";
+                                [array] $Output = "$($CalLog.SentRepresentingDisplayName) $($Action) $($MeetingRespType) Meeting Response message."
                             }
                             default {
-                                [array] $Output = "Meeting Response $($MeetingRespType) from [$($CalLog.SentRepresentingDisplayName)] was $($Action) by $($CalLog.ResponsibleUserName) with $($CalLog.Client).";
+                                [array] $Output = "Meeting Response $($MeetingRespType) from [$($CalLog.SentRepresentingDisplayName)] was $($Action) by $($CalLog.ResponsibleUserName) with $($CalLog.Client)."
                             }
                         }
                     }
                 }
             }
             ForwardNotification {
-                [array] $Output = "The meeting was FORWARDED by $($CalLog.SentRepresentingDisplayName).";
+                [array] $Output = "The meeting was FORWARDED by $($CalLog.SentRepresentingDisplayName)."
             }
             ExceptionMsgClass {
                 if ($CalLog.TriggerAction -eq "Create") {
-                    $Action = "New";
+                    $Action = "New"
                 } else {
-                    $Action = "$($CalLog.TriggerAction)";
+                    $Action = "$($CalLog.TriggerAction)"
                 }
 
                 if ($CalLog.ResponsibleUser -ne "Calendar Assistant") {
-                    [array] $Output = "$($Action) Exception to the meeting series added by $($CalLog.ResponsibleUser) with $($CalLog.Client).";
+                    [array] $Output = "$($Action) Exception to the meeting series added by $($CalLog.ResponsibleUser) with $($CalLog.Client)."
                 }
             }
             IpmAppointment {
@@ -1136,20 +1136,20 @@ function BuildTimeline {
                     Create {
                         if ($CalLog.IsOrganizer) {
                             if ($CalLog.Client -eq "Transport") {
-                                [array] $Output = "Transport created a new meeting.";
+                                [array] $Output = "Transport created a new meeting."
                             } else {
-                                [array] $Output = "$($CalLog.SentRepresentingDisplayName) created a new Meeting with $($CalLog.Client).";
+                                [array] $Output = "$($CalLog.SentRepresentingDisplayName) created a new Meeting with $($CalLog.Client)."
                             }
                         } else {
                             switch ($CalLog.Client) {
                                 Transport {
-                                    [array] $Output = "$($CalLog.Client) added a new Tentative Meeting from $($CalLog.SentRepresentingDisplayName) to the Calendar.";
+                                    [array] $Output = "$($CalLog.Client) added a new Tentative Meeting from $($CalLog.SentRepresentingDisplayName) to the Calendar."
                                 }
                                 RBA {
-                                    [array] $Output = "$($CalLog.Client) added a new Tentative Meeting from $($CalLog.SentRepresentingDisplayName) to the Calendar.";
+                                    [array] $Output = "$($CalLog.Client) added a new Tentative Meeting from $($CalLog.SentRepresentingDisplayName) to the Calendar."
                                 }
                                 default {
-                                    [array] $Output = "Meeting was created by [$($CalLog.ResponsibleUser)] with $($CalLog.Client).";
+                                    [array] $Output = "Meeting was created by [$($CalLog.ResponsibleUser)] with $($CalLog.Client)."
                                 }
                             }
                         }
@@ -1157,87 +1157,87 @@ function BuildTimeline {
                     Update {
                         switch ($CalLog.Client) {
                             Transport {
-                                [array] $Output = "Transport $($CalLog.TriggerAction)d the meeting from $($CalLog.SentRepresentingDisplayName).";
+                                [array] $Output = "Transport $($CalLog.TriggerAction)d the meeting from $($CalLog.SentRepresentingDisplayName)."
                             }
                             LocationProcessor {
-                                [array] $Output = "";
+                                [array] $Output = ""
                             }
                             RBA {
-                                [array] $Output = "RBA $($CalLog.TriggerAction) the Meeting.";
+                                [array] $Output = "RBA $($CalLog.TriggerAction) the Meeting."
                             }
                             default {
                                 if ($CalLog.ResponsibleUser -eq "Calendar Assistant") {
-                                    [array] $Output = "The Exchange System $($CalLog.TriggerAction)d the meeting via the Calendar Assistant.";
+                                    [array] $Output = "The Exchange System $($CalLog.TriggerAction)d the meeting via the Calendar Assistant."
                                 } else {
-                                    [array] $Output = "$($CalLog.TriggerAction) to the Meeting by [$($CalLog.ResponsibleUserName)] with $($CalLog.Client).";
-                                    $AddChangedProperties = $True;
+                                    [array] $Output = "$($CalLog.TriggerAction) to the Meeting by [$($CalLog.ResponsibleUserName)] with $($CalLog.Client)."
+                                    $AddChangedProperties = $True
                                 }
                             }
                         }
 
                         if ($CalLog.FreeBusyStatus -eq 2 -and $PreviousCalLog.FreeBusyStatus -ne 2) {
-                            [array] $Output = "$($CalLog.ResponsibleUserName) Accepted the meeting with $($CalLog.Client).";
-                            $AddChangedProperties = $False;
+                            [array] $Output = "$($CalLog.ResponsibleUserName) Accepted the meeting with $($CalLog.Client)."
+                            $AddChangedProperties = $False
                         } elseif ($CalLog.FreeBusyStatus -ne 2 -and $PreviousCalLog.FreeBusyStatus -eq 2) {
-                            [array] $Output = "$($CalLog.ResponsibleUserName) Declined the Meeting with $($CalLog.Client).";
-                            $AddChangedProperties = $False;
+                            [array] $Output = "$($CalLog.ResponsibleUserName) Declined the Meeting with $($CalLog.Client)."
+                            $AddChangedProperties = $False
                         }
                     }
                     SoftDelete {
                         switch ($CalLog.Client) {
                             Transport {
-                                [array] $Output = "Transport $($CalLog.TriggerAction)d the Meeting from $($CalLog.SentRepresentingDisplayName).";
+                                [array] $Output = "Transport $($CalLog.TriggerAction)d the Meeting from $($CalLog.SentRepresentingDisplayName)."
                             }
                             LocationProcessor {
-                                [array] $Output = "";
+                                [array] $Output = ""
                             }
                             RBA {
-                                [array] $Output = "RBA $($CalLog.TriggerAction) the Meeting.";
+                                [array] $Output = "RBA $($CalLog.TriggerAction) the Meeting."
                             }
                             default {
                                 if ($CalLog.ResponsibleUser -eq "Calendar Assistant") {
-                                    [array] $Output = "The Exchange System $($CalLog.TriggerAction)s the meeting via the Calendar Assistant.";
+                                    [array] $Output = "The Exchange System $($CalLog.TriggerAction)s the meeting via the Calendar Assistant."
                                 } else {
-                                    [array] $Output = "The Meeting was $($CalLog.TriggerAction) by [$($CalLog.ResponsibleUserName)] with $($CalLog.Client).";
-                                    $AddChangedProperties = $True;
+                                    [array] $Output = "The Meeting was $($CalLog.TriggerAction) by [$($CalLog.ResponsibleUserName)] with $($CalLog.Client)."
+                                    $AddChangedProperties = $True
                                 }
                             }
                         }
 
                         if ($CalLog.FreeBusyStatus -eq 2 -and $PreviousCalLog.FreeBusyStatus -ne 2) {
-                            [array] $Output = "The $($CalLog.ResponsibleUser) accepted the Meeting with $($CalLog.Client).";
-                            $AddChangedProperties = $False;
+                            [array] $Output = "The $($CalLog.ResponsibleUser) accepted the Meeting with $($CalLog.Client)."
+                            $AddChangedProperties = $False
                         } elseif ($CalLog.FreeBusyStatus -ne 2 -and $PreviousCalLog.FreeBusyStatus -eq 2) {
-                            [array] $Output = "The $($CalLog.ResponsibleUser) declined the Meeting with $($CalLog.Client).";
-                            $AddChangedProperties = $False;
+                            [array] $Output = "The $($CalLog.ResponsibleUser) declined the Meeting with $($CalLog.Client)."
+                            $AddChangedProperties = $False
                         }
                     }
                     MoveToDeletedItems {
-                        [array] $Output = "[$($CalLog.ResponsibleUser)] moved the Meeting to the Deleted Items with $($CalLog.Client).";
+                        [array] $Output = "[$($CalLog.ResponsibleUser)] moved the Meeting to the Deleted Items with $($CalLog.Client)."
                     }
                     default {
-                        [array] $Output = "[$($CalLog.ResponsibleUser)] $($CalLog.TriggerAction) the Meeting with $($CalLog.Client).";
-                        [bool] $MeetingSummaryNeeded = $False;
+                        [array] $Output = "[$($CalLog.ResponsibleUser)] $($CalLog.TriggerAction) the Meeting with $($CalLog.Client)."
+                        [bool] $MeetingSummaryNeeded = $False
                     }
                 }
             }
             Cancellation {
                 switch ($CalLog.Client) {
                     Transport {
-                        [array] $Output = "Transport $($CalLog.TriggerAction)d the Meeting Cancellation from $($CalLog.SentRepresentingDisplayName).";
+                        [array] $Output = "Transport $($CalLog.TriggerAction)d the Meeting Cancellation from $($CalLog.SentRepresentingDisplayName)."
                     }
                     default {
-                        [array] $Output = "$($CalLog.ResponsibleUser) $($CalLog.TriggerAction) the Cancellation with $($CalLog.Client).";
+                        [array] $Output = "$($CalLog.ResponsibleUser) $($CalLog.TriggerAction) the Cancellation with $($CalLog.Client)."
                     }
                 }
             }
             default {
                 if ($CalLog.TriggerAction -eq "Create") {
-                    $Action = "New";
+                    $Action = "New"
                 } else {
-                    $Action = "$($CalLog.TriggerAction)";
+                    $Action = "$($CalLog.TriggerAction)"
                 }
-                [array] $Output = "$($Action) was performed on the $($CalLog.ItemClass) by $($CalLog.ResponsibleUser) with $($CalLog.Client).";
+                [array] $Output = "$($Action) was performed on the $($CalLog.ItemClass) by $($CalLog.ResponsibleUser) with $($CalLog.Client)."
             }
         }
 
@@ -1246,23 +1246,23 @@ function BuildTimeline {
 
         if ($Output) {
             if ($MeetingSummaryNeeded) {
-                MeetingSummary -Time $Time -MeetingChanges $Output;
-                MeetingSummary -Time " " -ShortVersion -Entry $CalLog;
+                MeetingSummary -Time $Time -MeetingChanges $Output
+                MeetingSummary -Time " " -ShortVersion -Entry $CalLog
             } else {
-                MeetingSummary -Time $Time -MeetingChanges $Output;
+                MeetingSummary -Time $Time -MeetingChanges $Output
                 if ($AddChangedProperties) {
-                    ChangedProperties;
+                    ChangedProperties
                 }
             }
         }
 
         # Setup Previous log (if current logs is an IPM.Appointment)
         if ($CalendarItemTypes.($CalLog.ItemClass) -eq "IpmAppointment" -or $CalendarItemTypes.($CalLog.ItemClass) -eq "ExceptionMsgClass") {
-            $PreviousCalLog = $CalLog;
+            $PreviousCalLog = $CalLog
         }
     }
 
-    $Results = @();
+    $Results = @()
 }
 
 <#
@@ -1316,7 +1316,7 @@ function CheckIdentities {
     } else {
         Write-Error "Get-Mailbox cmdlet not found.  Please validate that you are running this script from an Exchange Management Shell and try again."
         Write-Host "Look at Import-Module ExchangeOnlineManagement and Connect-ExchangeOnline."
-        exit;
+        exit
     }
 
     # See if it is a Customer Tenant running the cmdlet. (They will not have access to Organization parameter)
@@ -1324,7 +1324,7 @@ function CheckIdentities {
     Write-Verbose "MSSupport: $script:MSSupport"
 
     Write-Host "Checking for at least one valid mailbox..."
-    $IdentityList = @();
+    $IdentityList = @()
 
     Write-Host "Preparing to check $($Identity.count) Mailbox(es)..."
 
@@ -1337,13 +1337,13 @@ function CheckIdentities {
         }
         if (CheckForNoPIIAccess $Account.DisplayName) {
             Write-Host -ForegroundColor DarkRed "No PII access for Mailbox [$Id]. Falling back to SMTP Address."
-            $IdentityList += $ID;
+            $IdentityList += $ID
             if ($null -eq $script:MB) {
                 $script:MB = $Account
             }
         } else {
             Write-Host "Mailbox [$Id] found as : $($Account.DisplayName)"
-            $IdentityList += $Account.PrimarySmtpAddress.ToString();
+            $IdentityList += $Account.PrimarySmtpAddress.ToString()
             if ($null -eq $script:MB) {
                 $script:MB = $Account
             }
@@ -1354,10 +1354,10 @@ function CheckIdentities {
 
     if ($IdentityList.count -eq 0) {
         Write-DashLineBoxColor "`n No valid mailboxes found.  Please validate the mailbox name and try again. `n" Red
-        exit;
+        exit
     }
 
-    return $IdentityList;
+    return $IdentityList
 }
 
 <#
@@ -1375,8 +1375,8 @@ function GetCalLogsWithSubject {
     )
     Write-Host "Getting CalLogs based for [$Identity] with subject [$Subject]]"
 
-    $InitialCDOs = GetCalendarDiagnosticObjects -Identity $Identity -Subject $Subject;
-    $GlobalObjectIds = @();
+    $InitialCDOs = GetCalendarDiagnosticObjects -Identity $Identity -Subject $Subject
+    $GlobalObjectIds = @()
 
     # Find all the unique Global Object IDs
     foreach ($ObjectId in $InitialCDOs.CleanGlobalObjectId) {
@@ -1384,31 +1384,31 @@ function GetCalLogsWithSubject {
             $ObjectId -ne "NotFound" -and
             $ObjectId -ne "InvalidSchemaPropertyName" -and
             $ObjectId.Length -ge 90) {
-            $GlobalObjectIds += $ObjectId;
+            $GlobalObjectIds += $ObjectId
         }
     }
 
-    $GlobalObjectIds = $GlobalObjectIds | Select-Object -Unique;
+    $GlobalObjectIds = $GlobalObjectIds | Select-Object -Unique
     Write-Host "Found $($GlobalObjectIds.count) unique GlobalObjectIds."
     Write-Host "Getting the set of CalLogs for each GlobalObjectID."
 
     if ($GlobalObjectIds.count -eq 1) {
         $script:GCDO = $InitialCDOs; # use the CalLogs that we already have, since there is only one.
-        BuildCSV -Identity $Identity;
-        BuildTimeline -Identity $Identity; ;
+        BuildCSV -Identity $Identity
+        BuildTimeline -Identity $Identity
     }$ID
     # Get the CalLogs for each MeetingID found.
     if ($GlobalObjectIds.count -gt 1) {
         Write-Host "Found multiple GlobalObjectIds: $($GlobalObjectIds.Count)."
         foreach ($MID in $GlobalObjectIds) {
             Write-DashLineBoxColor "Processing MeetingID: [$MID]"
-            $script:GCDO = GetCalendarDiagnosticObjects -Identity $Identity -MeetingID $MID;
+            $script:GCDO = GetCalendarDiagnosticObjects -Identity $Identity -MeetingID $MID
             Write-Verbose "Found $($GCDO.count) CalLogs with MeetingID[$MID] ."
-            BuildCSV -Identity $Identity;
-            BuildTimeline -Identity $Identity; ;
+            BuildCSV -Identity $Identity
+            BuildTimeline -Identity $Identity
         }
     } else {
-        Write-Warning "No CalLogs were found.";
+        Write-Warning "No CalLogs were found."
     }
 }
 
@@ -1421,7 +1421,7 @@ $ValidatedIdentities = CheckIdentities -Identity $Identity
 if (-not ([string]::IsNullOrEmpty($Subject)) ) {
     if ($ValidatedIdentities.count -gt 1) {
         Write-Warning "Multiple mailboxes were found, but only one is supported for Subject searches.  Please specify a single mailbox."
-        exit;
+        exit
     }
     GetCalLogsWithSubject -Identity $ValidatedIdentities -Subject $Subject
 } elseif (-not ([string]::IsNullOrEmpty($MeetingID))) {
@@ -1431,18 +1431,18 @@ if (-not ([string]::IsNullOrEmpty($Subject)) ) {
         #    $script:InitialCDOs = @(); # clear the Initial CDOs.
         Write-DashLineBoxColor "Looking for CalLogs from [$ID] with passed in MeetingID."
         Write-Verbose "Running: Get-CalendarDiagnosticObjects -Identity [$ID] -MeetingID [$MeetingID] -CustomPropertyNames $CustomPropertyNameList -WarningAction Ignore -MaxResults $LogLimit -ResultSize $LogLimit -ShouldBindToItem $true;"
-        $script:GCDO = GetCalendarDiagnosticObjects -Identity $ID -MeetingID $MeetingID;
+        $script:GCDO = GetCalendarDiagnosticObjects -Identity $ID -MeetingID $MeetingID
 
         if ($script:GCDO.count -gt 0) {
             Write-Host "Found $($script:GCDO.count) CalLogs with MeetingID [$MeetingID]."
-            BuildCSV -Identity $ID;
-            BuildTimeline -Identity $ID;
+            BuildCSV -Identity $ID
+            BuildTimeline -Identity $ID
         } else {
             Write-Warning "No CalLogs were found for [$ID] with MeetingID [$MeetingID]."
         }
     }
 } else {
-    Write-Warning "A valid MeetingID was not found, nor Subject. Please confirm the MeetingID or Subject and try again.";
+    Write-Warning "A valid MeetingID was not found, nor Subject. Please confirm the MeetingID or Subject and try again."
 }
 
 Write-DashLineBoxColor "Hope this script was helpful in getting and understanding the Calendar Logs.",

--- a/Calendar/Get-RBASummary.ps1
+++ b/Calendar/Get-RBASummary.ps1
@@ -38,15 +38,15 @@ function ValidateMailbox {
 
     # check we get a response
     if ($null -eq $script:Mailbox) {
-        Write-Host -ForegroundColor Red "Get-Mailbox returned null. Make sure you Import-Module ExchangeOnlineManagement and  Connect-ExchangeOnline. Exiting script.";
-        exit;
+        Write-Host -ForegroundColor Red "Get-Mailbox returned null. Make sure you Import-Module ExchangeOnlineManagement and  Connect-ExchangeOnline. Exiting script."
+        exit
     } else {
         if ($script:Mailbox.RecipientTypeDetails -ne "RoomMailbox" -and $script:Mailbox.RecipientTypeDetails -ne "EquipmentMailbox") {
-            Write-Host -ForegroundColor Red "The mailbox is not a Room Mailbox / Equipment Mailbox. RBA will only work with these. Exiting script.";
-            exit;
+            Write-Host -ForegroundColor Red "The mailbox is not a Room Mailbox / Equipment Mailbox. RBA will only work with these. Exiting script."
+            exit
         }
         if ($script:Mailbox.ResourceType -eq "Workspace") {
-            $script:Workspace = $true;
+            $script:Workspace = $true
         }
         Write-Host -ForegroundColor Green "The mailbox is valid for RBA will work with."
     }
@@ -59,11 +59,11 @@ function ValidateMailbox {
         Write-Error "Error: Get-Place returned Null for $Identity."
         Write-Host -ForegroundColor Red "Make sure you are running from the correct forest.  Get-Place does not cross forest boundaries."
         Write-Error "Exiting Script."
-        exit;
+        exit
     }
 
-    Write-Host -ForegroundColor Yellow "For more information see https://learn.microsoft.com/en-us/powershell/module/exchange/get-mailbox?view=exchange-ps";
-    Write-Host;
+    Write-Host -ForegroundColor Yellow "For more information see https://learn.microsoft.com/en-us/powershell/module/exchange/get-mailbox?view=exchange-ps"
+    Write-Host
 }
 
 # Validate that there are not delegate rules that will block RBA functionality
@@ -77,7 +77,7 @@ function ValidateInboxRules {
         Write-Host -NoNewline "Rule to look into: "
         Write-Host -ForegroundColor Red "$($rules.Name -like "Delegate Rule*")"
         Write-Host -ForegroundColor Red "Exiting script."
-        exit;
+        exit
     } elseif ($rules.Name -like "REDACTED-*") {
         Write-Host -ForegroundColor Yellow "Warning: No PII Access to MB so cannot check for Delegate Rules."
         Write-Host -ForegroundColor Red " --- Inbox Rules needs to be checked manually for any Delegate Rules. --"
@@ -104,15 +104,15 @@ function GetCalendarProcessing {
         Write-Host -ForegroundColor Red "Get-CalendarProcessing returned null.
                 Make sure you Import-Module ExchangeOnlineManagement
                 and  Connect-ExchangeOnline
-                Exiting script.";
-        exit;
+                Exiting script."
+        exit
     }
 
     $RbaSettings | Format-List
 
     Write-Host -ForegroundColor Yellow "For more information on Set-CalendarProcessing see
-                https://learn.microsoft.com/en-us/powershell/module/exchange/set-calendarprocessing?view=exchange-ps";
-    Write-Host;
+                https://learn.microsoft.com/en-us/powershell/module/exchange/set-calendarprocessing?view=exchange-ps"
+    Write-Host
 }
 
 function EvaluateCalProcessing {
@@ -123,7 +123,7 @@ function EvaluateCalProcessing {
         Write-Host -ForegroundColor Red "Error: AutomateProcessing is set to $($RbaSettings.AutomateProcessing)."
         Write-Host -ForegroundColor Yellow "Use 'Set-CalendarProcessing -Identity $Identity -AutomateProcessing AutoAccept' to set AutomateProcessing to AutoAccept."
         Write-Host -ForegroundColor Red "Exiting script."
-        exit;
+        exit
     } else {
         Write-Host -ForegroundColor Green "AutomateProcessing is set to AutoAccept. RBA will analyze the meeting request."
     }
@@ -146,7 +146,7 @@ function ProcessingLogic {
 function RBACriteria {
     Write-DashLineBoxColor @("Policy Configuration") -Color Cyan -DashChar =
 
-    Write-Host " The following criteria are used to determine if a meeting request is in-policy or out-of-policy. ";
+    Write-Host " The following criteria are used to determine if a meeting request is in-policy or out-of-policy. "
     Write-Host -ForegroundColor Cyan @"
     `t Setting                          Value
     `t ------------------------------  -----------------------------
@@ -164,12 +164,12 @@ function RBACriteria {
     `t MaximumConflictPercentage:      $($RbaSettings.MaximumConflictPercentage)
     `t EnforceSchedulingHorizon:       $($RbaSettings.EnforceSchedulingHorizon)
     `t SchedulingHorizonInDays:        $($RbaSettings.SchedulingHorizonInDays)
-"@;
+"@
     Write-Host -NoNewline "`r`nIf all the above criteria are met, the request is "
     Write-Host -ForegroundColor Yellow -NoNewline "In-Policy."
     Write-Host -NoNewline "`r`nIf any of the above criteria are not met, the request is "
-    Write-Host -ForegroundColor DarkYellow -NoNewline  "Out-of-Policy.";
-    Write-Host;
+    Write-Host -ForegroundColor DarkYellow -NoNewline  "Out-of-Policy."
+    Write-Host
 
     # RBA processing settings Verbose Output
     $RBACriteriaExtra = ""
@@ -227,7 +227,7 @@ function RBACriteria {
         $RBACriteriaExtra += "RBA will reject all External meeting requests.`r`n"
     }
 
-    $RBACriteriaExtra += "Meetings will only be accepted if within $($RbaSettings.BookingWindowInDays) days.`r`n";
+    $RBACriteriaExtra += "Meetings will only be accepted if within $($RbaSettings.BookingWindowInDays) days.`r`n"
 
     Write-Verbose $RBACriteriaExtra
 }
@@ -252,7 +252,7 @@ function RBAProcessingValidation {
         Write-Host "`t AllBookInPolicy:              "$RbaSettings.AllBookInPolicy
         Write-Host "`t RequestInPolicy:               {$($RbaSettings.RequestInPolicy)}"
         Write-Host "`t AllRequestInPolicy:           "$RbaSettings.AllRequestInPolicy
-        Write-Host -ForegroundColor Red "Exiting script.";
+        Write-Host -ForegroundColor Red "Exiting script."
         exit
     }
 }
@@ -471,13 +471,13 @@ function VerbosePostProcessing {
 
 #Add information about RBA logs.
 function RBAPostScript {
-    Write-Host;
+    Write-Host
     Write-Host "If more information is needed about this resource mailbox, please look at the RBA logs to
-        see how the system proceed the meeting request.";
-    Write-Host -ForegroundColor Yellow "`tExport-MailboxDiagnosticLogs $Identity -ComponentName RBA";
-    Write-Host;
+        see how the system proceed the meeting request."
+    Write-Host -ForegroundColor Yellow "`tExport-MailboxDiagnosticLogs $Identity -ComponentName RBA"
+    Write-Host
     Write-Host "`n`rIf you found an error with this script or a misconfigured RBA case that this should cover,
-         send mail to Shanefe@microsoft.com";
+         send mail to Shanefe@microsoft.com"
 }
 
 function RBALogSummary {
@@ -492,7 +492,7 @@ function RBALogSummary {
 
         if ($starts.count -gt 1) {
             $LastDate = ($Starts[0] -Split ",")[0].Trim()
-            $FirstDate = ($starts[$($Starts.count) -1 ] -Split ",")[0].Trim();
+            $FirstDate = ($starts[$($Starts.count) -1 ] -Split ",")[0].Trim()
             Write-Host "The RBA Log for $Identity shows the following:"
             Write-Host "`t $($starts.count) Processed events times between $FirstDate and $LastDate"
         }
@@ -572,7 +572,7 @@ function ValidateRoomListSettings {
     Write-Host -ForegroundColor White "`tTags can be used to list features of this room (i.e. Projector, etc.) so that users can narrow down their search for conference rooms."
 
     Write-Host -ForegroundColor White "`tLearn more at " -NoNewline
-    Write-Host -ForegroundColor Yellow "https://learn.microsoft.com/en-us/outlook/troubleshoot/calendaring/configure-room-finder-rooms-workspaces`n";
+    Write-Host -ForegroundColor Yellow "https://learn.microsoft.com/en-us/outlook/troubleshoot/calendaring/configure-room-finder-rooms-workspaces`n"
 
     if ([string]::IsNullOrEmpty($Place.Localities)) {
         ## validate Localities
@@ -580,7 +580,7 @@ function ValidateRoomListSettings {
         Write-Host -ForegroundColor Yellow "`tWarning: Adding this resource to a Room Lists can take 24 hours to be fully propagated."
     }
 
-    $requiredProperties = @("City", "Floor", "Capacity");
+    $requiredProperties = @("City", "Floor", "Capacity")
 
     foreach ($prop in $requiredProperties) {
         if ([string]::IsNullOrEmpty($script:Place.$prop)) {
@@ -598,8 +598,8 @@ function ValidateRoomListSettings {
         Write-Host -ForegroundColor White "to set the required properties on the resource."
     }
 
-    Write-Host -ForegroundColor White "`r`n`t New Room List commonly populated information:";
-    Write-Host -ForegroundColor White "`t ----------------------------------------- ";
+    Write-Host -ForegroundColor White "`r`n`t New Room List commonly populated information:"
+    Write-Host -ForegroundColor White "`t ----------------------------------------- "
     Write-Host -ForegroundColor White @"
     `t Address Info
     `t Street:              $($script:Place.Street)
@@ -618,7 +618,7 @@ function ValidateRoomListSettings {
     `t To update any of the above information, run 'Set-Place $Identity -<Property> <Value>'.
     `t For more information on this command, see
 "@
-    Write-Host -ForegroundColor Yellow "`t https://learn.microsoft.com/en-us/powershell/module/exchange/set-place?view=exchange-ps";
+    Write-Host -ForegroundColor Yellow "`t https://learn.microsoft.com/en-us/powershell/module/exchange/set-place?view=exchange-ps"
     Write-Host
 }
 

--- a/Databases/Analyze-SpaceDump.ps1
+++ b/Databases/Analyze-SpaceDump.ps1
@@ -96,7 +96,7 @@ $piTablesPerMailbox = New-Object 'System.Collections.Generic.Dictionary[string, 
 while ($null -ne ($buffer = $fileReader.ReadLine())) {
     if (!($buffer.StartsWith("    ")) -and $buffer -ne "") {
         if ($buffer.StartsWith("-----")) {
-            break;
+            break
         }
 
         if ($isCSV) {

--- a/Diagnostics/AVTester/Start-SleepWithProgress.ps1
+++ b/Diagnostics/AVTester/Start-SleepWithProgress.ps1
@@ -42,7 +42,7 @@ function Start-SleepWithProgress {
 
     # Loop Number of seconds you want to sleep
     for ($i = 0; $i -le $SleepTime; $i++) {
-        $timeLeft = ($SleepTime - $i);
+        $timeLeft = ($SleepTime - $i)
 
         # Progress bar showing progress of the sleep
         Write-Progress -Activity $Message -CurrentOperation "$timeLeft More Seconds" -PercentComplete (($i / $SleepTime) * 100) -Status " "

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/IO/Save-ServerInfoData.ps1
@@ -14,7 +14,7 @@ function Save-ServerInfoData {
     msInfo32.exe /nfo (Add-ServerNameToFileName -FilePath ("{0}\msInfo.nfo" -f $copyTo))
     Write-Host "Waiting for msInfo32.exe process to end before moving on..." -ForegroundColor "Yellow"
     while ((Get-Process | Where-Object { $_.ProcessName -eq "msInfo32" }).ProcessName -eq "msInfo32") {
-        Start-Sleep 5;
+        Start-Sleep 5
     }
 
     $tlsRegistrySettingsName = "TLS_RegistrySettings"

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -298,11 +298,11 @@ function Invoke-AnalyzerHybridInformation {
 
                         switch ($connector.TlsAuthLevel) {
                             "EncryptionOnly" {
-                                $tlsAuthLevelM365RelayWriteType = "Yellow";
+                                $tlsAuthLevelM365RelayWriteType = "Yellow"
                                 break
                             }
                             "CertificateValidation" {
-                                $tlsAuthLevelM365RelayWriteType = "Green";
+                                $tlsAuthLevelM365RelayWriteType = "Green"
                                 break
                             }
                             "DomainValidation" {
@@ -310,7 +310,7 @@ function Invoke-AnalyzerHybridInformation {
                                     $tlsAuthLevelM365RelayWriteType = "Red"
                                 } else {
                                     $tlsAuthLevelM365RelayWriteType = "Green"
-                                };
+                                }
                                 break
                             }
                             default { $tlsAuthLevelM365RelayWriteType = "Red" }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectors.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectors.Tests.ps1
@@ -244,9 +244,9 @@ Describe "Testing Get-ExchangeConnectors.ps1" {
         It "Send Connector Configured As Expected For Relaying Via M365" {
             switch ($results) {
                 { ($_.SmartHosts -like "*.mail.protection.outlook.com") } {
-                    $smartHostsPointToExo = $true;
-                    $_.Name | Should -Be "My company to Office 365";
-                    $_.RequireTLS | Should -Be $true;
+                    $smartHostsPointToExo = $true
+                    $_.Name | Should -Be "My company to Office 365"
+                    $_.RequireTLS | Should -Be $true
                     # 1 = EncryptionOnly; 2 = CertificateValidation; 3 = DomainValidation
                     $_.TlsAuthLevel | Should -Be 2
                 }

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -205,7 +205,7 @@ begin {
             -not $ScriptUpdateOnly)) {
             Write-Warning "The script needs to be executed in elevated mode. Start the Exchange Management Shell as an Administrator."
             $Error.Clear()
-            Start-Sleep -Seconds 2;
+            Start-Sleep -Seconds 2
             exit
         }
 
@@ -232,7 +232,7 @@ begin {
                 exit
             }
             Get-HtmlServerReport -AnalyzedHtmlServerValues $importData.HtmlServerValues -HtmlOutFilePath $htmlOutFilePath
-            Start-Sleep 2;
+            Start-Sleep 2
             return
         }
 

--- a/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
+++ b/Diagnostics/ManagedAvailabilityTroubleshooter/ManagedAvailabilityTroubleshooter.ps1
@@ -21,8 +21,8 @@ function TestFileOrCmd {
     param( [String] $FileOrCmd )
 
     if ($FileOrCmd -like "File missing for this action*") {
-        Write-Host -ForegroundColor red $FileOrCmd;
-        exit;
+        Write-Host -ForegroundColor red $FileOrCmd
+        exit
     }
 }
 
@@ -30,7 +30,7 @@ function ParseProbeResult {
     [CmdletBinding()]
     param( [String] $FilterXpath , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
 
-    TestFileOrCmd $ProbeResultEventCmd;
+    TestFileOrCmd $ProbeResultEventCmd
     ParseProbeResult2 -ProbeResultEventCompleteCmd ($ProbeResultEventCmd + " -MaxEvents 200" ) `
         -FilterXpath $FilterXpath `
         -WaitString "Parsing only last 200 probe events for quicker response time" `
@@ -49,7 +49,7 @@ function ParseProbeResult2 {
     [CmdletBinding()]
     param( [String] $ProbeResultEventCompleteCmd , [String] $FilterXpath , [String] $WaitString , [String] $MonitorToInvestigate , [String] $ResponderToInvestigate)
 
-    TestFileOrCmd $ProbeResultEventCmd;
+    TestFileOrCmd $ProbeResultEventCmd
     $ProbeEventsCmd = '(' + $ProbeResultEventCompleteCmd + ' -FilterXPath ("' + $FilterXpath + '") -ErrorAction SilentlyContinue | % {[XML]$_.toXml()}).event.userData.eventXml'
     Write-Verbose $ProbeEventsCmd
     $titleProbeEvents = "Probe events"
@@ -77,7 +77,7 @@ function ParseProbeResult2 {
             if ($ProbeEvt.ResultType -eq 4) {
                 $Script:lastProbeError = $ProbeEvt
                 if ($Script:KnownIssueDetectionAlreadyDone -eq $false) { KnownIssueDetection $MonitorToInvestigate $ResponderToInvestigate }
-                break;
+                break
             }
         }
         if ($Script:KnownIssueDetectionAlreadyDone -eq $false) { KnownIssueDetection $MonitorToInvestigate $ResponderToInvestigate }
@@ -90,7 +90,7 @@ function InvestigateProbe {
     [CmdletBinding()]
     param([String]$ProbeToInvestigate , [String]$MonitorToInvestigate , [String]$ResponderToInvestigate , [String]$ResourceNameToInvestigate , [String]$ResponderTargetResource )
 
-    TestFileOrCmd $ProbeDefinitionEventCmd;
+    TestFileOrCmd $ProbeDefinitionEventCmd
     if (-Not ($ResponderTargetResource) -and ($ProbeToInvestigate.split("/").Count -gt 1)) {
         $ResponderTargetResource = $ProbeToInvestigate.split("/")[1]
     }
@@ -183,10 +183,10 @@ function InvestigateMonitor {
         $MaintenanceFailureMonitor = $MonitorToInvestigate.split(".")[1]
         Write-Host ("`nThis is triggered by MaintenanceFailureMonitor " + $MaintenanceFailureMonitor)
         InvestigateMaintenanceMonitor $MaintenanceFailureMonitor $ResponderToInvestigate
-        break;
+        break
     }
 
-    TestFileOrCmd $MonitorDefinitionCmd;
+    TestFileOrCmd $MonitorDefinitionCmd
     $MonitorDetailsCmd = '(' + $MonitorDefinitionCmd + '| % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.Name -like "' + $MonitorToInvestigate.split("/")[0] + '*" }'
     Write-Verbose $MonitorDetailsCmd
     Write-Progress "Checking Monitor definition"
@@ -253,7 +253,7 @@ function InvestigateMaintenanceMonitor {
     [CmdletBinding()]
     param([String]$MaintenanceFailureMonitor , [String] $ResponderToInvestigate)
 
-    TestFileOrCmd $MaintenanceDefinitionCmd;
+    TestFileOrCmd $MaintenanceDefinitionCmd
     $MaintenanceDefinitionCmd = '(' + $MaintenanceDefinitionCmd + '| % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.ServiceName -like "' + $MaintenanceFailureMonitor + '*" }'
     Write-Verbose $MaintenanceDefinitionCmd
     Write-Progress "Checking Maintenance definition"
@@ -271,7 +271,7 @@ function InvestigateMaintenanceMonitor {
 
         $MaintenanceDetails | Format-List
 
-        TestFileOrCmd $MaintenanceResultCmd;
+        TestFileOrCmd $MaintenanceResultCmd
         $MaintenanceResultCmd = '(' + $MaintenanceResultCmd + ' -FilterXPath "*/System/Level<=3" | % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.ResultName -like "' + $MaintenanceDetails.Name + '*" }'
         Write-Verbose $MaintenanceResultCmd
         Write-Progress "Checking Maintenance Result warnings and errors"
@@ -312,7 +312,7 @@ function OverrideIfNeeded {
             $continueToCheckIfResponderIsEnabled = $true
             while ( $continueToCheckIfResponderIsEnabled) {
                 if ("yes", "YES", "Y", "y" -contains (Read-Host ("Do you like to check if " + $ResponderToInvestigate + " Responder is now disabled ? Y/N"))) {
-                    TestFileOrCmd $ResponderDefinitionCmd;
+                    TestFileOrCmd $ResponderDefinitionCmd
                     $ResponderDetailsCmd = '(' + $ResponderDefinitionCmd + '| % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.Name -eq "' + $ResponderToInvestigate + '" }'
                     Write-Verbose $ResponderDetailsCmd
                     Write-Progress "Checking Responder definition"
@@ -364,7 +364,7 @@ function InvestigateResponder {
         Write-Host "`nIn case it is a reboot , there can be related 1074 events in system log showing that a user forced a rebooted around that time."
         Write-Host "looking for 1074 events ..."
 
-        TestFileOrCmd $SystemCmd;
+        TestFileOrCmd $SystemCmd
         $SystemCmd = $SystemCmd + ' -FilterXPath ("*[System[(EventID=''1074'')]]")'
         Write-Verbose $SystemCmd
         trap [System.Exception] { continue }
@@ -376,7 +376,7 @@ function InvestigateResponder {
             $1074events | Format-List
         }
     } else {
-        TestFileOrCmd $ResponderDefinitionCmd;
+        TestFileOrCmd $ResponderDefinitionCmd
         $ResponderDetailsCmd = '(' + $ResponderDefinitionCmd + '| % {[XML]$_.toXml()}).event.userData.eventXml| ? {$_.Name -eq "' + $ResponderToInvestigate + '" }'
         Write-Verbose $ResponderDetailsCmd
         Write-Progress "Checking Responder definition"
@@ -462,25 +462,25 @@ function CheckIfThisCanBeAKnownIssueUsingResponder {
     if (($ResponderToInvestigate -eq "ActiveDirectoryConnectivityConfigDCServerReboot") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 0) -and ($BuildExchangeVersion -lt 775)) {
         Write-Host -foreground yellow ("There is a known issue with restarts initiated by the  ActiveDirectoryConnectivityConfigDCServerReboot prior to CU3 which appears to be your case" )
         Write-Host -foreground yellow ("Check https://support.microsoft.com/en-us/kb/2883203" )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
 
     if ($ResponderToInvestigate -eq "ImapProxyTestCafeOffline") {
         Write-Host -foreground yellow ("ImapProxyTestCafeOffline can set ImapProxy component as inactive when 127.0.0.1 is blocked in IMAP bindings." )
         Write-Host -foreground yellow ("Check ImapSettings using Exchange Powershell command : Get-ImapSettings." )
         Write-Host ("Change the settings if needed with Set-ImapSettings - https://technet.microsoft.com/en-us/library/aa998252(v=exchg.150).aspx")
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
     if ($ResponderToInvestigate -eq "PopProxyTestCafeOffline") {
         Write-Host -foreground yellow ("PopProxyTestCafeOffline can set POPProxy component as inactive when 127.0.0.1 is blocked in POP bindings." )
         Write-Host -foreground yellow ("Check PopSettings using Exchange Powershell command : Get-POPSettings." )
         Write-Host -foreground yellow ("Change the settings if needed with Set-POPSettings - https://technet.microsoft.com/en-us/library/aa997154(v=exchg.150).aspx")
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
     if (($ResponderToInvestigate -eq "OutlookMapiHttpSelfTestRestart") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 0) -and ($BuildExchangeVersion -lt 1130)) {
         Write-Host -foreground yellow ("There is a known issue with OutlookMapiHttpSelfTestRestart prior to CU10 ( for reference OfficeMain: 1541090)" )
         Write-Host -foreground yellow ("You may plan to apply CU10 : https://support.microsoft.com/en-us/kb/3078678" )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
 }
 
@@ -491,21 +491,21 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
     $Script:checkForKnownIssue = $true
     if (($MonitorToInvestigate -like "*Mapi.Submit.Monitor") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 0)) {
         Write-Host -foreground yellow ("There is a known issue with Mapi.Submit.Monitor. This issue is fixed in CU11 ( OfficeMain: 1956332) " )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
     if (($MonitorToInvestigate -like "MaintenanceFailureMonitor.Network") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 0) -and ($BuildExchangeVersion -lt 1130)) {
         Write-Host -foreground yellow ("There is a known issue with MaintenanceFailureMonitor.Network/IntraDagPingProbe is fixed in CU10.( for reference OfficeMain: 2080370)" )
         Write-Host -foreground yellow ("You may plan to apply CU10 : https://support.microsoft.com/en-us/kb/3078678" )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
     if (($MonitorToInvestigate -like "MaintenanceFailureMonitor.ShadowService") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 1) ) {
         Write-Host -foreground yellow ("There is a known issue with MaintenanceFailureMonitor.ShadowService which fix will be included in Exchange 2016 CU5 and upper.( for reference OfficeMain: 142253)" )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
 
     if (($MonitorToInvestigate -like "EacBackEndLogonMonitor") -and ($MajorExchangeVersion -eq 15) -and ($MinorExchangeVersion -eq 1) ) {
         Write-Host -foreground yellow ("EacBackEndLogonMonitor has been seen unhealthy linked uninitialized culture on test mailboxes. You may run this command and check if this helps : get-mailbox -Monitoring -server $env:COMPUTERNAME | Set-MailboxRegionalConfiguration -Language En-US -TimeZone ""Pacific Standard Time""" )
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
 
     if ($MonitorToInvestigate -like "ActiveSyncCTPMonitor") {
@@ -518,7 +518,7 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
             Write-Host ("ActiveSyncCTPMonitor can fail with error 401 when BasicAuthEnabled setting in get-ActiveSyncVirtualDirectory has been changed and set to `$false.  - KB 3125818" )
             Write-Host("If this is your case , Enable Basic Authentication again if possible using the command :`nSet-ActiveSyncVirtualDirectory -basicAuthEnabled `$true." )
             Write-Host("Or disable this monitor using an override :`nAdd-GlobalMonitoringOverride -Identity ActiveSync\ActiveSyncCTPMonitor  -ItemType Monitor -PropertyName Enabled -PropertyValue 0" )
-            $Script:foundIssue = $true; return;
+            $Script:foundIssue = $true; return
         }
     }
 
@@ -534,7 +534,7 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
             Write-Host ("ActiveSyncDeepTestMonitor can fail with Index was out of range error when no active database are found on the server" )
             Write-Host("If this is your case , disable this monitor with this command : " )
             Write-Host("Add-GlobalMonitoringOverride -Identity ActiveSync\ActiveSyncDeepTestMonitor  -ItemType Monitor -PropertyName Enabled -PropertyValue 0" )
-            $Script:foundIssue = $true; return;
+            $Script:foundIssue = $true; return
         }
     }
 
@@ -551,7 +551,7 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
             Write-Host -foreground yellow "WMI request failing should be : SELECT LastBootUpTime FROM Win32_OperatingSystem WHERE Primary='true'"
             Write-Host -foreground yellow "This may be investigated at WMI level looking for this request"
             Write-Host  -foreground yellow "This WMI request is planned to be replaced in future version higher than 15.00.1187.000 likely CU13 by direct Windows native call without going through WMI layer.( for reference OfficeMain:2908185)"
-            $Script:foundIssue = $true; return;
+            $Script:foundIssue = $true; return
         }
     }
     if ($MonitorToInvestigate -like "ServiceHealthMSExchangeReplEndpointMonitor*") {
@@ -566,12 +566,12 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
             Write-Host -foreground yellow "ServiceHealthMSExchangeReplEndpointMonitor is failing due to missing DNS entry."
             Write-Host -foreground yellow "Make sure that the 'Register this connection's addresses in DNS' property is selected on the network adapter"
             Write-Host -foreground yellow "https://support.microsoft.com/en-us/kb/2969070"
-            $Script:foundIssue = $true; return;
+            $Script:foundIssue = $true; return
         }
     }
     if ($MonitorToInvestigate -like "DiscoveryErrorReportMonitor*") {
         Write-Host -foreground yellow "DiscoveryErrorReportMonitor is Disabled by default and should not be enabled"
-        $Script:foundIssue = $true; return;
+        $Script:foundIssue = $true; return
     }
     if ($Script:lastProbeError) {
         if ($Script:lastProbeError.Exception -like "*The underlying connection was closed*") {
@@ -580,7 +580,7 @@ function CheckIfThisCanBeAKnownIssueUsingMonitor {
             Write-Host -foreground yellow "This has been seen when blocking some TLS version using SecureProtocols registry key or through GPO.`n"
             Write-Host -foreground yellow "You can check if some TLS version are disabled under HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols (https://techcommunity.microsoft.com/t5/exchange-team-blog/exchange-server-tls-guidance-part-2-enabling-tls-1-2-and/ba-p/607761).`n"
             Write-Host -foreground yellow "You may also check if this is linked with antivirus or local firewall rules.`n"
-            $Script:foundIssue = $true; return;
+            $Script:foundIssue = $true; return
         }
     }
 }
@@ -591,7 +591,7 @@ function InvestigateUnhealthyMonitor {
 
     Write-Progress "Checking MonitorHealth"
     if ($pathForLogsSpecified) {
-        TestFileOrCmd $ServerHealthFile;
+        TestFileOrCmd $ServerHealthFile
         if ( -not (Test-Path $ServerHealthFile))
         { Write-Host -ForegroundColor red ("Path to ServerHealth file is invalid : $ServerHealthFile"); exit }
 
@@ -599,7 +599,7 @@ function InvestigateUnhealthyMonitor {
         $currentHealthEntry = New-Object -TypeName PSObject
         $firstLine = $true
         foreach ($line in (Get-Content $ServerHealthFile)) {
-            $propName = $line.split(" ")[0];
+            $propName = $line.split(" ")[0]
             if ( -not $propName) { continue; }
             if ($propName -eq "SerializationData" -or $propName -eq "Result" -or $propName -eq "PSComputerName" -or $propName -eq "PSShowComputerName") { continue; }
             $newMonitor = $false
@@ -622,11 +622,11 @@ function InvestigateUnhealthyMonitor {
             }
             if ($propName -eq "RunSpaceId")
             { continue }
-            $propValue = ($line.split(":")[1]).split(" ")[1];
+            $propValue = ($line.split(":")[1]).split(" ")[1]
             if ($propValue) { $currentHealthEntry | Add-Member -Name $propName -Value $propValue -MemberType NoteProperty }
         }
     } else {
-        TestFileOrCmd $ServerHealthCmd;
+        TestFileOrCmd $ServerHealthCmd
         $ServerHealthCmd = $ServerHealthCmd + '|?{$_.AlertValue -ne "Healthy"}'
         Write-Verbose $ServerHealthCmd
         $myHealthEntryList = Invoke-Expression $ServerHealthCmd
@@ -849,17 +849,17 @@ if ($pathForLogs) {
         $RecoveryActionResultsLog = ($Dir | Where-Object { $_.Name -like "*RecoveryActionResults.evtx" })
         if ( $RecoveryActionResultsLog.Count -ne 1) {
             if ($RecoveryActionResultsLog.Count -eq 0) {
-                $errorMsg = "Can't find RecoveryActionResults evtx file in " + $pathForLogs + " directory. Check the directory";
+                $errorMsg = "Can't find RecoveryActionResults evtx file in " + $pathForLogs + " directory. Check the directory"
                 if ($usingLocalPath) {
                     Write-Host -ForegroundColor yellow "Exchange Powershell not loaded.`nIn case you like to analyze directly on the Exchange server , run this script in Exchange Powershell"
                     Write-Host ("No path for logs specified , using local path " + $pathForLogs)
                 }
             } else {
-                $errorMsg = "Too much RecoveryActionResults evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much RecoveryActionResults evtx files in " + $pathForLogs + " directory."
                 foreach ($RecoveryActionResultsLogFile in $RecoveryActionResultsLog)
                 { $errorMsg += "`n" + $RecoveryActionResultsLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $RecoveryActionResultsCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $RecoveryActionResultsLog.FullName)
@@ -871,11 +871,11 @@ if ($pathForLogs) {
             if ($ResponderDefinitionLog.Count -eq 0)
             { $errorMsg = "Can't find ResponderDefinition evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ResponderDefinition evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ResponderDefinition evtx files in " + $pathForLogs + " directory."
                 foreach ($ResponderDefinitionLogFile in $ResponderDefinitionLog)
                 { $errorMsg += "`n" + $ResponderDefinitionLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $ResponderDefinitionCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $ResponderDefinitionLog.FullName)
@@ -887,11 +887,11 @@ if ($pathForLogs) {
             if ($MaintenanceDefinitionLog.Count -eq 0)
             { $errorMsg = "Can't find MaintenanceDefinition evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much MaintenanceDefinition evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much MaintenanceDefinition evtx files in " + $pathForLogs + " directory."
                 foreach ($MaintenanceDefinitionLogFile in $MaintenanceDefinitionLog)
                 { $errorMsg += "`n" + $MaintenanceDefinitionLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $MaintenanceDefinitionCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $MaintenanceDefinitionLog.FullName)
@@ -903,11 +903,11 @@ if ($pathForLogs) {
             if ($MaintenanceResultLog.Count -eq 0)
             { $errorMsg = "Can't find MaintenanceResult evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much MaintenanceResult evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much MaintenanceResult evtx files in " + $pathForLogs + " directory."
                 foreach ($MaintenanceResultLogFile in $MaintenanceResultLog)
                 { $errorMsg += "`n" + $MaintenanceResultLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $MaintenanceResultCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $MaintenanceResultLog.FullName)
@@ -919,11 +919,11 @@ if ($pathForLogs) {
             if ($MonitorDefinitionLog.Count -eq 0)
             { $errorMsg = "Can't find MonitorDefinition evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much MonitorDefinition evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much MonitorDefinition evtx files in " + $pathForLogs + " directory."
                 foreach ($MonitorDefinitionLogFile in $MonitorDefinitionLog)
                 { $errorMsg += "`n" + $MonitorDefinitionLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $MonitorDefinitionCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $MonitorDefinitionLog.FullName)
@@ -935,11 +935,11 @@ if ($pathForLogs) {
             if ($ProbeDefinitionLog.Count -eq 0)
             { $errorMsg = "Can't find ProbeDefinition evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ProbeDefinition evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ProbeDefinition evtx files in " + $pathForLogs + " directory."
                 foreach ($ProbeDefinitionLogFile in $ProbeDefinitionLog)
                 { $errorMsg += "`n" + $ProbeDefinitionLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $ProbeDefinitionEventCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $ProbeDefinitionLog.FullName)
@@ -951,11 +951,11 @@ if ($pathForLogs) {
             if ($ProbeResultLog.Count -eq 0)
             { $errorMsg = "Can't find ProbeResult evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ProbeResult evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ProbeResult evtx files in " + $pathForLogs + " directory."
                 foreach ($ProbeResultLogFile in $ProbeResultLog)
                 { $errorMsg += "`n" + $ProbeResultLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $ProbeResultEventCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $ProbeResultLog.FullName)
@@ -967,11 +967,11 @@ if ($pathForLogs) {
             if ($ManagedAvailabilityMonitoringLog.Count -eq 0)
             { $errorMsg = "Can't find ManagedAvailability Monitoring evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ManagedAvailability Monitoring evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ManagedAvailability Monitoring evtx files in " + $pathForLogs + " directory."
                 foreach ($ManagedAvailabilityMonitoringLogFile in $ManagedAvailabilityMonitoringLog)
                 { $errorMsg += "`n" + $ManagedAvailabilityMonitoringLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $ManagedAvailabilityMonitoringCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $ManagedAvailabilityMonitoringLog.FullName)
@@ -983,42 +983,42 @@ if ($pathForLogs) {
             if ($SystemLog.Count -eq 0)
             { $errorMsg = "Can't find System evtx file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much System evtx files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much System evtx files in " + $pathForLogs + " directory."
                 foreach ($SystemLogFile in $SystemLog)
                 { $errorMsg += "`n" + $SystemLogFile.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $SystemCmd = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $SystemLog.FullName)
             $SystemCmd = "Get-WinEvent -path ""$SystemLog"""
             $foundNoLogToAnalyze = $false
         }
-        $ServerHealthFile = Get-ChildItem ($pathForLogs + "*ServerHealth_FL.TXT");
+        $ServerHealthFile = Get-ChildItem ($pathForLogs + "*ServerHealth_FL.TXT")
         if ( $ServerHealthFile.Count -ne 1) {
             if ($ServerHealthFile.Count -eq 0)
             { $errorMsg = "Can't find ServerHealth_FL TXT file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ServerHealth_FL TXT files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ServerHealth_FL TXT files in " + $pathForLogs + " directory."
                 foreach ($ServerHealthFileInstance in $ServerHealthFile)
                 { $errorMsg += "`n" + $ServerHealthFileInstance.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $ServerHealthFile = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $ServerHealthFile)
             $foundNoLogToAnalyze = $false
         }
-        $GetExchangeServerFile = Get-ChildItem ($pathForLogs + "*_ExchangeServer_FL.TXT");
+        $GetExchangeServerFile = Get-ChildItem ($pathForLogs + "*_ExchangeServer_FL.TXT")
         if ( $GetExchangeServerFile.Count -ne 1) {
             if ($GetExchangeServerFile.Count -eq 0)
             { $errorMsg = "Can't find ExchangeServer_FL TXT file in " + $pathForLogs + " directory. Check the directory"; }
             else {
-                $errorMsg = "Too much ExchangeServer_FL TXT files in " + $pathForLogs + " directory.";
+                $errorMsg = "Too much ExchangeServer_FL TXT files in " + $pathForLogs + " directory."
                 foreach ($GetExchangeServerFileInstance in $GetExchangeServerFile)
                 { $errorMsg += "`n" + $GetExchangeServerFileInstance.FullName }
             }
-            Write-Host -ForegroundColor red ($errorMsg) ;
+            Write-Host -ForegroundColor red ($errorMsg)
             $GetExchangeServerFile = "File missing for this action.`n" + $errorMsg
         } else {
             Write-Host ("Found file " + $GetExchangeServerFile)
@@ -1026,11 +1026,11 @@ if ($pathForLogs) {
             { Write-Host -ForegroundColor red ("Path to ServerHealth file is invalid : $GetExchangeServerFile") }
             else {
                 foreach ($line in (Get-Content $GetExchangeServerFile)) {
-                    $propName = $line.split(" ")[0];
+                    $propName = $line.split(" ")[0]
                     if ( -not $propName) { continue; }
                     if ($propName -eq "AdminDisplayVersion") {
-                        $exchangeVersion = $line.split(":")[1];
-                        break;
+                        $exchangeVersion = $line.split(":")[1]
+                        break
                     }
                 }
             }
@@ -1146,7 +1146,7 @@ if ($InvestigationChoose -eq 0 -or $InvestigationChoose -eq 1) {
                 if ([string]::Compare($RecoveryActionToInvestigate.MachineName, $env:COMPUTERNAME, $true) -ne 0) {
                     Write-Host -ForegroundColor yellow ("`nThe RecoveryAction you select is regarding a different server : " + $RecoveryActionToInvestigate.MachineName + " .")
                     Write-Host -ForegroundColor yellow ("Run this script on this server directly to analyze this RecoveryAction further." )
-                    exit;
+                    exit
                 }
             }
             InvestigateResponder $RecoveryActionToInvestigate.RequestorName $RecoveryActionToInvestigate.ResourceName

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -9,28 +9,28 @@
     )
 
     Rules               = @{
-        PSPlaceOpenBrace           = @{
+        PSPlaceOpenBrace                   = @{
             Enable             = $true
             OnSameLine         = $true
             NewLineAfter       = $true
             IgnoreOneLineBlock = $true
         }
 
-        PSPlaceCloseBrace          = @{
+        PSPlaceCloseBrace                  = @{
             Enable             = $true
             NewLineAfter       = $false
             IgnoreOneLineBlock = $true
             NoEmptyLineBefore  = $true
         }
 
-        PSUseConsistentIndentation = @{
+        PSUseConsistentIndentation         = @{
             Enable              = $true
             Kind                = 'space'
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             IndentationSize     = 4
         }
 
-        PSUseConsistentWhitespace  = @{
+        PSUseConsistentWhitespace          = @{
             Enable                                  = $true
             CheckInnerBrace                         = $true
             CheckOpenBrace                          = $true
@@ -43,12 +43,16 @@
             IgnoreAssignmentOperatorInsideHashTable = $true
         }
 
-        PSAlignAssignmentStatement = @{
+        PSAlignAssignmentStatement         = @{
             Enable         = $true
             CheckHashtable = $true
         }
 
-        PSUseCorrectCasing         = @{
+        PSUseCorrectCasing                 = @{
+            Enable = $true
+        }
+
+        PSAvoidSemicolonsAsLineTerminators = @{
             Enable = $true
         }
     }

--- a/Performance/ExPerfAnalyzer.ps1
+++ b/Performance/ExPerfAnalyzer.ps1
@@ -761,14 +761,14 @@ function Convert-PerformanceCounterSampleObjectToServerPerformanceObjectWithQuic
                 $counterDataObj.DisplayOptions.FormatDivider = $xmlCounter.DisplayOptions.FormatDivider
                 $counterDataObj.DisplayOptions.FormatString = $xmlCounter.DisplayOptions.FormatString
                 #If we find it, we shouldn't need to loop through any longer and we can break out of the XML loop
-                break;
+                break
             }
         }
 
         #Now we need to quick Analyze the data sets while we are in here.
         # $measured = $counterObj.RawData | Measure-Object -Property CookedValue -Maximum -Minimum -Average   ## Bill Long removed this, checking with him to verify why this change was made.
-        $min = [Int64]::MaxValue;
-        $max = [Int64]::MinValue;
+        $min = [Int64]::MaxValue
+        $max = [Int64]::MinValue
         foreach ($sample in $counterDataObj.RawData) {
             if ($sample.CookedValue -lt $min) { $min = $sample.CookedValue }
             if ($sample.CookedValue -gt $max) { $max = $sample.CookedValue }
@@ -1020,7 +1020,7 @@ function Main {
                     break
                 }
             }
-            break;
+            break
         }
         "SingleFile" {
             if (-not (Test-Path $PerfmonFile)) {

--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -438,7 +438,7 @@ begin {
             [string]$Id
         )
         $ps = New-Object Microsoft.Exchange.WebServices.Data.PropertySet(New-Object Microsoft.Exchange.WebServices.Data.ExtendedPropertyDefinition([Microsoft.Exchange.WebServices.Data.DefaultExtendedPropertySet]::Common, 0x0000851F, [Microsoft.Exchange.WebServices.Data.MapiPropertyType]::String))
-        return [Microsoft.Exchange.WebServices.Data.Item]::Bind($ExchangeService, $Id, $ps);
+        return [Microsoft.Exchange.WebServices.Data.Item]::Bind($ExchangeService, $Id, $ps)
     }
 
     function GetAzureApplication {
@@ -884,7 +884,7 @@ begin {
         $pageSize = 100
         $findItemsResults = $null
         do {
-            $itemView = New-Object Microsoft.Exchange.WebServices.Data.ItemView($pageSize, $offset);
+            $itemView = New-Object Microsoft.Exchange.WebServices.Data.ItemView($pageSize, $offset)
             $findItemsResults = $searchFolders[0].FindItems($itemView)
             foreach ($item in $findItemsResults.Items) {
                 $item
@@ -1273,7 +1273,7 @@ begin {
                         }
                     }
 
-                    $mailboxProcessed ++;
+                    $mailboxProcessed ++
                 }
             }
         } else {
@@ -1347,7 +1347,7 @@ begin {
                     }
                 }
 
-                $mailboxProcessed ++;
+                $mailboxProcessed ++
             }
         }
 

--- a/Security/src/EOMT.ps1
+++ b/Security/src/EOMT.ps1
@@ -847,7 +847,7 @@ try {
         Set-LogActivity -Stage $Stage -RegMessage $RegMessage -Message $Message -Notice
     }
 
-    $DisableAutoUpdateIfNeeded = "If you are getting this error even with updated EOMT, re-run with -DoNotAutoUpdateEOMT parameter";
+    $DisableAutoUpdateIfNeeded = "If you are getting this error even with updated EOMT, re-run with -DoNotAutoUpdateEOMT parameter"
 
     $Stage = "AutoUpdateEOMT"
     if ($latestEOMTVersion -and ($BuildVersion -ne $latestEOMTVersion)) {

--- a/Security/src/EOMTv2.ps1
+++ b/Security/src/EOMTv2.ps1
@@ -572,7 +572,7 @@ try {
         Set-LogActivity -Stage $Stage -RegMessage $RegMessage -Message $Message -Notice
     }
 
-    $DisableAutoUpdateIfNeeded = "If you are getting this error even with updated EOMTv2, re-run with -DoNotAutoUpdateEOMTv2 parameter";
+    $DisableAutoUpdateIfNeeded = "If you are getting this error even with updated EOMTv2, re-run with -DoNotAutoUpdateEOMTv2 parameter"
 
     $Stage = "AutoUpdateEOMTv2"
     if ($latestEOMTv2Version -and ($BuildVersion -ne $latestEOMTv2Version)) {

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureMitigation.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ConfigureMitigation.ps1
@@ -224,7 +224,7 @@ function Invoke-ConfigureMitigation {
             $progressParams.PercentComplete = ($counter / $totalCount * 100)
             $progressParams.Status = "$baseStatus Applying rules"
             Write-Progress @progressParams
-            $counter ++;
+            $counter ++
 
             Write-Verbose ("Calling Invoke-ScriptBlockHandler on Server {0} with arguments SiteVDirLocation: {1}, IPRangeAllowListRules : {2}" -f $Server, $SiteVDirLocation, $IPRangeAllowListString)
             $resultsInvoke = Invoke-ScriptBlockHandler -ComputerName $Server -ScriptBlock $ConfigureMitigation -ArgumentList $ScriptBlockArgs

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
@@ -159,7 +159,7 @@ function Invoke-RollbackIPFiltering {
             $progressParams.PercentComplete = ($exchangeServersProcessed / $totalExchangeServers * 100)
             $progressParams.Status = "$baseStatus Rolling back rules"
             Write-Progress @progressParams
-            $exchangeServersProcessed++;
+            $exchangeServersProcessed++
 
             Write-Verbose ("Calling Invoke-ScriptBlockHandler on Server {0} with Arguments Site: {1}, VDir: {2}" -f $Server.Name, $Site, $VDir)
             Write-Verbose ("Restoring previous state for Server {0}" -f $Server.Name)

--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ValidateMitigation.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-ValidateMitigation.ps1
@@ -180,7 +180,7 @@ function Invoke-ValidateMitigation {
             $progressParams.PercentComplete = ($counter / $totalCount * 100)
             $progressParams.Status = "$baseStatus Validating rules"
             Write-Progress @progressParams
-            $counter ++;
+            $counter ++
 
             Write-Verbose ("Calling Invoke-ScriptBlockHandler on Server {0} with arguments SiteVDirLocations: {1}, ipRangeAllowListRules: {2}" -f $Server, [string]::Join(", ", $SiteVDirLocations), $ipRangeAllowListString)
             $resultsInvoke = Invoke-ScriptBlockHandler -ComputerName $Server -ScriptBlock $ValidateMitigationScriptBlock -ArgumentList $ScriptBlockArgs

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
@@ -62,7 +62,7 @@ function Invoke-ExtendedProtectionTlsPrerequisitesCheck {
                         if ($null -ne $result) {
                             Write-Verbose "Found difference in TLS for $key"
                             $nextServer = $true
-                            break;
+                            break
                         }
                     }
 

--- a/Shared/Get-ExtendedProtectionConfiguration.ps1
+++ b/Shared/Get-ExtendedProtectionConfiguration.ps1
@@ -72,7 +72,7 @@ function Get-ExtendedProtectionConfiguration {
                         if ($SiteVDirLocation -eq "$($WebSite[$i])/$virtualDirectory") {
                             Write-Verbose "Set Extended Protection to None because of restriction override '$($WebSite[$i])\$virtualDirectory'"
                             $ExtendedProtection[$i] = "None"
-                            break;
+                            break
                         }
                     }
                 }

--- a/Transport/Compute-TopExoRecipientsFromMessageTrace.ps1
+++ b/Transport/Compute-TopExoRecipientsFromMessageTrace.ps1
@@ -54,7 +54,7 @@ $CreateHourlyReport =
             if ($hourlyEvent.RecipientAddress -eq $_.RecipientAddress -and $hourlyEvent.Hour -eq $_.Received.Hour) {
                 $hourlyEvent.MessageCount +=1
             } else {
-                $eventObj = New-Object PSObject -Property @{ Hour=$_.Received.Hour; Date=$_.Received.Date.ToString("dd/mm/yyyy dd:hh tt"); MessageCount=1; RecipientAddress=$_.RecipientAddress };
+                $eventObj = New-Object PSObject -Property @{ Hour=$_.Received.Hour; Date=$_.Received.Date.ToString("dd/mm/yyyy dd:hh tt"); MessageCount=1; RecipientAddress=$_.RecipientAddress }
                 [void]$hourlyReport.Add($eventObj)
             }
         }
@@ -93,5 +93,5 @@ $props = [ordered]@{
     'HourlyReport'       = $hourlyReport
     'MessageTraceEvents' = $eventList
 }
-$results = New-Object -TypeName PSObject -Property $props;
+$results = New-Object -TypeName PSObject -Property $props
 return $results


### PR DESCRIPTION
**Issue:**
In a few of the sections of code, we see a back and forward use for using `;` when at the end of the line which is not required in PowerShell.

**Fix:**
To make the code consistent, enable the rule to prevent this from being checked in. 

**Additional:**
Need to wait to update the current code with the new rule after the current pending PRs (#1877 #1876) are merged as they would cause conflicts.

