### PR TITLE
handle 3rd IIS site not fully configured

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -384,7 +384,12 @@ function Invoke-AnalyzerIISInformation {
 
     $iisWebSettings | ForEach-Object {
         $key = if ($null -ne $_.FriendlyName) { $_.FriendlyName } else { $_.Name }
-        $iisWebConfigContent.Add($key, $_.ConfigurationFileInfo.Content)
+
+        if ($null -ne $key) {
+            $iisWebConfigContent.Add($key, $_.ConfigurationFileInfo.Content)
+        } else {
+            Write-Verbose "Failed to set Key for iisWebConfigContent hashtable because it was null."
+        }
     }
 
     $ruleParams = @{

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebSite.ps1
@@ -131,6 +131,12 @@ function Get-IISWebSite {
             }
         }
 
+        $physicalPath = [string]::Empty
+
+        if (-not ([string]::IsNullOrEmpty($site.physicalPath))) {
+            $physicalPath = $site.physicalPath.Replace("%windir%", $env:windir).Replace("%SystemDrive%", $env:SystemDrive)
+        }
+
         $returnList.Add([PSCustomObject]@{
                 Name                       = $site.Name
                 Id                         = $site.Id
@@ -148,7 +154,7 @@ function Get-IISWebSite {
                 Collection                 = $site.collection
                 ApplicationPool            = $site.applicationPool
                 EnabledProtocols           = $site.enabledProtocols
-                PhysicalPath               = $site.physicalPath.Replace("%windir%", $env:windir).Replace("%SystemDrive%", $env:SystemDrive)
+                PhysicalPath               = $physicalPath
                 ConfigurationFileInfo      = [PSCustomObject]@{
                     Location = $configurationFilePath
                     Content  = $webConfigContent


### PR DESCRIPTION
**Issue:**
Customer was unable to run HealthChecker because it would get into a state where we try to process a 3rd IIS Site and then particular attributes where not there causing a problem. 

Various errors that we addressed. 

```
Exchange websites detected: Default Web Site, Exchange Back End, Admin_EAC
Calling: Invoke-ScriptBlockHandler
Description: Get-IISWebSite
Running Script Block Locally with argument list
Working on Site: Default Web Site
No Hsts via custom header configuration detected
Working on Site: Exchange Back End
No Hsts via custom header configuration detected
Working on Site: 
No Hsts via custom header configuration detected
Failed to run Invoke-ScriptBlockHandler - Get-IISWebSite
Calling: 
Error Excluded Count: 7
Error Count: 7
 : Es ist nicht möglich, eine Methode für einen Ausdruck aufzurufen, der den NULL hat.
Inner Exception:    bei System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   bei Invoke-ScriptBlockHandler<Process>(Closure , FunctionContext )
Position Message: In C:\HealthChecker.ps1:11241 Zeichen:9
+         $returnList.Add([PSCustomObject]@{
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: bei Get-IISWebSite, C:\HealthChecker.ps1: Zeile 11241
bei Invoke-ScriptBlockHandler<Process>, C:\HealthChecker.ps1: Zeile 523
bei Get-ExchangeServerIISSettings<Process>, C:\HealthChecker.ps1: Zeile 11626
bei Get-ExchangeInformation<Process>, C:\HealthChecker.ps1: Zeile 13061
bei Get-HealthCheckerExchangeServer<Process>, C:\HealthChecker.ps1: Zeile 14814
bei Get-HealthCheckerData, C:\HealthChecker.ps1: Zeile 15561
bei Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: Zeile 15647
bei <ScriptBlock><End>, C:\HealthChecker.ps1: Zeile 16458
bei <ScriptBlock>, <Keine Datei>: Zeile 1
```

```
Failed to Health Checker against ExchangeServerName
Calling: Invoke-CatchActions
Error Excluded Count: 9
Error Count: 9
 : Ausnahme beim Aufrufen von "Add" mit 2 Argument(en):  "Der Schlüssel darf nicht NULL sein.
Parametername: key"
Inner Exception:    bei System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   bei System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   bei System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   bei System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   bei System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   bei System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   bei System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Object[] args)
   bei System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   bei System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   bei System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   bei System.Management.Automation.ScriptBlock.InvokeUsingCmdlet(Cmdlet contextCmdlet, Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Object[] args)
   bei Microsoft.PowerShell.Commands.ForEachObjectCommand.ProcessRecord()
   bei System.Management.Automation.CommandProcessor.ProcessRecord()
Position Message: In C:\HealthChecker.ps1:4780 Zeichen:9
+         $iisWebConfigContent.Add($key, $_.ConfigurationFileInfo.Conte ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: bei <ScriptBlock>, C:\HealthChecker.ps1: Zeile 4780
bei Invoke-AnalyzerIISInformation, C:\HealthChecker.ps1: Zeile 4778
bei Invoke-AnalyzerEngine, C:\HealthChecker.ps1: Zeile 8753
bei Get-HealthCheckerData, C:\HealthChecker.ps1: Zeile 15566
bei Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: Zeile 15647
bei <ScriptBlock><End>, C:\HealthChecker.ps1: Zeile 16458
bei <ScriptBlock>, <Keine Datei>: Zeile 1
Failed Server List: ExchangeServerName
```


**Reason:**
Need to be able to complete the script. 

**Fix:**

Added null checks where required. 

**Validation:**
Customer tested out results. 

