### PR TITLE
Include "-ErrorAction Stop" to Get-LocalGroupMember

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -203,7 +203,7 @@ function Get-ExchangeInformation {
                 CatchActionFunction    = ${Function:Invoke-CatchActions}
                 ScriptBlock            = {
                     [PSCustomObject]@{
-                        LocalGroupMember  = (Get-LocalGroupMember -SID "S-1-5-32-544")
+                        LocalGroupMember  =  (Get-LocalGroupMember -SID "S-1-5-32-544" -ErrorAction Stop)
                         ADGroupMembership = (Get-ADPrincipalGroupMembership (Get-ADComputer $env:COMPUTERNAME).DistinguishedName)
                     }
                 }


### PR DESCRIPTION
This allows problem environments to still execute the script

**Issue:**
After today's release, a few customers reported a problem with the Health Checker Script. It has to do with `Get-LocalGroupMember` returning an error that is causing some problems.

**Reason:**
Adding a quick fix for this to prevent other customers seeing this issue. 

**Fix:**
Add in `-ErrorAction Stop` to the cmdlet and it executes as you would expect it to. However, might want to come back in and add in a workaround for those issues so the customers that are unable to run `Get-LocalGroupMember` can still have the same check performed. 

**Validation:**
Lab and customer tested.
