### PR TITLE
Handle exception in write to screen for Health Checker Report

### DIFF
--- a/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-Functions.ps1
@@ -40,14 +40,23 @@ function Write-HostLog ($message) {
 
 function Write-OutColumns($OutColumns) {
     if ($null -ne $OutColumns) {
-        $stringOutput = $null
-        $OutColumns.DisplayObject |
-            Out-Columns -Properties $OutColumns.SelectProperties `
-                -ColorizerFunctions $OutColumns.ColorizerFunctions `
-                -IndentSpaces $OutColumns.IndentSpaces `
-                -StringOutput ([ref]$stringOutput)
-        $stringOutput | Out-File ($Script:OutputFullPath) -Append
-        Write-DebugLog $stringOutput
+        try {
+            $stringOutput = $null
+            $params = @{
+                Properties         = $OutColumns.SelectProperties
+                ColorizerFunctions = $OutColumns.ColorizerFunctions
+                IndentSpaces       = $OutColumns.IndentSpaces
+                StringOutput       = ([ref]$stringOutput)
+            }
+            $OutColumns.DisplayObject | Out-Columns @params
+            $stringOutput | Out-File ($Script:OutputFullPath) -Append
+            Write-DebugLog $stringOutput
+        } catch {
+            # We do not want to call Invoke-CatchActions here because we want the issues reported.
+            Write-Verbose "Failed to export Out-Columns. Inner Exception: $_"
+            $s = $OutColumns.DisplayObject | Out-String
+            Write-DebugLog $s
+        }
     }
 }
 

--- a/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
+++ b/Diagnostics/HealthChecker/Writers/Write-ResultsToScreen.ps1
@@ -20,36 +20,48 @@ function Write-ResultsToScreen {
         Write-Verbose "Working on Key Group: $($keyGrouping.Name)"
         Write-Verbose "Total lines to write: $($ResultsToWrite[$keyGrouping].Count)"
 
-        if ($keyGrouping.DisplayGroupName) {
-            Write-Grey($keyGrouping.Name)
-            $dashes = [string]::empty
-            1..($keyGrouping.Name.Length) | ForEach-Object { $dashes = $dashes + "-" }
-            Write-Grey($dashes)
+        try {
+            if ($keyGrouping.DisplayGroupName) {
+                Write-Grey($keyGrouping.Name)
+                $dashes = [string]::empty
+                1..($keyGrouping.Name.Length) | ForEach-Object { $dashes = $dashes + "-" }
+                Write-Grey($dashes)
+            }
+
+            foreach ($line in $ResultsToWrite[$keyGrouping]) {
+                try {
+                    $tab = [string]::Empty
+
+                    if ($line.TabNumber -ne 0) {
+                        1..($line.TabNumber) | ForEach-Object { $tab = $tab + "`t" }
+                    }
+
+                    if ([string]::IsNullOrEmpty($line.Name)) {
+                        $displayLine = $line.DisplayValue
+                    } else {
+                        $displayLine = [string]::Concat($line.Name, ": ", $line.DisplayValue)
+                    }
+
+                    $writeValue = "{0}{1}" -f $tab, $displayLine
+                    switch ($line.WriteType) {
+                        "Grey" { Write-Grey($writeValue) }
+                        "Yellow" { Write-Yellow($writeValue) }
+                        "Green" { Write-Green($writeValue) }
+                        "Red" { Write-Red($writeValue) }
+                        "OutColumns" { Write-OutColumns($line.OutColumns) }
+                    }
+                } catch {
+                    # We do not want to call Invoke-CatchActions here because we want the issues reported.
+                    Write-Verbose "Failed inside the section loop writing. Writing out a blank line and continuing. Inner Exception: $_"
+                    Write-Grey ""
+                }
+            }
+
+            Write-Grey ""
+        } catch {
+            # We do not want to call Invoke-CatchActions here because we want the issues reported.
+            Write-Verbose "Failed in $($MyInvocation.MyCommand) outside section writing loop. Inner Exception: $_"
+            Write-Grey ""
         }
-
-        foreach ($line in $ResultsToWrite[$keyGrouping]) {
-            $tab = [string]::Empty
-
-            if ($line.TabNumber -ne 0) {
-                1..($line.TabNumber) | ForEach-Object { $tab = $tab + "`t" }
-            }
-
-            if ([string]::IsNullOrEmpty($line.Name)) {
-                $displayLine = $line.DisplayValue
-            } else {
-                $displayLine = [string]::Concat($line.Name, ": ", $line.DisplayValue)
-            }
-
-            $writeValue = "{0}{1}" -f $tab, $displayLine
-            switch ($line.WriteType) {
-                "Grey" { Write-Grey($writeValue) }
-                "Yellow" { Write-Yellow($writeValue) }
-                "Green" { Write-Green($writeValue) }
-                "Red" { Write-Red($writeValue) }
-                "OutColumns" { Write-OutColumns($line.OutColumns) }
-            }
-        }
-
-        Write-Grey("")
     }
 }


### PR DESCRIPTION
**Issue:**
When we start to write to the screen, continue to write if an exception occurs. More information see #1885 

**Reason:**
Should continue to write to the screen even after the exception. Log out the debug information and flag it as an issue so issues can come in still.

**Fix:**
Add `try` `catch` around the functions that handle the output information. 

Resolved #1885 

**Validation:**
Lab tested.

