### PR TITLE
Add HC Script Version to vulnerability report

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerData.ps1
@@ -96,7 +96,12 @@ function Get-HealthCheckerData {
 
         try {
             Invoke-SetOutputInstanceLocation -Server $serverName -FileName "HealthChecker" -IncludeServerName $true
-            Write-HostLog "Exchange Health Checker version $BuildVersion"
+
+            if (-not $Script:VulnerabilityReport) {
+                # avoid having vulnerability report having a txt file with nothing in it besides the Exchange Health Checker Version
+                Write-HostLog "Exchange Health Checker version $BuildVersion"
+            }
+
             $HealthObject = Get-HealthCheckerExchangeServer -ServerName $serverNameParam
             $HealthObject.OrganizationInformation = $organizationInformation
 

--- a/Diagnostics/HealthChecker/Features/Invoke-VulnerabilityReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Invoke-VulnerabilityReport.ps1
@@ -8,6 +8,18 @@
 function Invoke-VulnerabilityReport {
 
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+    $currentErrors = $Error.Count
+
+    if ((-not $SkipVersionCheck) -and
+                (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/HC-VersionsUrl")) {
+        Write-Yellow "Script was updated. Please rerun the command."
+        return
+    } else {
+        $Script:DisplayedScriptVersionAlready = $true
+        Write-Green "Exchange Health Checker version $BuildVersion"
+    }
+
+    Invoke-ErrorCatchActionLoopFromIndex $currentErrors
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
     Set-ADServerSettings -ViewEntireForest $true
     $exchangeServers = @(Get-ExchangeServer)

--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -14,7 +14,8 @@ function Get-ErrorsThatOccurred {
     }
 
     if ($Error.Count -gt 0) {
-        Write-Grey(" "); Write-Grey(" ")
+        Write-Host ""
+        Write-Host ""
         function Write-Errors {
             Write-Verbose "`r`n`r`nErrors that occurred that wasn't handled"
 


### PR DESCRIPTION
**Issue:**
Didn't have the version number of the script in the vulnerability report.


**Fix:**
Added the script update feature and log the version number to the debug log. Avoid having empty files when running the vulnerability report. 

Resolved #1993 

**Validation:**
Lab tested

