### PR TITLE
Handle missing ExSetup on server

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -118,6 +118,17 @@ function Invoke-AnalyzerExchangeInformation {
         }
     }
 
+    # If the ExSetup wasn't found, we need to report that.
+    if ($exchangeInformation.BuildInformation.ExchangeSetup.FailedGetExSetup -eq $true) {
+        $params = $baseParams + @{
+            Name                   = "Warning"
+            Details                = "Didn't detect ExSetup.exe on the server. This might mean that setup didn't complete correctly the last time it was run."
+            DisplayCustomTabNumber = 2
+            DisplayWriteType       = "Yellow"
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
     if ($null -ne $exchangeInformation.BuildInformation.KBsInstalled) {
         Add-AnalyzedResultInformation -Name "Exchange IU or Security Hotfix Detected" @baseParams
         $problemKbFound = $false

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
@@ -11,7 +11,11 @@ function Get-ExSetupDetails {
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     $exSetupDetails = [string]::Empty
     function Get-ExSetupDetailsScriptBlock {
-        Get-Command ExSetup | ForEach-Object { $_.FileVersionInfo }
+        try {
+            Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+        } catch {
+            Write-Verbose "Failed to find ExSetup, need to fallback."
+        }
     }
 
     $exSetupDetails = Invoke-ScriptBlockHandler -ComputerName $Server -ScriptBlock ${Function:Get-ExSetupDetailsScriptBlock} -ScriptBlockDescription "Getting ExSetup remotely" -CatchActionFunction ${Function:Invoke-CatchActions}

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExSetupDetails.ps1
@@ -14,7 +14,16 @@ function Get-ExSetupDetails {
         try {
             Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
         } catch {
-            Write-Verbose "Failed to find ExSetup, need to fallback."
+            try {
+                Write-Verbose "Failed to find ExSetup by environment path locations. Attempting manual lookup."
+                $installDirectory = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction Stop).MsiInstallPath
+
+                if ($null -ne $installDirectory) {
+                    Get-Command ([System.IO.Path]::Combine($installDirectory, "bin\ExSetup.exe")) -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+                }
+            } catch {
+                Write-Verbose "Failed to find ExSetup, need to fallback."
+            }
         }
     }
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -36,7 +36,21 @@ function Get-ExchangeInformation {
         $getExchangeServer = (Get-ExchangeServer -Identity $Server -Status)
         $exchangeCertificates = Get-ExchangeServerCertificates -Server $Server
         $exSetupDetails = Get-ExSetupDetails -Server $Server
-        $versionInformation = (Get-ExchangeBuildVersionInformation -FileVersion ($exSetupDetails.FileVersion))
+
+        if ($null -eq $exSetupDetails) {
+            # couldn't find ExSetup.exe this should be rare so we are just going to handle this by displaying the AdminDisplayVersion from Get-ExchangeServer
+            $versionInformation = (Get-ExchangeBuildVersionInformation -AdminDisplayVersion $getExchangeServer.AdminDisplayVersion)
+            $exSetupDetails = [PSCustomObject]@{
+                FileVersion      = $versionInformation.BuildVersion.ToString()
+                FileBuildPart    = $versionInformation.BuildVersion.Build
+                FilePrivatePart  = $versionInformation.BuildVersion.Revision
+                FileMajorPart    = $versionInformation.BuildVersion.Major
+                FileMinorPart    = $versionInformation.BuildVersion.Minor
+                FailedGetExSetup = $true
+            }
+        } else {
+            $versionInformation = (Get-ExchangeBuildVersionInformation -FileVersion ($exSetupDetails.FileVersion))
+        }
 
         $buildInformation = [PSCustomObject]@{
             ServerRole         = (Get-ServerRole -ExchangeServerObj $getExchangeServer)


### PR DESCRIPTION
**Issue:**
See linked issue

**Reason:**
Want Health Checker attempt to complete, then display if we weren't able to find the ExSetup.

**Fix:**
Use `AdminDisplayVersion` from `Get-ExchangeServer` to get the build information. While this doesn't get the security updates, it will allow the script to continue. Then we will call out in the display if the `ExSetup.exe` was not found.

Resolved #1692 

**Validation:**
Lab tested

