### PR TITLE
Skip over Default Web Site PS for EP

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -411,8 +411,14 @@ function Invoke-AnalyzerExchangeInformation {
 
         # If any directory has a higher than expected configuration, we need to throw a warning
         # This will be detected by SupportedExtendedProtection being set to false, as we are set higher than expected/recommended value you will likely run into issues of some kind
+        # Skip over Default Web Site/Powershell if RequireSsl is not set.
         $notSupportedExtendedProtectionDirectories = $exchangeInformation.ExtendedProtectionConfig.ExtendedProtectionConfiguration |
-            Where-Object { $_.SupportedExtendedProtection -eq $false }
+            Where-Object { ($_.SupportedExtendedProtection -eq $false -and
+                    $_.VirtualDirectoryName -ne "Default Web Site/Powershell") -or
+                ($_.SupportedExtendedProtection -eq $false -and
+                $_.VirtualDirectoryName -eq "Default Web Site/Powershell" -and
+                $_.Configuration.SslSettings.RequireSsl -eq $true)
+            }
 
         if ($null -ne $notSupportedExtendedProtectionDirectories) {
             foreach ($entry in $notSupportedExtendedProtectionDirectories) {


### PR DESCRIPTION
**Issue:**
The original version of the EP Script did set Default Web Site for PowerShell to Require. Now we don't do that. Only call out an issue if EP isn't supported.

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/30068469-5ef9-4e7a-a313-c1a96b5e57e6)


**Fix:**
Skip over Default Web Site for PowerShell if RequireSsl is not set.

**Validation:**
Lab tested

