### PR TITLE
Exchange IIS Information Docs & HTML

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -112,12 +112,13 @@ function Invoke-AnalyzerIISInformation {
     $sbStarted = { param($o, $p) if ($p -eq "State") { if ($o."$p" -eq "Started") { "Green" } else { "Red" } } }
 
     $params = $baseParams + @{
-        OutColumns       = ([PSCustomObject]@{
+        OutColumns           = ([PSCustomObject]@{
                 DisplayObject      = $outputObjectDisplayValue
                 ColorizerFunctions = @($sbStarted)
                 IndentSpaces       = 8
             })
-        AddHtmlDetailRow = $false
+        OutColumnsColorTests = @($sbStarted)
+        HtmlName             = "IIS Sites Information"
     }
     Add-AnalyzedResultInformation @params
 
@@ -270,12 +271,13 @@ function Invoke-AnalyzerIISInformation {
 
     $sbRestart = { param($o, $p) if ($p -eq "RestartConditionSet") { if ($o."$p") { "Red" } else { "Green" } } }
     $params = $baseParams + @{
-        OutColumns       = ([PSCustomObject]@{
+        OutColumns           = ([PSCustomObject]@{
                 DisplayObject      = $outputObjectDisplayValue
                 ColorizerFunctions = @($sbStarted, $sbRestart)
                 IndentSpaces       = 8
             })
-        AddHtmlDetailRow = $false
+        OutColumnsColorTests = @($sbStarted, $sbRestart)
+        HtmlName             = "Application Pool Information"
     }
     Add-AnalyzedResultInformation @params
 
@@ -319,19 +321,19 @@ function Invoke-AnalyzerIISInformation {
         }
 
         $params = $baseParams + @{
-            OutColumns       = ([PSCustomObject]@{
+            OutColumns           = ([PSCustomObject]@{
                     DisplayObject      = $outputObjectDisplayValue
                     ColorizerFunctions = @($sbColorizer)
                     IndentSpaces       = 8
                 })
-            AddHtmlDetailRow = $false
+            OutColumnsColorTests = @($sbColorizer)
+            HtmlName             = "Application Pools Restarts"
         }
         Add-AnalyzedResultInformation @params
 
         $params = $baseParams + @{
             Details          = "Error: The above app pools currently have the periodic restarts set. This restart will cause disruption to end users."
             DisplayWriteType = "Red"
-            AddHtmlDetailRow = $false
         }
         Add-AnalyzedResultInformation @params
     }
@@ -429,11 +431,11 @@ function Invoke-AnalyzerIISInformation {
     }
 
     $params = $baseParams + @{
-        OutColumns       = ([PSCustomObject]@{
+        OutColumns = ([PSCustomObject]@{
                 DisplayObject = $iisVirtualDirectoriesDisplay
                 IndentSpaces  = 8
             })
-        AddHtmlDetailRow = $false
+        HtmlName   = "Virtual Directory Locations"
     }
     Add-AnalyzedResultInformation @params
 

--- a/docs/Diagnostics/HealthChecker/IISInformation.md
+++ b/docs/Diagnostics/HealthChecker/IISInformation.md
@@ -1,0 +1,40 @@
+# Exchange IIS Information
+
+## Description
+
+We show some general information about your Exchange Server from the IIS perspective. This goes into detail to make sure that Sites and App Pools are started, which might not be easy to spot at a quick look a the server. It will also call out some common misconfiguration issues, that will cause problems with client connectivity.
+
+
+## Sites
+
+This provides the sites that we found and the following information:
+
+- State (Started or Stopped)
+- HSTS Enabled (Only supported on `Default Web Site`)
+- Protocol - Binding - Certificate ( Which protocol is binding to which port and with what certificate if any)
+
+**NOTE:** HSTS if enabled on the Back End will call out an issue.
+
+## App Pools
+
+This provides the application pools on the server with the following information:
+
+- State (Started or Stopped)
+- GCServerEnabled (Garbage Collection Server Enabled - Depends on the RAM on the server if this should be enabled or not on the server. If it should be, Health Checker should call it out.)
+- RestartConditionSet ( If there is an IIS setting that will automatically restart the App Pool. This is not recommended and will cause issues with client connectivity )
+
+## Virtual Directory Locations
+
+This provides the different locations that you use for different connection endpoints with the following information:
+
+- Extended Protection ( The current value )
+- Ssl Flags ( If enabled and/or Cert based )
+- IP Filtering Enabled ( If any IP filtering is enabled )
+- URL Rewrite ( Names of each rule applied at the location )
+- Authentication ( Provides each type of authentication that is enabled for the location. If anonymous `default setting` will be provided if that is enabled Out of the Box on the server )
+
+**NOTE:** For each of the URL Rewrite rules, we will display additional information about the rule to let you know what it is doing. It is also recommended to remove any mitigation rules that you might have applied if you have the security fix installed on the server.
+
+### Included in HTML Report?
+
+Yes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - DownloadDomainCheck: Diagnostics/HealthChecker/DownloadDomainCheck.md
       - OpenRelayDomainCheck: Diagnostics/HealthChecker/OpenRelayDomain.md
       - FIPFSCheck: Diagnostics/HealthChecker/FIPFSCheck.md
+      - IISInformation: Diagnostics/HealthChecker/IISInformation.md
       - IISWebConfigCheck: Diagnostics/HealthChecker/IISWebConfigCheck.md
       - HCScheduledTask: Diagnostics/HealthChecker/RunHCViaSchedTask.md
       - ADSiteCount: Diagnostics/HealthChecker/ADSiteCount.md


### PR DESCRIPTION
**Issue:**
It was requested to create a docs page about the IIS Information that we were displaying and to include it in the HTML report.

**Fix:**
Create the IIS Information doc and included the different IIS information sections to the HTML report page.

Resolved #1936 
Resolved #1935 

**Validation:**
Lab tested


![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/ece97bf4-9bfc-41e6-bb96-1327afe4a68d)
