### PR TITLE
Extended Protection Updates

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -75,6 +75,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
 
                 if ($null -eq $lmValue) { $lmValue = 3 }
 
+                Write-Verbose "Server $($server.FQDN) LmCompatibilityLevel set to $lmValue"
                 $registryValues.SuppressExtendedProtection = $epValue
                 $registryValues.LmCompatibilityLevel = $lmValue
             } else {

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -3,6 +3,7 @@
 
 . $PSScriptRoot\..\..\..\..\Shared\TLS\Get-AllTlsSettings.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-ExtendedProtectionConfiguration.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
 
 # This function is used to collect the required information needed to determine if a server is ready for Extended Protection
 function Get-ExtendedProtectionPrerequisitesCheck {
@@ -39,6 +40,10 @@ function Get-ExtendedProtectionPrerequisitesCheck {
             $progressParams.Status = "$baseStatus Extended Protection Configuration"
             Write-Progress @progressParams
             $tlsSettings = $null
+            $registryValues = @{
+                SuppressExtendedProtection = 0
+                LmCompatibilityLevel       = $null
+            }
             Write-Verbose "$($progressParams.Status)"
 
             $params = @{
@@ -60,6 +65,18 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 Write-Progress @progressParams
                 Write-Verbose "$($progressParams.Status)"
                 $tlsSettings = Get-AllTlsSettings -MachineName $server.FQDN
+                $params = @{
+                    MachineName = $server.FQDN
+                    SubKey      = "SYSTEM\CurrentControlSet\Control\Lsa"
+                }
+
+                $lmValue = Get-RemoteRegistryValue @params -GetValue "LmCompatibilityLevel" -ValueType "DWord"
+                [int]$epValue = Get-RemoteRegistryValue @params -GetValue "SuppressExtendedProtection"
+
+                if ($null -eq $lmValue) { $lmValue = 3 }
+
+                $registryValues.SuppressExtendedProtection = $epValue
+                $registryValues.LmCompatibilityLevel = $lmValue
             } else {
                 Write-Verbose "Server doesn't appear to be online. Skipped over trying to get the TLS settings"
             }
@@ -73,6 +90,7 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                         FQDN         = $server.FQDN
                         Settings     = $tlsSettings
                     }
+                    RegistryValue                   = $registryValues
                     ServerOnline                    = $extendedProtectionConfiguration.ServerConnected
                 })
         }


### PR DESCRIPTION
**Issue:**
We want to block EP from being configured if this key `SuppressExtendedProtection` is set.

Also needed to address issue with Outlook Anywhere not blocking on already configured EP servers.

**Reason:**
Avoid customers from enabling EP anymore without addressing the problems. 

Resolved #2033 

**Validation:**
Lab tested

