### PR TITLE
Improve Visual C++ Redistributables is out of date display

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -349,25 +349,28 @@ function Invoke-AnalyzerOsInformation {
 
     if ($null -ne $osInformation.VcRedistributable) {
 
+        $installed2012 = Get-VisualCRedistributableLatest 2012 $osInformation.VcRedistributable
+        $installed2013 = Get-VisualCRedistributableLatest 2013 $osInformation.VcRedistributable
+
         if (Test-VisualCRedistributableUpToDate -Year 2012 -Installed $osInformation.VcRedistributable) {
             $displayWriteType2012 = "Green"
-            $displayValue2012 = "$((Get-VisualCRedistributableInfo 2012).VersionNumber) Version is current"
+            $displayValue2012 = "$($installed2012.DisplayVersion) Version is current"
         } elseif (Test-VisualCRedistributableInstalled -Year 2012 -Installed $osInformation.VcRedistributable) {
-            $displayValue2012 = "Redistributable is outdated"
+            $displayValue2012 = "Redistributable ($($installed2012.DisplayVersion)) is outdated"
             $displayWriteType2012 = "Yellow"
         }
 
         if (Test-VisualCRedistributableUpToDate -Year 2013 -Installed $osInformation.VcRedistributable) {
             $displayWriteType2013 = "Green"
-            $displayValue2013 = "$((Get-VisualCRedistributableInfo 2013).VersionNumber) Version is current"
+            $displayValue2013 = "$($installed2013.DisplayVersion) Version is current"
         } elseif (Test-VisualCRedistributableInstalled -Year 2013 -Installed $osInformation.VcRedistributable) {
-            $displayValue2013 = "Redistributable is outdated"
+            $displayValue2013 = "Redistributable ($($installed2013.DisplayVersion)) is outdated"
             $displayWriteType2013 = "Yellow"
         }
     }
 
     $params = $baseParams + @{
-        Name             = "Visual C++ 2012"
+        Name             = "Visual C++ 2012 x64"
         Details          = $displayValue2012
         DisplayWriteType = $displayWriteType2012
     }
@@ -375,7 +378,7 @@ function Invoke-AnalyzerOsInformation {
 
     if ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $false) {
         $params = $baseParams + @{
-            Name             = "Visual C++ 2013"
+            Name             = "Visual C++ 2013 x64"
             Details          = $displayValue2013
             DisplayWriteType = $displayWriteType2013
         }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -56,8 +56,8 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Power Plan" "Balanced --- Error" -WriteType "Red"
             $httpProxy = GetObject "Http Proxy Setting"
             $httpProxy.ProxyAddress | Should -Be "None"
-            TestObjectMatch "Visual C++ 2012" "184610406 Version is current" -WriteType "Green"
-            TestObjectMatch "Visual C++ 2013" "Redistributable is outdated" -WriteType "Yellow"
+            TestObjectMatch "Visual C++ 2012 x64" "11.0.61030 Version is current" -WriteType "Green"
+            TestObjectMatch "Visual C++ 2013 x64" "Redistributable (12.0.21005) is outdated" -WriteType "Yellow"
             TestObjectMatch "Server Pending Reboot" $false
 
             $pageFile = GetObject "PageFile Size 0"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -56,8 +56,8 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Power Plan" "Balanced --- Error"-WriteType "Red"
             $httpProxy = GetObject "Http Proxy Setting"
             $httpProxy.ProxyAddress | Should -Be "None"
-            TestObjectMatch "Visual C++ 2012" "Redistributable is outdated" -WriteType "Yellow"
-            TestObjectMatch "Visual C++ 2013" "Redistributable is outdated" -WriteType "Yellow"
+            TestObjectMatch "Visual C++ 2012 x64" "Redistributable (11.0.50727) is outdated" -WriteType "Yellow"
+            TestObjectMatch "Visual C++ 2013 x64" "Redistributable (12.0.21005) is outdated" -WriteType "Yellow"
             TestObjectMatch "Server Pending Reboot" $false
 
             $pageFile = GetObject "PageFile Size 0"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -56,8 +56,8 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Power Plan" "Balanced --- Error" -WriteType "Red"
             $httpProxy = GetObject "Http Proxy Setting"
             $httpProxy.ProxyAddress | Should -Be "None"
-            TestObjectMatch "Visual C++ 2012" "184610406 Version is current" -WriteType "Green"
-            TestObjectMatch "Visual C++ 2013" "Redistributable is outdated" -WriteType "Yellow"
+            TestObjectMatch "Visual C++ 2012 x64" "11.0.61030 Version is current" -WriteType "Green"
+            TestObjectMatch "Visual C++ 2013 x64" "Redistributable (12.0.21005) is outdated" -WriteType "Yellow"
             TestObjectMatch "Server Pending Reboot" $false
 
             $pageFile = GetObject "PageFile Size 0"

--- a/Shared/VisualCRedistributableVersionFunctions.ps1
+++ b/Shared/VisualCRedistributableVersionFunctions.ps1
@@ -99,3 +99,24 @@ function Test-VisualCRedistributableUpToDate {
                 $_.DisplayName -like $desired.DisplayName -and $_.VersionIdentifier -eq $desired.VersionNumber
             }))
 }
+
+function Get-VisualCRedistributableLatest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateSet(2012, 2013)]
+        [int]
+        $Year,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [object]
+        $Installed
+    )
+
+    $desired = Get-VisualCRedistributableInfo $Year
+
+    return $Installed |
+        Sort-Object VersionIdentifier -Descending |
+        Where-Object { $_.DisplayName -like $desired.DisplayName } |
+        Select-Object -First 1
+}


### PR DESCRIPTION
**Issue:**
Would like to improve the output of the Visual C++ for what you need to have installed. 

**Reason:**
It was requested to at least include `x64` in the output. 

While I was at it, ended up displaying the friendly name of the current installed version or out of date version. 

**Fix:**
- include `x64` in the name. 
- include friendly display name
- adjusted pester for the changes.

Resolved #1336 

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/662fb0db-e389-4924-96dd-c085e0a2a22d)

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/d98efa78-3f6c-4e82-b7e9-5f848dbd3590)


![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/57bbc901-4d9b-429f-b7aa-14f5db029427)


**Validation:**
Lab & Pester tested 

