### PR TITLE
RoutingTableLogPath could be null in some scenarios

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -41,7 +41,7 @@ function Get-TransportLoggingInformationPerServer {
             if (($Version -eq 15 -and (-not ($MailboxOnly))) -or $Version -ge 16) {
                 $data = Get-FrontendTransportService -Identity $Server
 
-                if ($Version -ne 15) {
+                if ($Version -ne 15 -and (-not([string]::IsNullOrEmpty($data.RoutingTableLogPath)))) {
                     $routingTableLogPath = $data.RoutingTableLogPath.ToString()
                 }
 
@@ -59,7 +59,7 @@ function Get-TransportLoggingInformationPerServer {
                 #Mailbox Transport Layer
                 $data = Get-MailboxTransportService -Identity $Server
 
-                if ($Version -ne 15) {
+                if ($Version -ne 15 -and (-not([string]::IsNullOrEmpty($data.RoutingTableLogPath)))) {
                     $routingTableLogPath = $data.RoutingTableLogPath.ToString()
                 }
 


### PR DESCRIPTION
**Issue:**
unable to do `ToString()` when it is null causing a script failure

**Reason:**
This prevents the script from being able to execute. 

**Fix:**
Do a null check prior to calling `ToString()`.

**Validation:**
Customer verified

