### PR TITLE
TlsDomain only needs to be set if TlsAuthLevel is set to DomainValidation

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -318,7 +318,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             $showMoreInfo = $true
         }
 
-        if ($connector.TlsDomain -ne "mail.protection.outlook.com") {
+        if ($connector.TlsDomain -ne "mail.protection.outlook.com" -and
+            $connector.TlsAuthLevel -eq "DomainValidation") {
             $params = $baseParams + @{
                 Name                   = "Send Connector - $($connector.Identity.ToString())"
                 Details                = "TLSDomain  not set to mail.protection.outlook.com"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -121,7 +121,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
             TestObjectMatch "EXO Connector Present" "True" # Custom EXO Connector with no TlsDomain TlsAuthLevel
 
-            $Script:ActiveGrouping.Count | Should -Be 14
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
 
         It "Display Results - Security Settings" {

--- a/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
+++ b/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
@@ -17,7 +17,7 @@ These are now being flagged as an issue due to some recent changes within Exchan
 Some additional configuration concerns are also warned about if one of the following is true:
 
 - TLSAuthLevel is not set to `CertificateValidation` or `DomainValidation`
-- TLSDomain is not set to `mail.protection.outlook.com`
+- TLSDomain is not set to `mail.protection.outlook.com` if TLSAuthLevel is set to `DomainValidation`
 
 ## Included in HTML Report?
 


### PR DESCRIPTION
**Issue:**
Customer has reported that they have `TlsAuthLevel` set to `CertificateValidation`. HealthChecker is calling out a problem with `TlsDomain` as this is not set. However, that is an acceptable configuration. 


**Fix:**
Only throw warning about `TlsDomain` if `TlsAuthLevel` is not set to `DomainValidation`

Resolved #1999 

**Validation:**
Pester

