### PR TITLE
Address bug with HSTS detection with no ; in value

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -101,9 +101,13 @@ function Get-IISWebSite {
                     # add 8 to find the start index after 'max-age='
                     $maxAgeIndex = $maxAgeIndex + 8
 
-                    # subtract maxAgeIndex to get the length that we need to find the substring
-                    $maxAgeValueIndex = $maxAgeValueIndex - $maxAgeIndex
-                    $customHeaderHstsObj.'max-age' = $customHeaderHsts.Substring($maxAgeIndex, $maxAgeValueIndex)
+                    if ($maxAgeValueIndex -ne -1) {
+                        # subtract maxAgeIndex to get the length that we need to find the substring
+                        $maxAgeValueIndex = $maxAgeValueIndex - $maxAgeIndex
+                        $customHeaderHstsObj.'max-age' = $customHeaderHsts.Substring($maxAgeIndex, $maxAgeValueIndex)
+                    } else {
+                        $customHeaderHstsObj.'max-age' = $customHeaderHsts.Substring($maxAgeIndex)
+                    }
                 } else {
                     Write-Verbose "max-age directive not found"
                 }


### PR DESCRIPTION
**Issue:**
See #1926 

**Fix:**
If no index of `;` is found, just read the rest of the line for `max-age`. 

**Validation:**
Lab tested

Resolved #1926 

