### PR TITLE
ExtendedProtectionManagement script fails when run against servers which are in a different (sub-)domain

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ConfigurationAction/Invoke-RollbackIPFiltering.ps1
@@ -163,7 +163,7 @@ function Invoke-RollbackIPFiltering {
 
             Write-Verbose ("Calling Invoke-ScriptBlockHandler on Server {0} with Arguments Site: {1}, VDir: {2}" -f $Server.Name, $Site, $VDir)
             Write-Verbose ("Restoring previous state for Server {0}" -f $Server.Name)
-            $resultsInvoke = Invoke-ScriptBlockHandler -ComputerName $Server.Name -ScriptBlock $RollbackIPFiltering -ArgumentList $ScriptBlockArgs
+            $resultsInvoke = Invoke-ScriptBlockHandler -ComputerName $Server.FQDN -ScriptBlock $RollbackIPFiltering -ArgumentList $ScriptBlockArgs
 
             if ($null -eq $resultsInvoke) {
                 $line = "Server Unreachable: Unable to rollback IP filtering rules on server $($Server.Name)."

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExchangeServerIPs.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExchangeServerIPs.ps1
@@ -37,7 +37,8 @@ function Get-ExchangeServerIPs {
             Write-Progress @progressParams
 
             $IpsFound = $false
-            $HostNetworkInfo = Get-AllNicInformation -ComputerName $Server.Name -ComputerFQDN $Server.FQDN
+            # TODO: Refactor Get-AllNicInformation function to get rid of the duplicate ComputerName / FQDN logic
+            $HostNetworkInfo = Get-AllNicInformation -ComputerName $Server.FQDN
             if ($null -ne $HostNetworkInfo) {
                 if ($null -ne $HostNetworkInfo.IPv4Addresses) {
                     foreach ($address in $HostNetworkInfo.IPv4Addresses) {

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -42,7 +42,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
             Write-Verbose "$($progressParams.Status)"
 
             $params = @{
-                ComputerName         = $server.Fqdn
+                ComputerName         = $server.FQDN
                 IsClientAccessServer = $server.IsClientAccessServer
                 IsMailboxServer      = $server.IsMailboxServer
                 ExcludeEWS           = $SkipEWS
@@ -59,16 +59,18 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 $progressParams.Status = "$baseStatus TLS Settings"
                 Write-Progress @progressParams
                 Write-Verbose "$($progressParams.Status)"
-                $tlsSettings = Get-AllTlsSettings -MachineName $server.Fqdn
+                $tlsSettings = Get-AllTlsSettings -MachineName $server.FQDN
             } else {
                 Write-Verbose "Server doesn't appear to be online. Skipped over trying to get the TLS settings"
             }
 
             $results.Add([PSCustomObject]@{
-                    ComputerName                    = $server.ToString()
+                    ComputerName                    = $server.Name
+                    FQDN                            = $server.FQDN
                     ExtendedProtectionConfiguration = $extendedProtectionConfiguration
                     TlsSettings                     = [PSCustomObject]@{
-                        ComputerName = $server.ToString()
+                        ComputerName = $server.Name
+                        FQDN         = $server.FQDN
                         Settings     = $tlsSettings
                     }
                     ServerOnline                    = $extendedProtectionConfiguration.ServerConnected

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -59,7 +59,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 $progressParams.Status = "$baseStatus TLS Settings"
                 Write-Progress @progressParams
                 Write-Verbose "$($progressParams.Status)"
-                $tlsSettings = Get-AllTlsSettings -MachineName $server
+                $tlsSettings = Get-AllTlsSettings -MachineName $server.Fqdn
             } else {
                 Write-Verbose "Server doesn't appear to be online. Skipped over trying to get the TLS settings"
             }

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -75,6 +75,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
 
                 if ($null -eq $lmValue) { $lmValue = 3 }
 
+                Write-Verbose "Server $($server.FQDN) LmCompatibilityLevel set to $lmValue"
                 $registryValues.SuppressExtendedProtection = $epValue
                 $registryValues.LmCompatibilityLevel = $lmValue
             } else {

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -3,6 +3,7 @@
 
 . $PSScriptRoot\..\..\..\..\Shared\TLS\Get-AllTlsSettings.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-ExtendedProtectionConfiguration.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
 
 # This function is used to collect the required information needed to determine if a server is ready for Extended Protection
 function Get-ExtendedProtectionPrerequisitesCheck {
@@ -39,6 +40,10 @@ function Get-ExtendedProtectionPrerequisitesCheck {
             $progressParams.Status = "$baseStatus Extended Protection Configuration"
             Write-Progress @progressParams
             $tlsSettings = $null
+            $registryValues = @{
+                SuppressExtendedProtection = 0
+                LmCompatibilityLevel       = $null
+            }
             Write-Verbose "$($progressParams.Status)"
 
             $params = @{
@@ -60,6 +65,18 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 Write-Progress @progressParams
                 Write-Verbose "$($progressParams.Status)"
                 $tlsSettings = Get-AllTlsSettings -MachineName $server.FQDN
+                $params = @{
+                    MachineName = $server.FQDN
+                    SubKey      = "SYSTEM\CurrentControlSet\Control\Lsa"
+                }
+
+                $lmValue = Get-RemoteRegistryValue @params -GetValue "LmCompatibilityLevel" -ValueType "DWord"
+                [int]$epValue = Get-RemoteRegistryValue @params -GetValue "SuppressExtendedProtection"
+
+                if ($null -eq $lmValue) { $lmValue = 3 }
+
+                $registryValues.SuppressExtendedProtection = $epValue
+                $registryValues.LmCompatibilityLevel = $lmValue
             } else {
                 Write-Verbose "Server doesn't appear to be online. Skipped over trying to get the TLS settings"
             }
@@ -73,6 +90,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                         FQDN         = $server.FQDN
                         Settings     = $tlsSettings
                     }
+                    RegistryValue                   = $registryValues
                     ServerOnline                    = $extendedProtectionConfiguration.ServerConnected
                 })
         }

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -42,7 +42,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
             Write-Verbose "$($progressParams.Status)"
 
             $params = @{
-                ComputerName         = $server.ToString()
+                ComputerName         = $server.Fqdn
                 IsClientAccessServer = $server.IsClientAccessServer
                 IsMailboxServer      = $server.IsMailboxServer
                 ExcludeEWS           = $SkipEWS

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Invoke-ExtendedProtectionTlsPrerequisitesCheck.ps1
@@ -39,7 +39,7 @@ function Invoke-ExtendedProtectionTlsPrerequisitesCheck {
             $netKeys = @("NETv4") # Only think we care about v4
 
             foreach ($serverTls in $TlsSettingsList) {
-                $currentServer = $serverTls.ComputerName
+                $currentServer = $serverTls.FQDN
                 $tlsSettings = $serverTls.Settings
                 # Removing TLS 1.3 here to avoid it being displayed
                 $tlsSettings.Registry.TLS.Remove("1.3")

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -555,7 +555,7 @@ begin {
 
                     if ($null -ne $suppressExtendedProtectionSet) {
                         Write-Verbose "Some Online Server have the Suppress Extended Protection Set"
-                        $requiredServers = $suppressExtendedProtectionSet | Where-Object { $_.ComputerName -in $serverNames -or $_.ExtendedProtectionConfiguration.ExtendedProtectionConfigured -eq $true }
+                        $requiredServers = $suppressExtendedProtectionSet | Where-Object { $_.FQDN -in $serverNames -or $_.ExtendedProtectionConfiguration.ExtendedProtectionConfigured -eq $true }
                         Write-Host "SYSTEM\CurrentControlSet\Control\Lsa\SuppressExtendedProtection is set on the following servers: $([string]::Join(", ", $suppressExtendedProtectionSet.ComputerName))" -ForegroundColor Red
 
                         if ($null -ne $requiredServers) {

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -120,6 +120,7 @@ begin {
     . $PSScriptRoot\..\..\..\Shared\OutputOverrides\Write-Progress.ps1
     . $PSScriptRoot\..\..\..\Shared\OutputOverrides\Write-Verbose.ps1
     . $PSScriptRoot\..\..\..\Shared\OutputOverrides\Write-Warning.ps1
+    . $PSScriptRoot\..\..\..\Security\src\Shared\Get-ProcessedServerList.ps1
     . $PSScriptRoot\..\..\..\Shared\ScriptUpdateFunctions\Test-ScriptVersion.ps1
     . $PSScriptRoot\..\..\..\Shared\Confirm-Administrator.ps1
     . $PSScriptRoot\..\..\..\Shared\Confirm-ExchangeShell.ps1
@@ -276,9 +277,20 @@ begin {
             Show-Disclaimer @params
         }
 
-        Write-Verbose ("Running Get-ExchangeServer to get list of all exchange servers")
-        Set-ADServerSettings -ViewEntireForest $true
-        $ExchangeServers = Get-ExchangeServer | Where-Object { $_.AdminDisplayVersion -like "Version 15*" -and $_.ServerRole -ne "Edge" }
+        $processParams = @{
+            ExchangeServerNames              = $includeExchangeServerNames
+            SkipExchangeServerNames          = $SkipExchangeServerNames
+            CheckOnline                      = $true
+            DisableGetExchangeServerFullList = $false # We want a list of all Exchange Servers as we need to run the prerequisites check against them
+        }
+
+        $processedExchangeServers = Get-ProcessedServerList @processParams
+
+        Write-Verbose "Get a list of all Exchange servers to perform prerequisites check against"
+        $ExchangeServersPrerequisitesCheckSettingsCheck = $processedExchangeServers.GetExchangeServer | Where-Object { $_.AdminDisplayVersion -like "Version 15*" -and $_.ServerRole -ne "Edge" }
+
+        Write-Verbose "Get a list of all Exchange servers which are online and not skipped"
+        $ExchangeServers = $processedExchangeServers.ValidExchangeServer | Where-Object { $_.AdminDisplayVersion -like "Version 15*" -and $_.ServerRole -ne "Edge" }
 
         if ($FindExchangeServerIPAddresses) {
             Get-ExchangeServerIPs -OutputFilePath $OutputFilePath -ExchangeServers $ExchangeServers
@@ -289,18 +301,12 @@ begin {
             return
         }
 
-        $ExchangeServersPrerequisitesCheckSettingsCheck = $ExchangeServers
-
         if ($null -ne $includeExchangeServerNames -and $includeExchangeServerNames.Count -gt 0) {
-            Write-Verbose "Running only on servers: $([string]::Join(", " ,$includeExchangeServerNames))"
-            $ExchangeServers = $ExchangeServers | Where-Object { ($_.Name -in $includeExchangeServerNames) -or ($_.FQDN -in $includeExchangeServerNames) }
+            Write-Verbose "Running only on servers: $([string]::Join(", " ,$processedExchangeServers.ValidExchangeServer))"
         }
 
         if ($null -ne $SkipExchangeServerNames -and $SkipExchangeServerNames.Count -gt 0) {
             Write-Verbose "Skipping servers: $([string]::Join(", ", $SkipExchangeServerNames))"
-
-            # Remove all the servers present in the SkipExchangeServerNames list
-            $ExchangeServers = $ExchangeServers | Where-Object { ($_.Name -notin $SkipExchangeServerNames) -and ($_.FQDN -notin $SkipExchangeServerNames) }
         }
 
         if ($null -eq $ExchangeServers) {
@@ -311,7 +317,7 @@ begin {
         if ($ValidateTypeSelected) {
             # Validate mitigation
             $ExchangeServers = $ExchangeServers | Where-Object { -not ((Get-ExchangeBuildVersionInformation -AdminDisplayVersion $_.AdminDisplayVersion).BuildVersion.Major -eq 15 -and (Get-ExchangeBuildVersionInformation -AdminDisplayVersion $_.AdminDisplayVersion).BuildVersion.Minor -eq 0 -and $_.IsClientAccessServer) }
-            Invoke-ValidateMitigation -ExchangeServers $ExchangeServers.Name -ipRangeAllowListRules $ipRangeAllowListRules -SiteVDirLocations $SiteVDirLocations
+            Invoke-ValidateMitigation -ExchangeServers $ExchangeServers.FQDN -ipRangeAllowListRules $ipRangeAllowListRules -SiteVDirLocations $SiteVDirLocations
         }
 
         if ($ShowExtendedProtection) {
@@ -319,7 +325,7 @@ begin {
             $extendedProtectionConfigurations = New-Object 'System.Collections.Generic.List[object]'
             foreach ($server in $ExchangeServers) {
                 $params = @{
-                    ComputerName         = $server.Fqdn
+                    ComputerName         = $server.FQDN
                     IsClientAccessServer = $server.IsClientAccessServer
                     IsMailboxServer      = $server.IsMailboxServer
                     ExcludeEWS           = $SkipEWS
@@ -374,8 +380,6 @@ begin {
 
             if ($null -ne $prerequisitesCheck) {
                 Write-Host ""
-                # Remove the down servers from $ExchangeServers list.
-                $downServerName = New-Object 'System.Collections.Generic.List[string]'
                 $onlineSupportedServers = New-Object 'System.Collections.Generic.List[object]'
                 $unsupportedServers = New-Object 'System.Collections.Generic.List[string]'
                 $unsupportedAndConfiguredServers = New-Object 'System.Collections.Generic.List[object]'
@@ -384,11 +388,10 @@ begin {
                         $_.ExtendedProtectionConfiguration.SupportedVersionForExtendedProtection -eq $false) {
                         $unsupportedAndConfiguredServers.Add($_)
                     } elseif ($_.ExtendedProtectionConfiguration.SupportedVersionForExtendedProtection -eq $false) {
-                        $unsupportedServers.Add($_.ComputerName)
+                        $unsupportedServers.Add($_.FQDN)
                     } elseif ($_.ServerOnline) {
+                        # For now, keep this as a failsafe
                         $onlineSupportedServers.Add($_)
-                    } else {
-                        $downServerName.Add($_.ComputerName)
                     }
                 }
 
@@ -397,7 +400,7 @@ begin {
                 # However, if there is an unsupported version of Exchange that does have EP enabled,
                 # We need to prompt to the admin stating that we are going to revert the change to get back to a supported state.
                 Write-Verbose ("Found the following servers configured for EP and Unsupported: " +
-                    "$(if ($unsupportedAndConfiguredServers.Count -eq 0) { 'None' } else {[string]::Join(", " ,$unsupportedAndConfiguredServers.ComputerName)})")
+                    "$(if ($unsupportedAndConfiguredServers.Count -eq 0) { 'None' } else {[string]::Join(", " ,$unsupportedAndConfiguredServers.FQDN)})")
 
                 Write-Verbose ("Found the following servers that not supported to configure EP and not enabled: " +
                     "$(if ($unsupportedServers.Count -eq 0) { 'None' } else {[string]::Join(", " ,$unsupportedServers)})")
@@ -417,7 +420,7 @@ begin {
 
                 if ($unsupportedServers.Count -gt 0) {
 
-                    $serversInList = @($ExchangeServers | Where-Object { $($_.Name -in $unsupportedServers) })
+                    $serversInList = @($ExchangeServers | Where-Object { $($_.FQDN -in $unsupportedServers) })
 
                     if ($serversInList.Count -gt 0) {
                         $line = "The following servers are not the minimum required version to support Extended Protection. Please update them, or re-run the script without including them in the list: $($serversInList -Join " ")"
@@ -429,23 +432,22 @@ begin {
                     Write-Verbose "The following servers are unsupported but not included in the list to configure: $([string]::Join(", " ,$unsupportedServers))"
                 }
 
-                if ($downServerName.Count -gt 0) {
-                    $line = "Removing the following servers from the list to configure because we weren't able to reach them: $([string]::Join(", " ,$downServerName))"
+                if (($processedExchangeServers.OfflineExchangeServer).Count -gt 0) {
+                    $line = "Removing the following servers from the list to configure because we weren't able to reach them: $([string]::Join(", " ,$processedExchangeServers.OfflineExchangeServerFqdn))"
                     Write-Verbose $line
                     Write-Warning $line
-                    $ExchangeServers = $ExchangeServers | Where-Object { $($_.Name -notin $downServerName) }
                     Write-Host ""
                 }
 
                 # Only need to set the server names for the ones we are trying to configure and the ones that are up.
                 # Also need to add Unsupported Configured EP servers to the list.
                 $serverNames = New-Object 'System.Collections.Generic.List[string]'
-                $ExchangeServers | ForEach-Object { $serverNames.Add($_.Name) }
+                $ExchangeServers | ForEach-Object { $serverNames.Add($_.FQDN) }
 
                 if ($unsupportedAndConfiguredServers.Count -gt 0) {
                     $unsupportedAndConfiguredServers |
-                        Where-Object { $_.ComputerName -notin $serverNames } |
-                        ForEach-Object { $serverNames.Add($_.ComputerName) }
+                        Where-Object { $_.FQDN -notin $serverNames } |
+                        ForEach-Object { $serverNames.Add($_.FQDN) }
                 }
 
                 # If there aren't any servers to check against for TLS settings, bypass this check.
@@ -502,11 +504,11 @@ begin {
                         # before displaying an issue, make sure that the online supported servers & EP enabled server have the correct settings.
                         $epEnabledServerList = New-Object 'System.Collections.Generic.List[string]'
                         $epEnabledServers = $onlineSupportedServers | Where-Object { $_.ExtendedProtectionConfiguration.ExtendedProtectionConfigured -eq $true }
-                        $wantedCheckAgainst = $onlineSupportedServers | Where-Object { $_.ComputerName -in $serverNames }
+                        $wantedCheckAgainst = $onlineSupportedServers | Where-Object { $_.FQDN -in $serverNames }
                         $checkAgainst = $onlineSupportedServers |
                             Where-Object {
                                 $_.ExtendedProtectionConfiguration.ExtendedProtectionConfigured -eq $true -or
-                                $_.ComputerName -in $serverNames
+                                $_.FQDN -in $serverNames
                             }
 
                         $wantedResults = Invoke-ExtendedProtectionTlsPrerequisitesCheck -TlsConfiguration $wantedCheckAgainst.TlsSettings
@@ -521,7 +523,7 @@ begin {
                                     foreach ($list in $entry.List) {
                                         Write-Host "System affected: $list" -ForegroundColor Red
 
-                                        if ($list -in $epEnabledServers.ComputerName) {
+                                        if ($list -in $epEnabledServers.FQDN) {
                                             $epEnabledServerList.Add($list)
                                         }
                                     }
@@ -595,6 +597,7 @@ begin {
                             Write-Verbose "Server $($server.Name) is not a CAS. Skipping over the RPC FE Check."
                             continue
                         }
+                        # Get-OutlookAnywhere doesn't return the FQDN so we must compare the ComputerName instead
                         $rpcSettings = $outlookAnywhere | Where-Object { $_.ServerName -eq $server.Name }
 
                         if ($null -eq $rpcSettings) {
@@ -617,7 +620,7 @@ begin {
                         Write-Warning "The following cmdlet should be run against each of the servers: Set-OutlookAnywhere 'SERVERNAME\RPC (Default Web Site)' -SSLOffloading `$false -InternalClientsRequireSsl `$true -ExternalClientsRequireSsl `$true"
                         $prerequisitesCheckFailed = $true
                     } elseif ($rpcNullServers.Count -gt 0) {
-                        Write-Warning "Failed to find the following servers RPC (Default Web Site) for SSL Offloading: $([string]::Join(", " ,$rpcFailedServers))"
+                        Write-Warning "Failed to find the following servers RPC (Default Web Site) for SSL Offloading: $([string]::Join(", " ,$rpcNullServers))"
                         Write-Warning $canNotConfigure
                         $prerequisitesCheckFailed = $true
                     }
@@ -653,7 +656,7 @@ begin {
             # for onlineSupportedServers, because the are online and we want to revert them.
             $unsupportedAndConfiguredServers | ForEach-Object { $onlineSupportedServers.Add($_) }
             $extendedProtectionConfigurations = ($onlineSupportedServers |
-                    Where-Object { $_.ComputerName -in $serverNames }).ExtendedProtectionConfiguration
+                    Where-Object { $_.FQDN -in $serverNames }).ExtendedProtectionConfiguration
 
             if ($null -ne $extendedProtectionConfigurations) {
                 Invoke-ConfigureExtendedProtection -ExtendedProtectionConfigurations $extendedProtectionConfigurations
@@ -664,7 +667,7 @@ begin {
             if ($ConfigureMitigationSelected) {
                 # Apply rules
                 $ExchangeServers = $ExchangeServers | Where-Object { -not ((Get-ExchangeBuildVersionInformation -AdminDisplayVersion $_.AdminDisplayVersion).BuildVersion.Major -eq 15 -and (Get-ExchangeBuildVersionInformation -AdminDisplayVersion $_.AdminDisplayVersion).BuildVersion.Minor -eq 0 -and $_.IsClientAccessServer) }
-                Invoke-ConfigureMitigation -ExchangeServers $ExchangeServers.Name -ipRangeAllowListRules $ipRangeAllowListRules -SiteVDirLocations $SiteVDirLocations
+                Invoke-ConfigureMitigation -ExchangeServers $ExchangeServers.FQDN -ipRangeAllowListRules $ipRangeAllowListRules -SiteVDirLocations $SiteVDirLocations
             }
         } elseif ($RollbackSelected) {
             Write-Host "Prerequisite check will be skipped due to Rollback"
@@ -679,7 +682,7 @@ begin {
                 }
 
                 Show-Disclaimer @params
-                Invoke-RollbackExtendedProtection -ExchangeServers $ExchangeServers
+                Invoke-RollbackExtendedProtection -ExchangeServers $ExchangeServers.FQDN
             }
 
             if ($RollbackRestoreConfiguration) {
@@ -696,7 +699,7 @@ begin {
 
                 $inputList = New-Object System.Collections.Generic.List[object]
                 $ExchangeServers | ForEach-Object { $inputList.Add([PSCustomObject]@{
-                            ServerName = $_.Fqdn
+                            ServerName = $_.FQDN
                             Restore    = ([PSCustomObject]@{
                                     FileName     = "ConfigureExtendedProtection"
                                     PassedWhatIf = $WhatIfPreference
@@ -714,7 +717,7 @@ begin {
             return
         } elseif ($DisableExtendedProtection) {
             # Disabling EP for all the servers provided in the list.
-            Invoke-DisableExtendedProtection -ExchangeServers $ExchangeServers
+            Invoke-DisableExtendedProtection -ExchangeServers $ExchangeServers.FQDN
         }
     } finally {
         Write-Host "Do you have feedback regarding the script? Please email ExToolsFeedback@microsoft.com."

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -319,7 +319,7 @@ begin {
             $extendedProtectionConfigurations = New-Object 'System.Collections.Generic.List[object]'
             foreach ($server in $ExchangeServers) {
                 $params = @{
-                    ComputerName         = $server.ToString()
+                    ComputerName         = $server.Fqdn
                     IsClientAccessServer = $server.IsClientAccessServer
                     IsMailboxServer      = $server.IsMailboxServer
                     ExcludeEWS           = $SkipEWS
@@ -696,7 +696,7 @@ begin {
 
                 $inputList = New-Object System.Collections.Generic.List[object]
                 $ExchangeServers | ForEach-Object { $inputList.Add([PSCustomObject]@{
-                            ServerName = $_.Name
+                            ServerName = $_.Fqdn
                             Restore    = ([PSCustomObject]@{
                                     FileName     = "ConfigureExtendedProtection"
                                     PassedWhatIf = $WhatIfPreference

--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -549,6 +549,26 @@ begin {
                         }
                     }
 
+                    # SuppressExtendedProtection Check
+                    $suppressExtendedProtectionSet = $onlineSupportedServers |
+                        Where-Object { $_.RegistryValue.SuppressExtendedProtection -ne 0 }
+
+                    if ($null -ne $suppressExtendedProtectionSet) {
+                        Write-Verbose "Some Online Server have the Suppress Extended Protection Set"
+                        $requiredServers = $suppressExtendedProtectionSet | Where-Object { $_.ComputerName -in $serverNames -or $_.ExtendedProtectionConfiguration.ExtendedProtectionConfigured -eq $true }
+                        Write-Host "SYSTEM\CurrentControlSet\Control\Lsa\SuppressExtendedProtection is set on the following servers: $([string]::Join(", ", $suppressExtendedProtectionSet.ComputerName))" -ForegroundColor Red
+
+                        if ($null -ne $requiredServers) {
+                            Write-Host "At least one server is trying to enable Extended Protection or already has Extended Protection Enabled." -ForegroundColor Red
+                            Write-Host "Having this key set to anything other than 0 will break Extended Protection functionality" -ForegroundColor Red
+                            $prerequisitesCheckFailed = $true
+                        } else {
+                            Write-Host "None of the servers that have this key set has Extended Protection enabled or trying to configure it." -ForegroundColor Yellow
+                            Write-Host "This may cause issues with Extended Protection server to server communication, therefore it is recommended to address as soon as possible." -ForegroundColor Yellow
+                            # Don't believe this should be a scenario where we need to block configuration from occurring
+                        }
+                    }
+
                     # now that we passed the TLS PrerequisitesCheck, now we need to do the RPC VDir check for SSLOffloading.
                     $rpcFailedServers = New-Object 'System.Collections.Generic.List[string]'
                     $rpcNullServers = New-Object 'System.Collections.Generic.List[string]'

--- a/Security/src/Shared/Get-ProcessedServerList.ps1
+++ b/Security/src/Shared/Get-ProcessedServerList.ps1
@@ -17,8 +17,6 @@ function Get-ProcessedServerList {
 
         [bool]$DisableGetExchangeServerFullList,
 
-        [bool]$ViewEntireForest = $true,
-
         [string]$MinimumSU
     )
     begin {
@@ -43,11 +41,6 @@ function Get-ProcessedServerList {
         $outdatedBuildExchangeServerFqdn = New-Object System.Collections.Generic.List[string]
     }
     process {
-        if ($ViewEntireForest) {
-            Write-Verbose "ViewEntireForest set to true"
-            Set-ADServerSettings -ViewEntireForest $true
-        }
-
         if ($DisableGetExchangeServerFullList) {
             # If we don't want to get all the Exchange Servers, then we need to make sure the list of Servers are Exchange Server
             if ($null -eq $ExchangeServerNames -or


### PR DESCRIPTION
**Issue:**
It was reported that the `ExtendedProtectionManagement.ps1` script didn't work properly if it's executed from a machine which is in a different domain (e.g., `management.it.contoso.com`) than the Exchange server (e.g., `exchangesrv01.sub.domain.contoso.com`).

**Reason:**
Name resolution fails since we use the flat name instead of Fqdn which leads to these issues.

**Fix:**
Improve the script to use `Fqdn` instead of `Name`.
Resolve #2018 

**Validation:**
Validated by the affected customer but should be validated internally as well.

