### PR TITLE
Handle list writers starting at different index

### DIFF
--- a/Databases/VSSTester/Logging/Get-VSSWriter.ps1
+++ b/Databases/VSSTester/Logging/Get-VSSWriter.ps1
@@ -11,7 +11,19 @@ function Get-VSSWriter {
         throw "Unable to list vss writers"
     }
 
-    for ($lineNumber = 3; $lineNumber -lt $writersText.Count; $lineNumber += 6) {
+    $startIndex = 3
+
+    if (-not ($writersText[$startIndex] -like "Writer name*")) {
+        Write-Host "Finding the first writer..."
+        for ($lineNumber = $startIndex; $lineNumber -lt $writersText.Count; $lineNumber++) {
+            if ($writersText[$lineNumber] -like "Writer name*") {
+                $startIndex = $lineNumber
+                break
+            }
+        }
+    }
+
+    for ($lineNumber = $startIndex; $lineNumber -lt $writersText.Count; $lineNumber += 6) {
         [PSCustomObject]@{
             Name       = $writersText[$lineNumber].Substring($writersText[$lineNumber].IndexOf("'") + 1).TrimEnd("'")
             Id         = $writersText[$lineNumber + 1].Substring($writersText[$lineNumber + 1].IndexOf("{") + 1).TrimEnd("}")


### PR DESCRIPTION
**Issue:**
`vssadmin list writers` not writing the output starting at the standard index value of 3 causing the script to fail. 

**Reason:**
Need to be able to handle this when `vssadmin list writers` doesn't have the standard index value. 

**Fix:**
Manually find the starting point instead when the starting point doesn't have `Writer name`
Resolved #2093 

**Validation:**
Verified based off customer output. 

