### PR TITLE
Only add key if not already in the list

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Get-IISAuthenticationType.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-IISAuthenticationType.ps1
@@ -106,7 +106,11 @@ function Get-IISAuthenticationType {
         # for this configuration type, clear flag doesn't appear to be used at all.
         foreach ($appKey in $appHostConfigLocations) {
             Write-Verbose "Working on appKey: $appKey"
-            $getIisAuthenticationType.Add($appKey, [string]::Empty)
+
+            if (-not ($getIisAuthenticationType.ContainsKey($appKey))) {
+                $getIisAuthenticationType.Add($appKey, [string]::Empty)
+            }
+
             $currentKey = $appKey
             $authentication = @()
             $continue = $true

--- a/Diagnostics/HealthChecker/Analyzer/Get-IPFilterSetting.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-IPFilterSetting.ps1
@@ -16,7 +16,11 @@ function Get-IPFilterSetting {
     process {
         foreach ($appKey in $locationPaths) {
             Write-Verbose "Working on appKey: $appKey"
-            $ipFilterSettings.Add($appKey, (New-Object System.Collections.Generic.List[object]))
+
+            if (-not ($ipFilterSettings.ContainsKey($appKey))) {
+                $ipFilterSettings.Add($appKey, (New-Object System.Collections.Generic.List[object]))
+            }
+
             $currentKey = $appKey
             $continue = $true
 


### PR DESCRIPTION
**Issue:**
Customer reported HealthChecker was no longer running after an update. 

Problem started after PR #1907 


**Fix:**
Don't add key if it is already present in the dictionary. 

Resolved #1977 

**Validation:**
Customer tested out. 

