### PR TITLE
ExchangeExtendedProtectionManagement.ps1 shows SystemTlsVersions instead of SystemDefaultTlsVersions

### DIFF
--- a/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/ExchangeExtendedProtectionManagement.ps1
@@ -481,9 +481,9 @@ begin {
 
                         $tlsSettings.TlsSettings.Registry.Net.Values |
                             ForEach-Object {
-                                $displayObject += NewDisplayObject "SystemTlsVersions" -Location $_.MicrosoftRegistryLocation -Value $_.SystemDefaultTlsVersionsValue
+                                $displayObject += NewDisplayObject "SystemDefaultTlsVersions" -Location $_.MicrosoftRegistryLocation -Value $_.SystemDefaultTlsVersionsValue
                                 $displayObject += NewDisplayObject "SchUseStrongCrypto" -Location $_.MicrosoftRegistryLocation -Value $_.SchUseStrongCryptoValue
-                                $displayObject += NewDisplayObject "SystemTlsVersions" -Location $_.WowRegistryLocation -Value $_.WowSystemDefaultTlsVersionsValue
+                                $displayObject += NewDisplayObject "SystemDefaultTlsVersions" -Location $_.WowRegistryLocation -Value $_.WowSystemDefaultTlsVersionsValue
                                 $displayObject += NewDisplayObject "SchUseStrongCrypto" -Location $_.WowRegistryLocation -Value $_.WowSchUseStrongCryptoValue
                             }
                         $stringOutput = [string]::Empty


### PR DESCRIPTION
**Issue:**
Customer reported the following issue:

_When the script ExchangeExtendedProtectionManagement.ps1 -PrerequisitesCheckOnly (Version 24.05.21.1635) is executed, the registry entries that are necessary for the TLS configuration are listed._

_I have noticed that the RegistryNames for `SystemDefaultTlsVersions` are incorrect (see screenshot)._

<img width="539" alt="image" src="https://github.com/microsoft/CSS-Exchange/assets/40993616/247f94c7-bbdd-41d1-abeb-17f399f9cdc9">

**Reason:**
Typo

**Fix:**
Replaced `SystemTlsVersions` with `SystemDefaultTlsVersions`

**Validation:**
N/A

