### PR TITLE
Reference to MonitorAuthCertificate added if EMS was not properly detected

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -243,6 +243,7 @@ begin {
             exit
         } elseif (-not($exchangeShell.EMS)) {
             Write-Warning "This script requires to be run inside of Exchange Management Shell. Please run on an Exchange Management Server or an Exchange Server with Exchange Management Shell."
+            Write-Warning "If the script was already executed via Exchange Management Shell, check your Auth Certificate by using the following script: https://aka.ms/MonitorExchangeAuthCertificate"
             exit
         }
 


### PR DESCRIPTION
**Issue:**
We see many reports from customers who can't run the script because of an invalid Auth Certificate.

**Reason:**
Auth Certificate is expired or doesn't exist and EMS detection fails due to not working SDS.

**Fix:**
Show a note that the MonitorExchangeAuthCertificate should be run

**Validation:**
Lab

