### PR TITLE
Check for incorrect virtual directory path

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -596,7 +596,7 @@ function Invoke-AnalyzerIISInformation {
                 $params = $baseParams + @{
                     Name             = "Incorrect Virtual Directory Path"
                     Details          = "Error: '$($webApp.FriendlyName)' location for the virtual directory configuration is incorrect." +
-                    "`r`n`t`tCurrently pointing to '$($webApp.PhysicalPath)'. Which is incorrect for this protocol and will cause problems."
+                    "`r`n`t`tCurrently pointing to '$($webApp.PhysicalPath)', which is incorrect for this protocol and will cause problems."
                     DisplayWriteType = "Red"
                 }
                 Add-AnalyzedResultInformation @params

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -462,9 +462,38 @@ function Invoke-AnalyzerIISInformation {
         Where-Object { $_.Valid -eq $true -and $_.Exist -eq $true } |
         ForEach-Object { $_.Location }
 
+    $iisWebApplications = $exchangeInformation.IISSettings.IISWebApplication
+
     if ($null -ne $siteConfigPaths) {
-        $missingWebApplicationConfigFile = $exchangeInformation.IISSettings.IISWebApplication |
+        $missingWebApplicationConfigFile = $iisWebApplications |
             Where-Object { $siteConfigPaths -contains "$($_.ConfigurationFileInfo.Location)" }
+    }
+
+    $correctLocations = @{
+        "Default Web Site/owa"                          = "FrontEnd\HttpProxy\owa"
+        "Default Web Site/ecp"                          = "FrontEnd\HttpProxy\ecp"
+        "Default Web Site/EWS"                          = "FrontEnd\HttpProxy\EWS"
+        "Default Web Site/API"                          = "FrontEnd\HttpProxy\Rest"
+        "Default Web Site/Autodiscover"                 = "FrontEnd\HttpProxy\Autodiscover"
+        "Default Web Site/Microsoft-Server-ActiveSync"  = "FrontEnd\HttpProxy\sync"
+        "Default Web Site/OAB"                          = "FrontEnd\HttpProxy\OAB"
+        "Default Web Site/PowerShell"                   = "FrontEnd\HttpProxy\PowerShell"
+        "Default Web Site/mapi"                         = "FrontEnd\HttpProxy\mapi"
+        "Default Web Site/Rpc"                          = "FrontEnd\HttpProxy\rpc"
+        "Exchange Back End/PowerShell"                  = "ClientAccess\PowerShell-Proxy"
+        "Exchange Back End/mapi/emsmdb"                 = "ClientAccess\mapi\emsmdb"
+        "Exchange Back End/mapi/nspi"                   = "ClientAccess\mapi\nspi"
+        "Exchange Back End/API"                         = "ClientAccess\rest"
+        "Exchange Back End/owa"                         = "ClientAccess\owa"
+        "Exchange Back End/OAB"                         = "ClientAccess\OAB"
+        "Exchange Back End/ecp"                         = "ClientAccess\ecp"
+        "Exchange Back End/Autodiscover"                = "ClientAccess\Autodiscover"
+        "Exchange Back End/Microsoft-Server-ActiveSync" = "ClientAccess\sync"
+        "Exchange Back End/EWS"                         = "ClientAccess\exchWeb\EWS"
+        "Exchange Back End/EWS/bin"                     = "ClientAccess\exchWeb\EWS\bin"
+        "Exchange Back End/Rpc"                         = "RpcProxy"
+        "Exchange Back End/RpcWithCert"                 = "RpcProxy"
+        "Exchange Back End/PushNotifications"           = "ClientAccess\PushNotifications"
     }
 
     # Missing config file should really only occur for SharedWebConfig files, as the web application would go back to the parent site.
@@ -558,6 +587,20 @@ function Invoke-AnalyzerIISInformation {
             }
 
             Add-AnalyzedResultInformation @params
+        }
+    }
+
+    foreach ($webApp in $iisWebApplications) {
+        if ($correctLocations.ContainsKey($webApp.FriendlyName)) {
+            if ($webApp.PhysicalPath -notlike "*$($correctLocations[$webApp.FriendlyName])") {
+                $params = $baseParams + @{
+                    Name             = "Incorrect Virtual Directory Path"
+                    Details          = "Error: '$($webApp.FriendlyName)' location for the virtual directory configuration is incorrect." +
+                    "`r`n`t`tCurrently pointing to '$($webApp.PhysicalPath)'. Which is incorrect for this protocol and will cause problems."
+                    DisplayWriteType = "Red"
+                }
+                Add-AnalyzedResultInformation @params
+            }
         }
     }
 


### PR DESCRIPTION
**Issue:**
Because you can re-create the virtual directories, we need to verify the paths to make sure they are pointed to the correct default locations. Otherwise, they will not work as intended. 

**Reason:**
Had a customer face this issue, easy enough to call out and avoid the cases. 


**Fix:**
Check the last part of the path to make sure it is pointing to the correct location. Otherwise, then display an error. 

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/8b7c21a9-5e61-4a3c-bd84-e03c3c28dfc6)

Unable to use the Get cmdlets for the virtual directories because we are using `-ADPropertiesOnly` which will not include the path. Therefore, we are basing this off the IISWebApplication information that we have collected. 

Resolved #1131 

**Validation:**
Lab tested
