### PR TITLE
Add NET Framework Support link to report

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -173,6 +173,13 @@ function Invoke-AnalyzerOsInformation {
             }
             Add-AnalyzedResultInformation @params
         }
+
+        $params = $baseParams + @{
+            Details                = "More Information: https://aka.ms/HC-NetFrameworkSupport"
+            DisplayWriteType       = "Yellow"
+            DisplayCustomTabNumber = 2
+        }
+        Add-AnalyzedResultInformation @params
     }
 
     $displayValue = [string]::Empty


### PR DESCRIPTION
**Reason:**
This was requested by a customer to have a link in the report when .NET is not at the correct version.

**Fix:**
Created an aka.ms link and added it to the report. 

Resolved #2014 

**Validation:**
Lab tested

