### PR TITLE
Add Server Member Check on the Exchange Server for AD Membership and Local Administrator

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -239,6 +239,68 @@ function Invoke-AnalyzerExchangeInformation {
         Add-AnalyzedResultInformation @params
     }
 
+    if ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $false) {
+        Write-Verbose "Determining Server Group Membership"
+
+        $params = $baseParams + @{
+            Name             = "Exchange Server Membership"
+            Details          = "Passed"
+            DisplayWriteType = "Grey"
+        }
+
+        if ($null -ne $exchangeInformation.ComputerMembership -and
+            $null -ne $HealthServerObject.OrganizationInformation.WellKnownSecurityGroups) {
+            $localGroupList = $HealthServerObject.OrganizationInformation.WellKnownSecurityGroups |
+                Where-Object { $_.WellKnownName -eq "Exchange Trusted Subsystem" }
+            # By Default, I also have Managed Availability Servers and Exchange Install Domain Servers.
+            # But not sure what issue they would cause if we don't have the server as a member, leaving out for now
+            $adGroupList = $HealthServerObject.OrganizationInformation.WellKnownSecurityGroups |
+                Where-Object { $_.WellKnownName -in @("Exchange Trusted Subsystem", "Exchange Servers") }
+            $displayMissingGroups = New-Object System.Collections.Generic.List[string]
+
+            foreach ($localGroup in $localGroupList) {
+                if (($null -eq ($exchangeInformation.ComputerMembership.LocalGroupMember.SID | Where-Object { $_.ToString() -eq $localGroup.SID } ))) {
+                    $displayMissingGroups.Add("$($localGroup.WellKnownName) - Local System Membership")
+                }
+            }
+
+            foreach ($adGroup in $adGroupList) {
+                if (($null -eq ($exchangeInformation.ComputerMembership.ADGroupMembership.SID | Where-Object { $_.ToString() -eq $adGroup.SID }))) {
+                    $displayMissingGroups.Add("$($adGroup.WellKnownName) - AD Group Membership")
+                }
+            }
+
+            if ($displayMissingGroups.Count -ge 1) {
+                $params.DisplayWriteType = "Red"
+                $params.Details = "Failed"
+                Add-AnalyzedResultInformation @params
+
+                foreach ($group in $displayMissingGroups) {
+                    $params = $baseParams + @{
+                        Details                = $group
+                        TestingName            = $group
+                        DisplayWriteType       = "Red"
+                        DisplayCustomTabNumber = 2
+                    }
+                    Add-AnalyzedResultInformation @params
+                }
+
+                $params = $baseParams + @{
+                    Details                = "More Information: https://aka.ms/HC-ServerMembership"
+                    DisplayWriteType       = "Yellow"
+                    DisplayCustomTabNumber = 2
+                }
+                Add-AnalyzedResultInformation @params
+            } else {
+                Add-AnalyzedResultInformation @params
+            }
+        } else {
+            $params.DisplayWriteType = "Yellow"
+            $params.Details = "Unknown - Wasn't able to get the Computer Membership information"
+            Add-AnalyzedResultInformation @params
+        }
+    }
+
     if ($exchangeInformation.BuildInformation.MajorVersion -eq "Exchange2013" -and
         $exchangeInformation.GetExchangeServer.IsClientAccessServer -eq $true) {
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -195,6 +195,21 @@ function Get-ExchangeInformation {
             Component = "ResourceThrottling"
         }
         $edgeTransportResourceThrottling = Get-ExchangeDiagnosticInformation @params
+
+        if ($getExchangeServer.IsEdgeServer -eq $false) {
+            $params = @{
+                ComputerName           = $Server
+                ScriptBlockDescription = "Getting Exchange Server Members"
+                CatchActionFunction    = ${Function:Invoke-CatchActions}
+                ScriptBlock            = {
+                    [PSCustomObject]@{
+                        LocalGroupMember  = (Get-LocalGroupMember -SID "S-1-5-32-544")
+                        ADGroupMembership = (Get-ADPrincipalGroupMembership (Get-ADComputer $env:COMPUTERNAME).DistinguishedName)
+                    }
+                }
+            }
+            $computerMembership = Invoke-ScriptBlockHandler @params
+        }
     } end {
 
         Write-Verbose "Exiting: Get-ExchangeInformation"
@@ -219,6 +234,7 @@ function Get-ExchangeInformation {
             FIPFSUpdateIssue                         = $FIPFSUpdateIssue
             AES256CBCInformation                     = $aes256CbcDetails
             FileContentInformation                   = $fileContentInformation
+            ComputerMembership                       = $computerMembership
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetADPrincipalGroupMembership.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/GetADPrincipalGroupMembership.xml
@@ -1,0 +1,173 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.ActiveDirectory.Management.ADGroup</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPrincipal</T>
+      <T>Microsoft.ActiveDirectory.Management.ADObject</T>
+      <T>Microsoft.ActiveDirectory.Management.ADEntity</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPropertyCollection</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>CN=Domain Computers,CN=Users,DC=Solo,DC=net</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Domain Computers,CN=Users,DC=Solo,DC=net</S>
+      <Obj N="GroupCategory" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupCategory</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupScope</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Domain Computers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">a265b2c2-546e-407b-ad71-db09915a10f7</G>
+      <S N="SamAccountName">Domain Computers</S>
+      <Obj N="SID" RefId="3">
+        <TN RefId="3">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1824353829-339629374-102541804-515</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1824353829-339629374-102541804</S>
+          <S N="Value">S-1-5-21-1824353829-339629374-102541804-515</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="4">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</S>
+      <Obj N="GroupCategory" RefId="5">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="6">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">0483eec8-edd9-4e86-9991-d4e53a57668b</G>
+      <S N="SamAccountName">Exchange Servers</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1824353829-339629374-102541804-1118</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1824353829-339629374-102541804</S>
+          <S N="Value">S-1-5-21-1824353829-339629374-102541804-1118</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="8">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</S>
+      <Obj N="GroupCategory" RefId="9">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="10">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Trusted Subsystem</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">03db4cb0-2e2f-424d-9b67-3aced8c2e7d1</G>
+      <S N="SamAccountName">Exchange Trusted Subsystem</S>
+      <Obj N="SID" RefId="11">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1824353829-339629374-102541804-1119</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1824353829-339629374-102541804</S>
+          <S N="Value">S-1-5-21-1824353829-339629374-102541804-1119</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="12">
+    <TNRef RefId="0" />
+    <ToString>CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=net</S>
+      <Obj N="GroupCategory" RefId="13">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="14">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Managed Availability Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">f7cb65c0-1f58-4504-a698-68fa0ae76505</G>
+      <S N="SamAccountName">Managed Availability Servers</S>
+      <Obj N="SID" RefId="15">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1824353829-339629374-102541804-1120</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1824353829-339629374-102541804</S>
+          <S N="Value">S-1-5-21-1824353829-339629374-102541804-1120</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="16">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=net</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=net</S>
+      <Obj N="GroupCategory" RefId="17">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="18">
+        <TNRef RefId="2" />
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Exchange Install Domain Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">fc1e7024-4d8b-4702-b171-a26997425da7</G>
+      <S N="SamAccountName">$A31000-HSHK6J896T3O</S>
+      <Obj N="SID" RefId="19">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1824353829-339629374-102541804-1130</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1824353829-339629374-102541804</S>
+          <S N="Value">S-1-5-21-1824353829-339629374-102541804-1130</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetADPrincipalGroupMembership.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetADPrincipalGroupMembership.xml
@@ -1,0 +1,173 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.ActiveDirectory.Management.ADGroup</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPrincipal</T>
+      <T>Microsoft.ActiveDirectory.Management.ADObject</T>
+      <T>Microsoft.ActiveDirectory.Management.ADEntity</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPropertyCollection</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>CN=Domain Computers,CN=Users,DC=Solo,DC=local</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Domain Computers,CN=Users,DC=Solo,DC=local</S>
+      <Obj N="GroupCategory" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupCategory</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupScope</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Domain Computers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">5917534d-4588-4ff6-bcb4-21cf859365d3</G>
+      <S N="SamAccountName">Domain Computers</S>
+      <Obj N="SID" RefId="3">
+        <TN RefId="3">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-515</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-515</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="4">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</S>
+      <Obj N="GroupCategory" RefId="5">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="6">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">88c1b02a-889e-4e68-9144-35c7bf16cc62</G>
+      <S N="SamAccountName">Exchange Servers</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1119</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1119</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="8">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</S>
+      <Obj N="GroupCategory" RefId="9">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="10">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Trusted Subsystem</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">7e140c1d-73eb-420e-89b0-aab50d68792f</G>
+      <S N="SamAccountName">Exchange Trusted Subsystem</S>
+      <Obj N="SID" RefId="11">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1120</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1120</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="12">
+    <TNRef RefId="0" />
+    <ToString>CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=local</S>
+      <Obj N="GroupCategory" RefId="13">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="14">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Managed Availability Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">e8dd8191-c1d1-4ff1-bcab-3e60f64b9dd0</G>
+      <S N="SamAccountName">Managed Availability Servers</S>
+      <Obj N="SID" RefId="15">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1121</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1121</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="16">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=local</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=local</S>
+      <Obj N="GroupCategory" RefId="17">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="18">
+        <TNRef RefId="2" />
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Exchange Install Domain Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">a0b88da6-d349-4f56-ab3f-f84eb1be5026</G>
+      <S N="SamAccountName">$E31000-7TOIPJH3L7D0</S>
+      <Obj N="SID" RefId="19">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1134</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1134</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetLocalGroupMember.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/GetLocalGroupMember.xml
@@ -1,0 +1,102 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.LocalPrincipal</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>SOLO\Domain Admins</ToString>
+    <Props>
+      <S N="Name">SOLO\Domain Admins</S>
+      <Obj N="SID" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-512</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-512</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.PowerShell.Commands.PrincipalSource</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="3">
+    <TNRef RefId="0" />
+    <ToString>SOLO\Exchange Trusted Subsystem</ToString>
+    <Props>
+      <S N="Name">SOLO\Exchange Trusted Subsystem</S>
+      <Obj N="SID" RefId="4">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1120</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1120</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="5">
+        <TNRef RefId="2" />
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="6">
+    <TNRef RefId="0" />
+    <ToString>SOLO\Organization Management</ToString>
+    <Props>
+      <S N="Name">SOLO\Organization Management</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-3966804624-2143408355-627260183-1105</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3966804624-2143408355-627260183</S>
+          <S N="Value">S-1-5-21-3966804624-2143408355-627260183-1105</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="8">
+        <TNRef RefId="2" />
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="9">
+    <TNRef RefId="0" />
+    <ToString>SOLO-E16A\Administrator</ToString>
+    <Props>
+      <S N="Name">SOLO-E16A\Administrator</S>
+      <Obj N="SID" RefId="10">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-2158029244-1591623683-1362856639-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-2158029244-1591623683-1362856639</S>
+          <S N="Value">S-1-5-21-2158029244-1591623683-1362856639-500</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="11">
+        <TNRef RefId="2" />
+        <ToString>Local</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="ObjectClass">User</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetADPrincipalGroupMembership.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetADPrincipalGroupMembership.xml
@@ -1,0 +1,173 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.ActiveDirectory.Management.ADGroup</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPrincipal</T>
+      <T>Microsoft.ActiveDirectory.Management.ADObject</T>
+      <T>Microsoft.ActiveDirectory.Management.ADEntity</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPropertyCollection</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>CN=Domain Computers,CN=Users,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Domain Computers,CN=Users,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupCategory</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupScope</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Domain Computers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">23db7c70-d0b5-4475-b573-7f17e3d64043</G>
+      <S N="SamAccountName">Domain Computers</S>
+      <Obj N="SID" RefId="3">
+        <TN RefId="3">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-515</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-515</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="4">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="5">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="6">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">b67f89a9-ed61-49b2-a26c-1bb4b5142101</G>
+      <S N="SamAccountName">Exchange Servers</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1119</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1119</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="8">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Trusted Subsystem,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="9">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="10">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Trusted Subsystem</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">769c386c-8ca6-479f-b3af-92e2d3f222bf</G>
+      <S N="SamAccountName">Exchange Trusted Subsystem</S>
+      <Obj N="SID" RefId="11">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1120</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1120</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="12">
+    <TNRef RefId="0" />
+    <ToString>CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="13">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="14">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Managed Availability Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">35cf4379-eb47-40ec-99bf-6a6c8c01245e</G>
+      <S N="SamAccountName">Managed Availability Servers</S>
+      <Obj N="SID" RefId="15">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1121</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1121</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="16">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="17">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="18">
+        <TNRef RefId="2" />
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Exchange Install Domain Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">030f144f-b669-4dc2-9af0-bbd6072bc60a</G>
+      <S N="SamAccountName">$E31000-7QVSVIUEUPLE</S>
+      <Obj N="SID" RefId="19">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1134</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1134</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetADPrincipalGroupMembership2.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetADPrincipalGroupMembership2.xml
@@ -1,0 +1,143 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.ActiveDirectory.Management.ADGroup</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPrincipal</T>
+      <T>Microsoft.ActiveDirectory.Management.ADObject</T>
+      <T>Microsoft.ActiveDirectory.Management.ADEntity</T>
+      <T>Microsoft.ActiveDirectory.Management.ADPropertyCollection</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>CN=Domain Computers,CN=Users,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Domain Computers,CN=Users,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="1">
+        <TN RefId="1">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupCategory</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.ActiveDirectory.Management.ADGroupScope</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Domain Computers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">23db7c70-d0b5-4475-b573-7f17e3d64043</G>
+      <S N="SamAccountName">Domain Computers</S>
+      <Obj N="SID" RefId="3">
+        <TN RefId="3">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-515</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-515</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="4">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="5">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="6">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Exchange Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">b67f89a9-ed61-49b2-a26c-1bb4b5142101</G>
+      <S N="SamAccountName">Exchange Servers</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1119</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1119</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="8">
+    <TNRef RefId="0" />
+    <ToString>CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Managed Availability Servers,OU=Microsoft Exchange Security Groups,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="9">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="10">
+        <TNRef RefId="2" />
+        <ToString>Universal</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="name">Managed Availability Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">35cf4379-eb47-40ec-99bf-6a6c8c01245e</G>
+      <S N="SamAccountName">Managed Availability Servers</S>
+      <Obj N="SID" RefId="11">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1121</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1121</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+  <Obj RefId="12">
+    <TNRef RefId="0" />
+    <ToString>CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=com</ToString>
+    <Props>
+      <S N="distinguishedName">CN=Exchange Install Domain Servers,CN=Microsoft Exchange System Objects,DC=Solo,DC=com</S>
+      <Obj N="GroupCategory" RefId="13">
+        <TNRef RefId="1" />
+        <ToString>Security</ToString>
+        <I32>1</I32>
+      </Obj>
+      <Obj N="GroupScope" RefId="14">
+        <TNRef RefId="2" />
+        <ToString>Global</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="name">Exchange Install Domain Servers</S>
+      <S N="objectClass">group</S>
+      <G N="objectGUID">030f144f-b669-4dc2-9af0-bbd6072bc60a</G>
+      <S N="SamAccountName">$E31000-7QVSVIUEUPLE</S>
+      <Obj N="SID" RefId="15">
+        <TNRef RefId="3" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1134</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1134</S>
+        </Props>
+      </Obj>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetLocalGroupMember.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetLocalGroupMember.xml
@@ -1,0 +1,102 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.LocalPrincipal</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>SOLO\Domain Admins</ToString>
+    <Props>
+      <S N="Name">SOLO\Domain Admins</S>
+      <Obj N="SID" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-512</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-512</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.PowerShell.Commands.PrincipalSource</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="3">
+    <TNRef RefId="0" />
+    <ToString>SOLO\Exchange Trusted Subsystem</ToString>
+    <Props>
+      <S N="Name">SOLO\Exchange Trusted Subsystem</S>
+      <Obj N="SID" RefId="4">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1120</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1120</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="5">
+        <TNRef RefId="2" />
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="6">
+    <TNRef RefId="0" />
+    <ToString>SOLO\Organization Management</ToString>
+    <Props>
+      <S N="Name">SOLO\Organization Management</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1105</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1105</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="8">
+        <TNRef RefId="2" />
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="9">
+    <TNRef RefId="0" />
+    <ToString>SOLO-E19A\Administrator</ToString>
+    <Props>
+      <S N="Name">SOLO-E19A\Administrator</S>
+      <Obj N="SID" RefId="10">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-895174743-3947352890-80968143-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-895174743-3947352890-80968143</S>
+          <S N="Value">S-1-5-21-895174743-3947352890-80968143-500</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="11">
+        <TNRef RefId="2" />
+        <ToString>Local</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="ObjectClass">User</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetLocalGroupMember2.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/GetLocalGroupMember2.xml
@@ -1,0 +1,80 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.LocalPrincipal</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>SOLO\Domain Admins</ToString>
+    <Props>
+      <S N="Name">SOLO\Domain Admins</S>
+      <Obj N="SID" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-512</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-512</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="2">
+        <TN RefId="2">
+          <T>Microsoft.PowerShell.Commands.PrincipalSource</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="3">
+    <TNRef RefId="0" />
+    <ToString>SOLO\Organization Management</ToString>
+    <Props>
+      <S N="Name">SOLO\Organization Management</S>
+      <Obj N="SID" RefId="4">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-1281225956-1072373970-2205875210-1105</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1281225956-1072373970-2205875210</S>
+          <S N="Value">S-1-5-21-1281225956-1072373970-2205875210-1105</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="5">
+        <TNRef RefId="2" />
+        <ToString>ActiveDirectory</ToString>
+        <I32>2</I32>
+      </Obj>
+      <S N="ObjectClass">Group</S>
+    </Props>
+  </Obj>
+  <Obj RefId="6">
+    <TNRef RefId="0" />
+    <ToString>SOLO-E19A\Administrator</ToString>
+    <Props>
+      <S N="Name">SOLO-E19A\Administrator</S>
+      <Obj N="SID" RefId="7">
+        <TNRef RefId="1" />
+        <ToString>S-1-5-21-895174743-3947352890-80968143-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-895174743-3947352890-80968143</S>
+          <S N="Value">S-1-5-21-895174743-3947352890-80968143-500</S>
+        </Props>
+      </Obj>
+      <Obj N="PrincipalSource" RefId="8">
+        <TNRef RefId="2" />
+        <ToString>Local</ToString>
+        <I32>1</I32>
+      </Obj>
+      <S N="ObjectClass">User</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -32,7 +32,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Internet Web Proxy" "Not Set"
             TestObjectMatch "Extended Protection Enabled (Any VDir)" $false
             TestObjectMatch "Setting Overrides Detected" $false
-            $Script:ActiveGrouping.Count | Should -Be 16
+            $Script:ActiveGrouping.Count | Should -Be 17
         }
 
         It "Display Results - Organization Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -32,7 +32,8 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Internet Web Proxy" "Not Set"
             TestObjectMatch "Extended Protection Enabled (Any VDir)" $false
             TestObjectMatch "Setting Overrides Detected" $false
-            $Script:ActiveGrouping.Count | Should -Be 14
+            TestObjectMatch "Exchange Server Membership" "Passed"
+            $Script:ActiveGrouping.Count | Should -Be 15
         }
 
         It "Display Results - Organization Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -32,7 +32,8 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Extended Protection Enabled (Any VDir)" $false
             TestObjectMatch "Setting Overrides Detected" $false
             TestObjectMatch "Out of Date" $true -WriteType "Red"
