### PR TITLE
Address empty array on property column

### DIFF
--- a/Shared/Out-Columns.ps1
+++ b/Shared/Out-Columns.ps1
@@ -271,9 +271,10 @@ function Out-Columns {
                     Write-Host (" " * $IndentSpaces) -NoNewline
                     [void]$stb.Append(" " * $IndentSpaces)
                     for ($i = 0; $i -lt $props.Count; $i++) {
-                        $val = $o."$($props[$i])"
-                        Write-Host ("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $lineObj."$($props[$i])") -NoNewline -ForegroundColor $colColors[$i]
-                        [void]$stb.Append("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $lineObj."$($props[$i])")
+                        $val = $lineObj."$($props[$i])"
+                        if ($val.Count -eq 0) { $val = "" }
+                        Write-Host ("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $val) -NoNewline -ForegroundColor $colColors[$i]
+                        [void]$stb.Append("{0,$(-1 * ($colWidths[$i] + $padding))}" -f $val)
                     }
 
                     Write-Host


### PR DESCRIPTION
**Issue:**
When providing an object that contains a property that contains an empty array, we throw an error like the following: 

```
 : Error formatting a string: Index (zero based) must be greater than or equal to zero and less than the size of the argument list..
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.PSScriptCmdlet.DoEndProcessing()
   at System.Management.Automation.CommandProcessorBase.Complete()
Position Message: At C:\Users\Han\Desktop\HealthChecker.ps1:8535 char:94
+ ... -1 * ($colWidths[$i] + $padding))}" -f $lineObj."$($props[$i])") -NoN ...
+                                                        ~~~~~~~~~~
Script Stack: at Out-Columns<End>, C:\Users\Han\Desktop\HealthChecker.ps1: line 8535
at Write-OutColumns, C:\Users\Han\Desktop\HealthChecker.ps1: line 8597
at Write-ResultsToScreen, C:\Users\Han\Desktop\HealthChecker.ps1: line 8255
at Get-HealthCheckerData, C:\Users\Han\Desktop\HealthChecker.ps1: line 14635
at Invoke-HealthCheckerMainReport, C:\Users\Han\Desktop\HealthChecker.ps1: line 14704
at <ScriptBlock><End>, C:\Users\Han\Desktop\HealthChecker.ps1: line 15515
at <ScriptBlock>, <No file>: line 1
-----------------------------------
```

**Reason:**
This should be fixed in the `Out-Columns` logic to prevent the error from being `thrown`. 

**Fix:**
If this is detected, set the line to an empty string vs an empty array. 

**Validation:**
Lab tested

