### PR TITLE
Correctly identify Cred Guard being enabled

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -112,7 +112,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
 
     if (-not ($credGuardUnknown)) {
         # CredentialGuardCimInstance is an array type and not sure if we can have multiple here, so just going to loop thru and handle it this way.
-        $credGuardRunning = $null -ne ($osInformation.CredentialGuardCimInstance | Where-Object { $_ -ne 0 })
+        $credGuardRunning = $null -ne ($osInformation.CredentialGuardCimInstance | Where-Object { $_ -eq 1 })
     }
 
     $displayValue = $credentialGuardValue = $osInformation.RegistryValues.CredentialGuard -ne 0 -or $credGuardRunning


### PR DESCRIPTION
**Issue:**
See #2069 

**Reason:**
Other values doesn't mean that Cred Guard is enabled. 

**Fix:**
Only look for a value of `1` for the WMI Call

Resolved #2069 

**Validation:**
Customer verified

