### PR TITLE
Health Checker Web Proxy Update

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -332,7 +332,9 @@ function Invoke-AnalyzerOsInformation {
 
     if (($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne "None") -and
         ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $false) -and
-        ($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne $exchangeInformation.GetExchangeServer.InternetWebProxy.Authority)) {
+        ($null -ne $exchangeInformation.GetExchangeServer.InternetWebProxy) -and
+        ($osInformation.NetworkInformation.HttpProxy.ProxyAddress -ne
+        "$($exchangeInformation.GetExchangeServer.InternetWebProxy.Host):$($exchangeInformation.GetExchangeServer.InternetWebProxy.Port)")) {
         $params = $baseParams + @{
             Details                = "Error: Exchange Internet Web Proxy doesn't match OS Web Proxy."
             DisplayWriteType       = "Red"


### PR DESCRIPTION
**Issue:**
When trying determine the values of the proxy set on the computer from the registry, it isn't providing the correct value if the bypass proxy list length is longer than 42. 

**Reason:**
We should be able to provide the correct value of the proxy accurately if it is set.

**Fix:**
Determined how the binary value was structured. The 4th byte in the byte array was the length of the proxy string value. Then very next byte after the proxy string value is the length of the bypass proxy list.

Need to use `[System.BitConverter]::ToInt32()` and `[System.Text.Encoding]::UTF8.GetString()` to correctly pull out the values that we want to use. 

Resolved #1875 

**Validation:**
Lab tested. 

Before: 
![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/a65a9e45-6d27-48a8-a40b-83beba22125f)


After:
![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/7fe63971-4f36-4fab-b492-dc9477033d29)


