### PR TITLE
Improve handling of ECC certificates in HealthChecker

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
@@ -106,7 +106,10 @@ function Invoke-AnalyzerSecurityExchangeCertificates {
             Add-AnalyzedResultInformation @params
         }
 
-        if ($certificate.PublicKeySize -lt 2048) {
+        # We show the 'Key Size' if a certificate is RSA or DSA based but not for ECC certificates where it would be displayed with a value of 0
+        # More information: https://stackoverflow.com/questions/32873851/load-a-certificate-using-x509certificate2-with-ecc-public-key
+        if ($certificate.PublicKeySize -lt 2048 -and
+            -not($certificate.IsEccCertificate)) {
             $params = $baseParams + @{
                 Name                   = "Key size"
                 Details                = $certificate.PublicKeySize
@@ -121,7 +124,7 @@ function Invoke-AnalyzerSecurityExchangeCertificates {
                 DisplayCustomTabNumber = 2
             }
             Add-AnalyzedResultInformation @params
-        } else {
+        } elseif (-not($certificate.IsEccCertificate)) {
             $params = $baseParams + @{
                 Name                   = "Key size"
                 Details                = $certificate.PublicKeySize
@@ -129,6 +132,13 @@ function Invoke-AnalyzerSecurityExchangeCertificates {
             }
             Add-AnalyzedResultInformation @params
         }
+
+        $params = $baseParams + @{
+            Name                   = "ECC Certificate"
+            Details                = $certificate.IsEccCertificate
+            DisplayCustomTabNumber = 2
+        }
+        Add-AnalyzedResultInformation @params
 
         if ($certificate.SignatureHashAlgorithmSecure -eq 1) {
             $shaDisplayWriteType = "Yellow"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -210,6 +210,7 @@ function Get-ExchangeServerCertificates {
                                 FriendlyName                   = $certFriendlyName
                                 Thumbprint                     = $cert.Thumbprint
                                 PublicKeySize                  = $cert.PublicKey.Key.KeySize
+                                IsEccCertificate               = $cert.PublicKey.Oid.Value -eq "1.2.840.10045.2.1" # WellKnownOid for ECC
                                 SignatureAlgorithm             = $certSignatureAlgorithm
                                 SignatureHashAlgorithm         = $certSignatureHashAlgorithm
                                 SignatureHashAlgorithmSecure   = $certSignatureHashAlgorithmSecure

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeServerCertificates.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeServerCertificates.Tests.ps1
@@ -49,6 +49,7 @@ Describe "Testing Get-ExchangeServerCertificates.ps1" {
             $results[0].SignatureHashAlgorithmSecure | Should -Be 1
             $results[0].IsSanCertificate | Should -Be $false
             $results[0].PublicKeySize | Should -Be 2048
+            $results[0].IsEccCertificate | Should -Be $false
         }
 
         It "Valid SAN Certificate (using weak SHA1 Hash Algorithm) Detected" {
@@ -61,12 +62,14 @@ Describe "Testing Get-ExchangeServerCertificates.ps1" {
             $results[1].IsSanCertificate | Should -Be $true
             ($results[1].Namespaces).Count | Should -Be 2
             $results[1].PublicKeySize | Should -Be 2048
+            $results[1].IsEccCertificate | Should -Be $false
         }
 
         It "Valid Certificate (using strong SHA256 Hash Algorithm) Detected" {
             $results[3].FriendlyName | Should -Be "WMSvc-SHA2-WIN-CTD3L0RGen4"
             $results[3].Thumbprint | Should -Be "3341CEAF3DF4D3A9527EC98BDD53C54ECC3E0620"
             $results[3].PublicKeySize | Should -Be 2048
+            $results[3].IsEccCertificate | Should -Be $false
             $results[3].SignatureAlgorithm | Should -Be "sha256RSA"
             $results[3].SignatureHashAlgorithm | Should -Be "sha256"
             $results[3].SignatureHashAlgorithmSecure | Should -Be 2

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -129,7 +129,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "SMB1 Installed" "True" -WriteType "Red"
             TestObjectMatch "SMB1 Blocked" "False" -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 85
+            $Script:ActiveGrouping.Count | Should -Be 88
         }
 
         It "Display Results - Security Vulnerability" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -132,7 +132,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Pattern service" "Unreachable`r`n`t`tMore information: https://aka.ms/HelpConnectivityEEMS" -WriteType "Yellow"
             TestObjectMatch "Telemetry enabled" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 99
+            $Script:ActiveGrouping.Count | Should -Be 102
         }
 
         It "Display Results - Security Vulnerability" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -140,7 +140,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "AES256-CBC Protected Content Support" "Not Supported Build" -WriteType "Red"
             TestObjectMatch "SerializedDataSigning Enabled" "Unsupported Version" -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 81
+            $Script:ActiveGrouping.Count | Should -Be 84
         }
 
         It "Display Results - Security Vulnerability" {


### PR DESCRIPTION
**Issue:**
Starting with the Exchange Server April 2024 Hotfix Update (HU), ECC certificates can be used on Exchange Server 2016 and Exchange Server 2019. The latest version of HealthChecker shows an error if an ECC certificate is assigned to an Exchange service (e.g., SMTP).

**Reason:**
The `PublicKeySize` is returned as `0` for ECC certificates (by design).

**Fix:**
Detect if a certificate is an ECC certificate. We do this by comparing the `WellKnownOid`. If it matches `1.2.840.10045.2.1` (Oid for ECC), we exclude the Key Size check for this certificate.

**Validation:**
Lab

