### PR TITLE
Add High Performance (ConfigMgr) power plan detection to HC

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PowerPlanSetting.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PowerPlanSetting.ps1
@@ -18,8 +18,8 @@ function Get-PowerPlanSetting {
 
         if ($null -ne $win32_PowerPlan) {
 
-            # Guid 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c is 'High Performance' powerplan that comes with the OS
-            # Guid db310065-829b-4671-9647-2261c00e86ef is 'High Performance (ConfigMgr)' powerplan when configured via Configuration Manager / SCCM
+            # Guid 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c is 'High Performance' power plan that comes with the OS
+            # Guid db310065-829b-4671-9647-2261c00e86ef is 'High Performance (ConfigMgr)' power plan when configured via Configuration Manager / SCCM
             if (($win32_PowerPlan.InstanceID -eq "Microsoft:PowerPlan\{8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c}") -or
                 ($win32_PowerPlan.InstanceID -eq "Microsoft:PowerPlan\{db310065-829b-4671-9647-2261c00e86ef}")) {
                 Write-Verbose "High Performance Power Plan is set to true"

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PowerPlanSetting.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-PowerPlanSetting.ps1
@@ -18,7 +18,10 @@ function Get-PowerPlanSetting {
 
         if ($null -ne $win32_PowerPlan) {
 
-            if ($win32_PowerPlan.InstanceID -eq "Microsoft:PowerPlan\{8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c}") {
+            # Guid 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c is 'High Performance' powerplan that comes with the OS
+            # Guid db310065-829b-4671-9647-2261c00e86ef is 'High Performance (ConfigMgr)' powerplan when configured via Configuration Manager / SCCM
+            if (($win32_PowerPlan.InstanceID -eq "Microsoft:PowerPlan\{8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c}") -or
+                ($win32_PowerPlan.InstanceID -eq "Microsoft:PowerPlan\{db310065-829b-4671-9647-2261c00e86ef}")) {
                 Write-Verbose "High Performance Power Plan is set to true"
                 $highPerformanceSet = $true
             } else { Write-Verbose "High Performance Power Plan is NOT set to true" }


### PR DESCRIPTION
**Issue:**
It's possible to configure the High Performance power plan by using Configuration Manager (ConfigMgr) or SCCM. If it's configured this way, the GUID that we use is different to the GUID that is used for the High Performance power plan that comes with the OS by default.

<img width="427" alt="image" src="https://github.com/microsoft/CSS-Exchange/assets/40993616/a41099cf-a707-4b0a-a740-bb212f2c4153">

**Reason:**
Improve detection of the power plan that is set on the computer

**Fix:**
Added check for `db310065-829b-4671-9647-2261c00e86ef` GUID which is the `High Performance (ConfigMgr)` power plan.

**Validation:**
Customer

