### PR TITLE
Address Edge Server Issue with noderunner.exe.config

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -141,6 +141,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
 
         # Only need to display a particular list all the time. Don't need every config that we want to possibly look at for issues.
         $alwaysDisplayConfigs = @("EdgeTransport.exe.config")
+        $skipEdgeOnlyConfigs = @("noderunner.exe.config")
         $keyList = $exchangeInformation.ApplicationConfigFileStatus.Keys | Sort-Object
 
         foreach ($configKey in $keyList) {
@@ -149,6 +150,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             $fileName = $configStatus.FileName
             $writeType = "Green"
             [string]$writeValue = $configStatus.Present
+
+            if ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $true -and
+                $skipEdgeOnlyConfigs -contains $fileName) {
+                continue
+            }
 
             if (-not $configStatus.Present) {
                 $writeType = "Red"

--- a/Shared/Get-FileContentInformation.ps1
+++ b/Shared/Get-FileContentInformation.ps1
@@ -29,11 +29,19 @@ function Get-FileContentInformation {
                 param($FileLocations)
                 $results = @{}
                 foreach ($fileLocation in $FileLocations) {
+                    $present = (Test-Path $fileLocation)
+
+                    if ($present) {
+                        $content = Get-Content $fileLocation -Raw
+                    } else {
+                        $content = $null
+                    }
+
                     $obj = [PSCustomObject]@{
-                        Present  = ((Test-Path $fileLocation))
+                        Present  = $present
                         FileName = ([IO.Path]::GetFileName($fileLocation))
                         FilePath = $fileLocation
-                        Content  = (Get-Content $fileLocation -Raw)
+                        Content  = $content
                     }
 
                     $results.Add($fileLocation, $obj)


### PR DESCRIPTION
**Issue:**
When running HealthChecker on an Edge Server, we added this check within #1953. However, didn't properly exclude Edge Servers. 

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/b0f6b740-d413-44a8-b1b5-49b2cde64320)

**Reason:**
Only run `Get-Content` if the file is there to avoid the error from occurring. 

**Validation:**
Lab tested

