### PR TITLE
SourceSideValidations SDS related requirements added

### DIFF
--- a/docs/PublicFolders/SourceSideValidations.md
+++ b/docs/PublicFolders/SourceSideValidations.md
@@ -4,6 +4,10 @@ Download the latest release: [SourceSideValidations.ps1](https://github.com/micr
 
 This script performs pre-migration public folder checks for Exchange 2013, 2016, and 2019. For Exchange 2010, please use previous script found [here](https://www.microsoft.com/en-us/download/details.aspx?id=100414).
 
+## Requirements
+
+The script must be run from an elevated Exchange Management Shell (EMS) command prompt on an Exchange Server running the Mailbox role. The script cannot be run on an Exchange Management Tools-only machine when [Configure certificate signing of PowerShell serialization payloads in Exchange Server](https://learn.microsoft.com/exchange/plan-and-deploy/post-installation-tasks/security-best-practices/exchange-serialization-payload-sign?view=exchserver-2019) is used.
+
 ## Syntax
 
 ```powershell


### PR DESCRIPTION
**Issue:**
`./SourceSideValidations.ps1 -RemoveInvalidPermissions` will fail to run if it was executed on an Exchange Server that has the management tools installed but no other Exchange Server role.

**Reason / Fix:**
In `-RemoveInvalidPermission`, we pipe the invalid permissions to `Remove-PublicFolderClientPermission` precisely because there is no other way to remove invalid permissions. You cannot specify them by user, because the user is an orphaned SID. Specifying that as the `-User` parameter causes us to try to look up the SID to validate the parameter, which fails, so the cmdlet does not succeed. Thus, `ForEach-Object` will not work here. 
  
Piping the bad permission to `Remove-PublicFolderClientPermission` is the only way to get it to treat that orphaned object as valid input. 
  
`SourceSideValidations.ps1` will need to be run from a Mailbox role going forward, at least if you need to use the `-RemoveInvalidPermissions` switch.