### PR TITLE
Bug fix for invalid date used during AuthCert renewal process

### DIFF
--- a/Admin/MonitorExchangeAuthCertificate/ConfigurationAction/New-ExchangeAuthCertificate.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/ConfigurationAction/New-ExchangeAuthCertificate.ps1
@@ -294,7 +294,13 @@ function New-ExchangeAuthCertificate {
                 try {
                     Write-Verbose ("[Required] Step 1: Set certificate: $($newAuthCertificateThumbprint) as the next Auth Certificate")
                     if ($PSCmdlet.ShouldProcess("Certificate: $newAuthCertificateThumbprint Date: $nextAuthCertificateActiveOn", "Set-AuthConfig")) {
-                        Set-AuthConfig -NewCertificateThumbprint $newAuthCertificateThumbprint -NewCertificateEffectiveDate $nextAuthCertificateActiveOn -Force -ErrorAction Stop
+                        $setAuthConfigParams = @{
+                            NewCertificateThumbprint    = $newAuthCertificateThumbprint
+                            NewCertificateEffectiveDate = if ($EnableDaysInFuture -eq 0) { Get-Date } else { $nextAuthCertificateActiveOn }
+                            Force                       = $true
+                            ErrorAction                 = "Stop"
+                        }
+                        Set-AuthConfig @setAuthConfigParams
                     }
 
                     if ($EnableDaysInFuture -eq 0) {

--- a/Admin/MonitorExchangeAuthCertificate/ConfigurationAction/New-ExchangeAuthCertificate.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/ConfigurationAction/New-ExchangeAuthCertificate.ps1
@@ -120,7 +120,14 @@ function New-ExchangeAuthCertificate {
 
                                 if (($null -ne $internalTransportCertificate.Services) -and
                                     ($internalTransportCertificate.Services -ne 0)) {
-                                    $servicesToEnableList.AddRange(($internalTransportCertificate.Services).ToString().ToUpper().Split(",").Trim())
+                                    $transportCertificateServices = ($internalTransportCertificate.Services).ToString().ToUpper().Split(",").Trim()
+                                    if ($transportCertificateServices.Count -eq 1) {
+                                        # Use the Add() method if only one service is bound to the transport certificate
+                                        $servicesToEnableList.Add($transportCertificateServices)
+                                    } else {
+                                        # Use the AddRange() method otherwise
+                                        $servicesToEnableList.AddRange($transportCertificateServices)
+                                    }
 
                                     # Make sure to remove IIS from list if the certificate was not bound to Front End Website before
                                     if (($isInternalTransportBoundToIisFe -eq $false) -and
@@ -329,7 +336,7 @@ function New-ExchangeAuthCertificate {
             #>
 
             Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-            $newAuthCertificateActiveOn = (Get-Date)
+            $newAuthCertificateActiveOn = $null
             $renewalSuccessful = $false
             $newAuthCertificateObject = GenerateNewAuthCertificate
 
@@ -339,8 +346,15 @@ function New-ExchangeAuthCertificate {
                 Write-Verbose ("New Auth Certificate with thumbprint: $($newAuthCertificateThumbprint) generated - the existing one will be replaced immediately with the new one")
                 try {
                     Write-Verbose ("[Required] Step 1: Set certificate: $($newAuthCertificateThumbprint) as new Auth Certificate")
-                    if ($PSCmdlet.ShouldProcess("Certificate: $newAuthCertificateThumbprint Date: $newAuthCertificateActiveOn", "Set-AuthConfig")) {
-                        Set-AuthConfig -NewCertificateThumbprint $newAuthCertificateThumbprint -NewCertificateEffectiveDate $newAuthCertificateActiveOn -Force -ErrorAction Stop
+                    if ($PSCmdlet.ShouldProcess("Certificate: $newAuthCertificateThumbprint Date: immediately", "Set-AuthConfig")) {
+                        # We must use Get-Date here to ensure that the date which is passed to NewCertificateEffectiveDate parameter is a valid one
+                        $setAuthConfigParams = @{
+                            NewCertificateThumbprint    = $newAuthCertificateThumbprint
+                            NewCertificateEffectiveDate = ($newAuthCertificateActiveOn = Get-Date)
+                            Force                       = $true
+                            ErrorAction                 = "Stop"
+                        }
+                        Set-AuthConfig @setAuthConfigParams
                     }
 
                     Write-Verbose ("[Required] Step 2: Publish the new Auth Certificate")

--- a/Admin/MonitorExchangeAuthCertificate/DataCollection/Get-ExchangeAuthCertificateStatus.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/DataCollection/Get-ExchangeAuthCertificateStatus.ps1
@@ -117,36 +117,40 @@ function Get-ExchangeAuthCertificateStatus {
                 ($IgnoreUnreachableServers))) {
 
                 if ($exchangeServersReachableList.Count -gt $currentAuthCertificateMissingOnServersList.Count) {
-                    $currentAuthCertificateValidInDays = (($currentAuthCertificate.NotAfter) - (Get-Date)).Days
+                    if ($null -ne $currentAuthCertificate.NotAfter) {
+                        $currentAuthCertificateValidInDays = (($currentAuthCertificate.NotAfter) - (Get-Date)).Days
 
-                    if (($currentAuthCertificate.NotAfter).Date -lt (Get-Date)) {
-                        if ($currentAuthCertificateValidInDays -eq 0) {
-                            Write-Verbose ("The current Auth Certificate has expired today")
-                            $currentAuthCertificateValidInDays = -1
-                        } elseif ($currentAuthCertificateValidInDays -ne -738845) {
-                            Write-Verbose ("The current Auth Certificate has already expired {0} days ago" -f [System.Math]::Abs($currentAuthCertificateValidInDays))
+                        if (($currentAuthCertificate.NotAfter).Date -lt (Get-Date)) {
+                            if ($currentAuthCertificateValidInDays -eq 0) {
+                                Write-Verbose ("The current Auth Certificate has expired today")
+                                $currentAuthCertificateValidInDays = -1
+                            } else {
+                                Write-Verbose ("The current Auth Certificate has already expired {0} days ago" -f [System.Math]::Abs($currentAuthCertificateValidInDays))
+                            }
                         } else {
-                            Write-Verbose ("There is no Auth Certificate configured")
+                            Write-Verbose ("The current Auth Certificate is still valid")
                         }
                     } else {
-                        Write-Verbose ("The current Auth Certificate is still valid")
+                        Write-Verbose ("There is no Auth Certificate configured")
                     }
                 }
 
                 if ($exchangeServersReachableList.Count -gt $nextAuthCertificateMissingOnServersList.Count) {
-                    $nextAuthCertificateValidInDays = (($nextAuthCertificate.NotAfter) - (Get-Date)).Days
+                    if ($null -ne $nextAuthCertificate.NotAfter) {
+                        $nextAuthCertificateValidInDays = (($nextAuthCertificate.NotAfter) - (Get-Date)).Days
 
-                    if (($nextAuthCertificate.NotAfter).Date -lt (Get-Date)) {
-                        if ($nextAuthCertificateValidInDays -eq 0) {
-                            Write-Verbose ("The next Auth Certificate has expired today")
-                            $nextAuthCertificateValidInDays = -1
-                        } elseif ($nextAuthCertificateValidInDays -ne -738845) {
-                            Write-Verbose ("The next Auth Certificate has already expired {0} days ago" -f [System.Math]::Abs($nextAuthCertificateValidInDays))
+                        if (($nextAuthCertificate.NotAfter).Date -lt (Get-Date)) {
+                            if ($nextAuthCertificateValidInDays -eq 0) {
+                                Write-Verbose ("The next Auth Certificate has expired today")
+                                $nextAuthCertificateValidInDays = -1
+                            } else {
+                                Write-Verbose ("The next Auth Certificate has already expired {0} days ago" -f [System.Math]::Abs($nextAuthCertificateValidInDays))
+                            }
                         } else {
-                            Write-Verbose ("There is no next Auth Certificate configured")
+                            Write-Verbose ("The next Auth Certificate is still valid")
                         }
                     } else {
-                        Write-Verbose ("The next Auth Certificate is still valid")
+                        Write-Verbose ("There is no next Auth Certificate configured")
                     }
                 }
 

--- a/Admin/MonitorExchangeAuthCertificate/DataCollection/Get-ExchangeAuthCertificateStatus.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/DataCollection/Get-ExchangeAuthCertificateStatus.ps1
@@ -32,8 +32,9 @@ function Get-ExchangeAuthCertificateStatus {
         $configureNextAuthRequired = $false
         $importNextAuthCertificateRequired = $false
 
-        $currentAuthCertificateValidInDays = 0
-        $nextAuthCertificateValidInDays = 0
+        # Make sure to initialize this with -1 as this is needed to properly run the validation in case that we're unable to query this information
+        $currentAuthCertificateValidInDays = -1
+        $nextAuthCertificateValidInDays = -1
 
         $exchangeServersUnreachableList = New-Object 'System.Collections.Generic.List[string]'
         $exchangeServersReachableList = New-Object 'System.Collections.Generic.List[string]'

--- a/Admin/MonitorExchangeAuthCertificate/DataCollection/Tests/Get-ExchangeAuthCertificateStatus.Tests.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/DataCollection/Tests/Get-ExchangeAuthCertificateStatus.Tests.ps1
@@ -254,7 +254,7 @@ Describe "Testing Get-ExchangeAuthCertificateStatus.ps1" {
 
         It "Should Not Return That An Auth Certificate Renewal Action Is Required" {
             $results | Should -Not -BeNullOrEmpty
-            $results.CurrentAuthCertificateLifetimeInDays | Should -Be 0
+            $results.CurrentAuthCertificateLifetimeInDays | Should -Be -1
             $results.ReplaceRequired | Should -Be $false
             $results.ConfigureNextAuthRequired | Should -Be $false
         }

--- a/Admin/MonitorExchangeAuthCertificate/MonitorExchangeAuthCertificate.ps1
+++ b/Admin/MonitorExchangeAuthCertificate/MonitorExchangeAuthCertificate.ps1
@@ -673,8 +673,10 @@ function Main {
             }
             Write-Host ("")
             Write-Host ("Test result: $($renewalActionWording)") -ForegroundColor Cyan
-            if (($authCertStatus.AuthCertificateMissingOnServers.Count -gt 0) -or
-                ($authCertStatus.NextAuthCertificateMissingOnServers.Count -gt 0)) {
+            if ((($authCertStatus.AuthCertificateMissingOnServers.Count -gt 0) -and
+                ($authCertStatus.CurrentAuthCertificateImportRequired)) -or
+                (($authCertStatus.NextAuthCertificateMissingOnServers.Count -gt 0) -and
+                ($authCertStatus.NextAuthCertificateImportRequired))) {
                 Write-Host ("`rThe script will try to import the certificate to the missing servers automatically (as long as it's valid).") -ForegroundColor Cyan
             }
         }


### PR DESCRIPTION
**Issue:**
The following issue, that occurred during the AuthCertificate renewal process, was reported by one of our support engineers:

```
[11/17/2023 16:35:43] : Inner Exception: System.Management.Automation.RemoteException: The new certificate effective date is invalid. The effective date must be greater than the current time.
[11/17/2023 16:35:43] : Position Message: At C:\Users\xxxxxx\AppData\Roaming\Microsoft\Exchange\RemotePowerShell\xxxxxx\xxxxxx.psm1:69571 char:9
+         $steppablePipeline.End()
+         ~~~~~~~~~~~~~~~~~~~~~~~~
[11/17/2023 16:35:43] : Remote Position Message: At line:59 char:23
+         $scriptCmd = {& $wrappedCmd @PSBoundParameters }
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**Reason:**
The date that was used and passed via `NewCertificateEffectiveDate` parameter was invalid. Cause was that the `DateTime` object was initialized a few milliseconds before the cmdlet was called. If the script was executed in manual mode, this could lead to this situation.

**Fix:**
Initialize the date immediately when running the `Set-AuthConfig` parameter and pass the `DateTime` back to `$newAuthCertificateActiveOn`.

I've also addressed another minor issue that caused a wrong display output.

**Validation:**
Lab

