### PR TITLE
EXO Send Connector Issue

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -263,4 +263,72 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
         Details = $exchangeInformation.RegistryValues.DisablePreservation
     }
     Add-AnalyzedResultInformation @params
+
+    # Detect Send Connector sending to EXO
+    $exoConnector = New-Object System.Collections.Generic.List[object]
+    $sendConnectors = $exchangeInformation.ExchangeConnectors | Where-Object { $_.ConnectorType -eq "Send" }
+
+    foreach ($sendConnector in $sendConnectors) {
+        $smartHostMatch = ($sendConnector.SmartHosts -like "*.mail.protection.outlook.com").Count -gt 0
+        $dnsMatch = $sendConnector.SmartHosts -eq 0 -and ($sendConnector.AddressSpaces.Address -like "*.mail.onmicrosoft.com").Count -gt 0
+
+        if ($dnsMatch -or $smartHostMatch) {
+            $exoConnector.Add($sendConnector)
+        }
+    }
+
+    $params = $baseParams + @{
+        Name    = "EXO Connector Present"
+        Details = ($exoConnector.Count -gt 0)
+    }
+    Add-AnalyzedResultInformation @params
+    $showMoreInfo = $false
+
+    foreach ($connector in $exoConnector) {
+        # Misconfigured connector is if TLSCertificateName is not set or CloudServicesMailEnabled not set to true
+        if ($connector.CloudEnabled -eq $false -or
+            $connector.CertificateDetails.TlsCertificateNameStatus -eq "TlsCertificateNameEmpty") {
+            $params = $baseParams + @{
+                Name                   = "Send Connector - $($connector.Identity.ToString())"
+                Details                = "Misconfigured to to send authenticated internal mail to M365." +
+                "`r`n`t`t`tCloudServicesMailEnabled: $($connector.CloudEnabled)" +
+                "`r`n`t`t`tTLSCertificateName set: $($connector.CertificateDetails.TlsCertificateNameStatus -ne "TlsCertificateNameEmpty")"
+                DisplayCustomTabNumber = 2
+                DisplayWriteType       = "Red"
+            }
+            Add-AnalyzedResultInformation @params
+            $showMoreInfo = $true
+        }
+
+        if ($connector.TlsAuthLevel -ne "DomainValidation") {
+            $params = $baseParams + @{
+                Name                   = "Send Connector - $($connector.Identity.ToString())"
+                Details                = "TlsAuthLevel not set to DomainValidation"
+                DisplayCustomTabNumber = 2
+                DisplayWriteType       = "Yellow"
+            }
+            Add-AnalyzedResultInformation @params
+            $showMoreInfo = $true
+        }
+
+        if ($connector.TlsDomain -ne "mail.protection.outlook.com") {
+            $params = $baseParams + @{
+                Name                   = "Send Connector - $($connector.Identity.ToString())"
+                Details                = "TLSDomain  not set to mail.protection.outlook.com"
+                DisplayCustomTabNumber = 2
+                DisplayWriteType       = "Yellow"
+            }
+            Add-AnalyzedResultInformation @params
+            $showMoreInfo = $true
+        }
+    }
+
+    if ($showMoreInfo) {
+        $params = $baseParams + @{
+            Details                = "More Information: https://aka.ms/HC-ExoConnectorIssue"
+            DisplayWriteType       = "Yellow"
+            DisplayCustomTabNumber = 2
+        }
+        Add-AnalyzedResultInformation @params
+    }
 }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -290,7 +290,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             $connector.CertificateDetails.TlsCertificateNameStatus -eq "TlsCertificateNameEmpty") {
             $params = $baseParams + @{
                 Name                   = "Send Connector - $($connector.Identity.ToString())"
-                Details                = "Misconfigured to to send authenticated internal mail to M365." +
+                Details                = "Misconfigured to send authenticated internal mail to M365." +
                 "`r`n`t`t`tCloudServicesMailEnabled: $($connector.CloudEnabled)" +
                 "`r`n`t`t`tTLSCertificateName set: $($connector.CertificateDetails.TlsCertificateNameStatus -ne "TlsCertificateNameEmpty")"
                 DisplayCustomTabNumber = 2

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -300,10 +300,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             $showMoreInfo = $true
         }
 
-        if ($connector.TlsAuthLevel -ne "DomainValidation") {
+        if ($connector.TlsAuthLevel -ne "DomainValidation" -and
+            $connector.TlsAuthLevel -ne "CertificateValidation") {
             $params = $baseParams + @{
                 Name                   = "Send Connector - $($connector.Identity.ToString())"
-                Details                = "TlsAuthLevel not set to DomainValidation"
+                Details                = "TlsAuthLevel not set to CertificateValidation or DomainValidation"
                 DisplayCustomTabNumber = 2
                 DisplayWriteType       = "Yellow"
             }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -117,8 +117,9 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "EXO Connector Present" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -117,8 +117,9 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Credential Guard Enabled" $false
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "EXO Connector Present" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -119,8 +119,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "NodeRunner.exe memory limit" "0 MB" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
+            TestObjectMatch "EXO Connector Present" "True" # Custom EXO Connector with no TlsDomain TlsAuthLevel
 
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 14
         }
 
         It "Display Results - Security Settings" {

--- a/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
+++ b/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
@@ -16,7 +16,7 @@ These are now being flagged as an issue due to some recent changes within Exchan
 
 Some additional configuration concerns are also warned about if one of the following is true:
 
-- TLSAuthLevel is not set to `DomainValidation`
+- TLSAuthLevel is not set to `CertificateValidation` or `DomainValidation`
 - TLSDomain is not set to `mail.protection.outlook.com`
 
 ## Included in HTML Report?

--- a/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
+++ b/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
@@ -1,0 +1,30 @@
+# Exchange Online Connector Check
+
+This is a simple check that can be performed from the Exchange On Prem side to quickly determine if the EXO connector is misconfigured. This does not completely determine if the connector is misconfigured, as Health Checker script is not designed to connect to Exchange Online to properly determine if everything is correctly configured for the way you want your mail flow to work.
+
+A Send Connector is determined to be destined for Exchange Online if one of the following is true:
+
+- SmartHost endpoint has a `*.mail.protection.outlook.com`
+- AddressSpaces address has a `*.mail.onmicrosoft.com`
+
+For those connectors, we then determine a misconfiguration if one of the following is true:
+
+- TLSCertificateName is not set
+- CloudServicesMailEnabled is not set to true
+
+These are now being flagged as an issue due to some recent changes within Exchange Online.
+
+Some additional configuration concerns are also warned about if one of the following is true:
+
+- TLSAuthLevel is not set to `DomainValidation`
+- TLSDomain is not set to `mail.protection.outlook.com`
+
+## Included in HTML Report?
+
+Yes
+
+## Additional resources
+
+[Set up connectors to route mail between Microsoft 365 or Office 365 and your own email servers](https://learn.microsoft.com/exchange/mail-flow-best-practices/use-connectors-to-configure-mail-flow/set-up-connectors-to-route-mail)
+
+[Updated Requirements for SMTP Relay through Exchange Online](https://techcommunity.microsoft.com/t5/exchange-team-blog/updated-requirements-for-smtp-relay-through-exchange-online/ba-p/3851357)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - FindFrontEndActivity: Diagnostics/FindFrontEndActivity/FindFrontEndActivity.md
     - HealthChecker:
       - Diagnostics/HealthChecker/index.md
+      - ExoConnectorCheck: Diagnostics/HealthChecker/ExoConnectorCheck.md
       - MaintenanceCheck: Diagnostics/HealthChecker/ExchangeServerMaintenanceCheck.md
       - GCModeCheck: Diagnostics/HealthChecker/MAPIFrontEndAppPoolGCModeCheck.md
       - RebootPending: Diagnostics/HealthChecker/RebootPending.md


### PR DESCRIPTION
**Issue:**
Needing to call out basic issues with the EXO Connector if not created correctly, either done by HCW or custom. This is in preparation for some changes that are coming that will break sending Auth messages to M365. 

**Fix:**

Where the following condition is true, this is determined that it is an EXO Send Connector:

* Send connector is using a *.mail.protection.outlook.com smart host
 or
* Send connector is using DNS routing to *.mail.onmicrosoft.com

The connector is misconfigured if the following requirements are not met:

* TLSCertificateName is set
* CloudServicesMailEnabled is True

A warning if the following requirements are not met:

* TLSAuthLevel is not set
* TLSDomain is set to mail.protection.outlook.com


Resolved #1976

**Validation:**
Lab Tested/Pester