-            $Script:ActiveGrouping.Count | Should -Be 14
+            TestObjectMatch "Exchange Server Membership" "Passed"
+            $Script:ActiveGrouping.Count | Should -Be 15
         }
 
         It "Display Results - Organization Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -49,6 +49,8 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Mock Get-ExchangeDiagnosticInfo -ParameterFilter { $Process -eq "EdgeTransport" -and $Component -eq "ResourceThrottling" } `
                 -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeDiagnosticInfo_EdgeTransportResourceThrottling1.xml" }
             Mock Get-IISModules { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetIISModulesNoTokenCacheModule.xml" }
+            Mock Get-ADPrincipalGroupMembership { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetADPrincipalGroupMembership2.xml" }
+            Mock Get-LocalGroupMember { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetLocalGroupMember2.xml" }
             Mock Get-Service {
                 param(
                     [string]$ComputerName,
@@ -66,6 +68,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Setting Overrides Detected" $true
             TestObjectMatch "Extended Protection Enabled (Any VDir)" $true
             TestObjectMatch "Transport Back Pressure" "--ERROR-- The following resources are causing back pressure: DatabaseUsedSpace" -WriteType "Red"
+            TestObjectMatch "Exchange Server Membership" "Failed" -WriteType "Red"
+            TestObjectMatch "Exchange Trusted Subsystem - Local System Membership" "Exchange Trusted Subsystem - Local System Membership" -WriteType "Red"
+            TestObjectMatch "Exchange Trusted Subsystem - AD Group Membership" "Exchange Trusted Subsystem - AD Group Membership" -WriteType "Red"
         }
 
         It "Dependent Services" {

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -226,6 +226,10 @@ Mock Get-ExSetupFileVersionInfo {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\ExSetup.xml"
 }
 
+Mock Get-LocalGroupMember {
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetLocalGroupMember.xml"
+}
+
 # Do nothing
 Mock Invoke-CatchActions { }
 
@@ -272,6 +276,12 @@ function Get-DynamicDistributionGroup {
 function Get-IRMConfiguration {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetIrmConfiguration.xml"
 }
+
+function Get-ADPrincipalGroupMembership {
+    return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetADPrincipalGroupMembership.xml"
+}
+
+function Get-ADComputer { return $null }
 
 # virtual directory cmdlets to return null till we do actual checks against the vDirs.
 function Get-ActiveSyncVirtualDirectory { return $null }

--- a/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
+++ b/Shared/ActiveDirectoryFunctions/Get-ExchangeOtherWellKnownObjects.ps1
@@ -8,7 +8,7 @@ function Get-ExchangeOtherWellKnownObjects {
     param ()
 
     $otherWellKnownObjectIds = @{
-        "C2F9A9F9D6A1B74A9E068728F8F842EA" = "Organization Management"
+        "C262A929D691B74A9E068728F8F842EA" = "Organization Management"
         "DB72C41D49580A4DB304FE6981E56297" = "Recipient Management"
         "1A9E39D35ABE5747B979FFC0C6E5EA26" = "View-Only Organization Management"
         "45FA417B3574DC4E929BC4B059699792" = "Public Folder Management"

--- a/docs/Diagnostics/HealthChecker/ExchangeComputerMembership.md
+++ b/docs/Diagnostics/HealthChecker/ExchangeComputerMembership.md
@@ -1,0 +1,14 @@
+# Exchange Server Computer Membership
+
+### Description:
+
+Checks for the computer object to be members of the `Exchange Trusted Subsystem` and `Exchange Servers` security groups by default. It will also make sure the default local system account has the `Exchange Trusted Subsystem` a member of it as well in order to have the correct access to local system files.
+
+This check is done by using the ADModule with using the cmdlets `Get-LocalGroupMember -SID "S-1-5-32-544"` and running `Get-ADPrincipalGroupMembership (Get-ADComputer $env:COMPUTERNAME).DistinguishedName`
+
+If an issue is detected, the group will display with where the problem is located. Either `Local System Membership` if the group isn't part of the local system account or `AD Group Membership` if the computer object isn't a member of the group provided.
+
+
+**Included in HTML Report?**
+
+Yes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - IISWebConfigCheck: Diagnostics/HealthChecker/IISWebConfigCheck.md
       - HCScheduledTask: Diagnostics/HealthChecker/RunHCViaSchedTask.md
       - ADSiteCount: Diagnostics/HealthChecker/ADSiteCount.md
+      - ExchangeComputerMembership: Diagnostics/HealthChecker/ExchangeComputerMembership.md
     - ManagedAvailabilityTroubleshooter: Diagnostics/ManagedAvailabilityTroubleshooter.md
     - Test-ExchAVExclusions: Diagnostics/Test-ExchAVExclusions.md
   - Hybrid:


### PR DESCRIPTION
**Issue:**
Exchange Server Missing the required membership to properly function. 

**Reason:**
Call out when Exchange is not apart of the correct default groups in AD or in the local server admin group. 

**NOTE:** This does not work with Windows Server 2012 R2 or lower. Since this OS is unsupported, not going to worry about this. 

**Fix:**
Added the data collection for the membership that the server is apart of and the local server admin group. 

Resolved #1886 

**Validation:**
Lab tested and pester tested. 



