### PR TITLE
Updated wording when EP is not configured

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -47,10 +47,13 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
                     # This combination means that EP is not configured and the Exchange build doesn't support it.
                     # Recommended action: Upgrade to a supported build (Aug 2022 SU+) and enable EP afterwards.
                     $epDetails = "Your Exchange server is at risk. Install the latest SU and enable Extended Protection"
-                } else {
+                } elseif ($extendedProtection.ExtendedProtectionConfigured) {
                     # This means that EP is supported but not configured for at least one vDir.
                     # Recommended action: Enable EP for each vDir on the system by using the script provided by us.
-                    $epDetails += "Extended Protection isn't configured as expected"
+                    $epDetails = "Extended Protection isn't configured as expected"
+                } else {
+                    # No Extended Protection is configured, provide a slightly different wording to avoid confusion of possible misconfigured EP.
+                    $epDetails = "Extended Protection is not configured"
                 }
 
                 $epCveParams = $baseParams + @{


### PR DESCRIPTION
**Issue:**
People can't determine from the current wording + the chart to understand if Extended Protection was even attempted to be configured. Because of this, we just want to provide slightly different wording when Extended Protection is not set at any location. 


**Fix:**
If EP is configured at any location, provide the same wording of not configured correctly. Otherwise, if not configured, provide that it is not configured. 

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/f9559d8a-6678-450b-8a59-8cc324ba5484)


Resolved #1685 

**Validation:**
Lab tested

