### PR TITLE
Check oldest log date entry to throw a warning

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -487,10 +487,13 @@ function Invoke-AnalyzerOsInformation {
         $days = 7
         $testDate = (Get-Date).AddDays(-$days)
         foreach ($logType in $osInformation.EventLogInformation.Keys) {
-            if ($osInformation.EventLogInformation[$logType].LastLogEntry -gt $testDate) {
+            $logInfo = $osInformation.EventLogInformation[$logType]
+            # If the log isn't at the max limit, it is possible that they just cleared the logs or on a new server. This should be rare scenario.
+            if ($logInfo.LastLogEntry -gt $testDate -and
+                $logInfo.FileSize -ge $logInfo.MaxSize) {
                 $params = $baseParams + @{
                     Name             = "Event Log - $logType"
-                    Details          = "--ERROR-- Not enough logs to cover $days days. Last log entry is at $($osInformation.EventLogInformation[$logType].LastLogEntry)." +
+                    Details          = "--ERROR-- Not enough logs to cover $days days. Last log entry is at $($logInfo.LastLogEntry)." +
                     " This could cause issues with determining Root Cause Analysis."
                     DisplayWriteType = "Red"
                 }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerOsInformation.ps1
@@ -482,4 +482,20 @@ function Invoke-AnalyzerOsInformation {
         Write-Verbose "No Windows Features where collected. Unable to process."
     }
     # cSpell:enable
+
+    if ($null -ne $osInformation.EventLogInformation) {
+        $days = 7
+        $testDate = (Get-Date).AddDays(-$days)
+        foreach ($logType in $osInformation.EventLogInformation.Keys) {
+            if ($osInformation.EventLogInformation[$logType].LastLogEntry -gt $testDate) {
+                $params = $baseParams + @{
+                    Name             = "Event Log - $logType"
+                    Details          = "--ERROR-- Not enough logs to cover $days days. Last log entry is at $($osInformation.EventLogInformation[$logType].LastLogEntry)." +
+                    " This could cause issues with determining Root Cause Analysis."
+                    DisplayWriteType = "Red"
+                }
+                Add-AnalyzedResultInformation @params
+            }
+        }
+    }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
@@ -1,0 +1,38 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+. $PSScriptRoot\..\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
+function Get-EventLogInformation {
+    [CmdletBinding()]
+    [OutputType("System.Collections.Hashtable")]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Server,
+        [ScriptBlock]$CatchActionFunction
+    )
+    process {
+        function GetRemoteEventLogInformation {
+            $results = @{}
+            foreach ($log in @("Application", "System")) {
+                $lastLogEntry = Get-WinEvent -LogName $log -Oldest -MaxEvents 1
+                $listLog = Get-WinEvent -ListLog $log
+                $results.Add($log, ([PSCustomObject]@{
+                            LastLogEntry = $lastLogEntry.TimeCreated
+                            MaxSize      = $listLog.MaximumSizeInBytes
+                            LogMode      = $listLog.LogMode.ToString()
+                            IsEnabled    = $listLog.IsEnabled
+                            LogFilePath  = $listLog.LogFilePath
+                        }))
+            }
+
+            return $results
+        }
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        $params = @{
+            ComputerName        = $Server
+            ScriptBlock         = ${Function:GetRemoteEventLogInformation}
+            CatchActionFunction = $CatchActionFunction
+        }
+        return (Invoke-ScriptBlockHandler @params)
+    }
+}

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
@@ -19,6 +19,7 @@ function Get-EventLogInformation {
                 $results.Add($log, ([PSCustomObject]@{
                             LastLogEntry = $lastLogEntry.TimeCreated
                             MaxSize      = $listLog.MaximumSizeInBytes
+                            FileSize     = $listLog.FileSize
                             LogMode      = $listLog.LogMode.ToString()
                             IsEnabled    = $listLog.IsEnabled
                             LogFilePath  = $listLog.LogFilePath

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -5,6 +5,7 @@
 . $PSScriptRoot\..\..\..\..\Shared\VisualCRedistributableVersionFunctions.ps1
 . $PSScriptRoot\..\..\..\..\Shared\TLS\Get-AllTlsSettings.ps1
 . $PSScriptRoot\..\..\..\..\Shared\Get-AllNicInformation.ps1
+. $PSScriptRoot\Get-EventLogInformation.ps1
 . $PSScriptRoot\Get-NETFrameworkInformation.ps1
 . $PSScriptRoot\Get-NetworkingInformation.ps1
 . $PSScriptRoot\Get-OperatingSystemBuildInformation.ps1
@@ -72,6 +73,7 @@ function Get-OperatingSystemInformation {
         $vcRedistributable = Get-VisualCRedistributableInstalledVersion -ComputerName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $smb1ServerSettings = Get-Smb1ServerSettings -ServerName $Server -GetWindowsFeature $windowsFeature -CatchActionFunction ${Function:Invoke-CatchActions}
         $registryValues = Get-OperatingSystemRegistryValues -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
+        $eventLogInformation = Get-EventLogInformation -Server $Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $netFrameworkInformation = Get-NETFrameworkInformation -Server $Server
     } end {
         Write-Verbose "Exiting: $($MyInvocation.MyCommand)"
@@ -91,6 +93,7 @@ function Get-OperatingSystemInformation {
             NETFramework               = $netFrameworkInformation
             CredentialGuardCimInstance = $credentialGuardCimInstance
             WindowsFeature             = $windowsFeature
+            EventLogInformation        = $eventLogInformation
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventApplication.xml
@@ -1,0 +1,369 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">Application</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Application</ToString>
+        <I32>0</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0x2;;;S-1-15-2-1)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\Application.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>.NET Runtime</S>
+          <S>.NET Runtime Optimization Service</S>
+          <S>Active Monitoring</S>
+          <S>Application</S>
+          <S>Application Error</S>
+          <S>Application Hang</S>
+          <S>Application Management</S>
+          <S>ASP.NET 4.0.30319.0</S>
+          <S>CardSpace 4.0.0.0</S>
+          <S>Chkdsk</S>
+          <S>Chrome</S>
+          <S>Desktop Window Manager</S>
+          <S>DiskQuota</S>
+          <S>ESE</S>
+          <S>ESE BACKUP</S>
+          <S>ESENT</S>
+          <S>ExchangeStoreDB</S>
+          <S>FfoSyncLog</S>
+          <S>FfoSystemProbe</S>
+          <S>Filtering ADConnector</S>
+          <S>FMS</S>
+          <S>Group Policy Applications</S>
+          <S>Group Policy Client</S>
+          <S>Group Policy Data Sources</S>
+          <S>Group Policy Device Settings</S>
+          <S>Group Policy Drive Maps</S>
+          <S>Group Policy Environment</S>
+          <S>Group Policy Files</S>
+          <S>Group Policy Folder Options</S>
+          <S>Group Policy Folders</S>
+          <S>Group Policy Ini Files</S>
+          <S>Group Policy Internet Settings</S>
+          <S>Group Policy Local Users and Groups</S>
+          <S>Group Policy Mail Profiles</S>
+          <S>Group Policy Network Options</S>
+          <S>Group Policy Network Shares</S>
+          <S>Group Policy Power Options</S>
+          <S>Group Policy Printers</S>
+          <S>Group Policy Regional Options</S>
+          <S>Group Policy Registry</S>
+          <S>Group Policy Scheduled Tasks</S>
+          <S>Group Policy Services</S>
+          <S>Group Policy Shortcuts</S>
+          <S>Group Policy Standard Edition</S>
+          <S>Group Policy Start Menu Settings</S>
+          <S>GroupPolicy</S>
+          <S>Handwriting Recognition</S>
+          <S>HostableWebCore</S>
+          <S>IISADMIN</S>
+          <S>IISInfoCtrs</S>
+          <S>InferenceTrainingAssistant</S>
+          <S>Interactive Services detection</S>
+          <S>Microsoft Exchange Server</S>
+          <S>Microsoft-Windows-Defrag</S>
+          <S>Microsoft-Windows-IIS-IISManager</S>
+          <S>Microsoft.Transactions.Bridge 4.0.0.0</S>
+          <S>MSExchange ActiveSync</S>
+          <S>MSExchange ADAccess</S>
+          <S>MSExchange Anchor Service</S>
+          <S>MSExchange Anti-spam Update</S>
+          <S>MSExchange Antimalware</S>
+          <S>MSExchange Antispam</S>
+          <S>MSExchange Assistants</S>
+          <S>MSExchange AuditLogSearch</S>
+          <S>MSExchange AuthAdmin</S>
+          <S>MSExchange Autodiscover</S>
+          <S>MSExchange Availability</S>
+          <S>MSExchange BackEndRehydration</S>
+          <S>MSExchange Bulk User Provisioning</S>
+          <S>MSExchange Certificate</S>
+          <S>MSExchange Certificate Authentication Module</S>
+          <S>MSExchange Certificate Deployment</S>
+          <S>MSExchange Certificate Notification</S>
+          <S>MSExchange ClassificationDefinitions</S>
+          <S>MSExchange Cluster</S>
+          <S>MSExchange Common</S>
+          <S>MSExchange Configuration Core</S>
+          <S>MSExchange Control Panel</S>
+          <S>MSExchange Delegated Authentication Module</S>
+          <S>MSExchange DiagnosticsAggregation</S>
+          <S>MSExchange EdgeSync</S>
+          <S>MSExchange Extensibility</S>
+          <S>MSExchange FailFast Module</S>
+          <S>MSExchange Front End HTTP Proxy</S>
+          <S>MSExchange IMAP4 backend service</S>
+          <S>MSExchange IMAP4 service</S>
+          <S>MSExchange Internet Proxy</S>
+          <S>MSExchange JobQueue</S>
+          <S>MSExchange LiveId Redirection Module</S>
+          <S>MSExchange LiveIdBasicAuthentication</S>
+          <S>MSExchange Mailbox Replication</S>
+          <S>MSExchange MailTips</S>
+          <S>MSExchange Management Application</S>
+          <S>MSExchange Messaging Policies</S>
+          <S>MSExchange Mid-Tier Storage</S>
+          <S>MSExchange Migration</S>
+          <S>MSExchange Migration Workflow</S>
+          <S>MSExchange Net</S>
+          <S>MSExchange Notifications Broker</S>
+          <S>MSExchange OABRequestHandler</S>
+          <S>MSExchange OAuth</S>
+          <S>MSExchange Organization Redirection Module</S>
+          <S>MSExchange OrganizationConfiguration</S>
+          <S>MSExchange OutlookPolicyNudgeRules</S>
+          <S>MSExchange OutlookProtectionRules</S>
+          <S>MSExchange OWA</S>
+          <S>MSExchange POP3 backend service</S>
+          <S>MSExchange POP3 service</S>
+          <S>MSExchange Provisioning MailboxAssistant</S>
+          <S>MSExchange RBAC</S>
+          <S>MSExchange RemotePowershell BackendCmdletProxy Module</S>
+          <S>MSExchange ReportingWebService</S>
+          <S>MSExchange RPC Over HTTP Autoconfig</S>
+          <S>MSExchange SACL Watcher</S>
+          <S>MSExchange Shared Cache</S>
+          <S>MSExchange Store Driver Delivery</S>
+          <S>MSExchange Store Driver Submission</S>
+          <S>MSExchange Topology</S>
+          <S>MSExchange TransportService</S>
+          <S>MSExchange Unified Messaging</S>
+          <S>MSExchange Web Services</S>
+          <S>MSExchange WorkloadManagement</S>
+          <S>MSExchange X400 Proxy</S>
+          <S>MSExchangeAB</S>
+          <S>MSExchangeADTopology</S>
+          <S>MSExchangeAL</S>
+          <S>MSExchangeAntispamUpdate</S>
+          <S>MSExchangeApplicationLogic</S>
+          <S>MSExchangeCluster</S>
+          <S>MSExchangeDagMgmt</S>
+          <S>MSExchangeDelivery</S>
+          <S>MSExchangeDiagnostics</S>
+          <S>MSExchangeEdgeSync</S>
+          <S>MSExchangeEHALogSearchComponent</S>
+          <S>MSExchangeFastSearch</S>
+          <S>MSExchangeFrontEndTransport</S>
+          <S>MSExchangeGlobalLocatorCache</S>
+          <S>MSExchangeHM</S>
+          <S>MSExchangeHMHost</S>
+          <S>MSExchangeIMAP4</S>
+          <S>MSExchangeIMAP4BE</S>
+          <S>MSExchangeInference</S>
+          <S>MSExchangeIS</S>
+          <S>MSExchangeIS Mailbox Store</S>
+          <S>MSExchangeIS Public Store</S>
+          <S>MSExchangeMailboxAssistants</S>
+          <S>MSExchangeMailboxReplication</S>
+          <S>MSExchangeMapiAddressBookAppPool</S>
+          <S>MSExchangeMapiMailboxAppPool</S>
+          <S>MSExchangeMig</S>
+          <S>MSExchangeMigDS</S>
+          <S>MSExchangeMU</S>
+          <S>MSExchangePOP3</S>
+          <S>MSExchangePOP3BE</S>
+          <S>MSExchangeRepl</S>
+          <S>MSExchangeRPC</S>
+          <S>MSExchangeSA</S>
+          <S>MSExchangeServiceHost</S>
+          <S>MSExchangeSetup</S>
+          <S>MSExchangeSubmission</S>
+          <S>MSExchangeThrottling</S>
+          <S>MSExchangeThrottlingClient</S>
+          <S>MSExchangeTransport</S>
+          <S>MSExchangeTransportDelivery</S>
+          <S>MSExchangeTransportLogSearch</S>
+          <S>MSExchangeTransportMailboxAssistants</S>
+          <S>MSExchangeTransportMailSubmission</S>
+          <S>MSExchangeTransportSearch</S>
+          <S>MSExchangeTransportSubmission</S>
+          <S>MSExchangeTransportSyncCommon</S>
+          <S>MSExchangeTransportSyncManager</S>
+          <S>MSExchangeTransportSyncWorker</S>
+          <S>MSExchangeTransportSyncWorkerFramework</S>
+          <S>MSExchangeUM</S>
+          <S>MSExchangeUMCR</S>
+          <S>MSExchangeWEB</S>
+          <S>MsiInstaller</S>
+          <S>RasClient</S>
+          <S>RPC Proxy</S>
+          <S>RPC/HTTP LB Service</S>
+          <S>SceCli</S>
+          <S>SceSrv</S>
+          <S>SCW</S>
+          <S>SCW Analysis</S>
+          <S>Search HostController</S>
+          <S>ServiceModel Audit 4.0.0.0</S>
+          <S>SideBySide</S>
+          <S>Software Installation</S>
+          <S>SrmSvc</S>
+          <S>System.IdentityModel 4.0.0.0</S>
+          <S>System.IO.Log 4.0.0.0</S>
+          <S>System.Runtime.Serialization 4.0.0.0</S>
+          <S>System.ServiceModel 4.0.0.0</S>
+          <S>usbperf</S>
+          <S>VBRuntime</S>
+          <S>vmicguestinterface</S>
+          <S>vmicheartbeat</S>
+          <S>vmickvpexchange</S>
+          <S>vmicrdv</S>
+          <S>vmicshutdown</S>
+          <S>vmictimesync</S>
+          <S>vmicvss</S>
+          <S>VSS</S>
+          <S>VSSetup</S>
+          <S>WerSvc</S>
+          <S>Windows Error Reporting</S>
+          <S>WMI.NET Provider Extension</S>
+          <S>Wow64 Emulation Layer</S>
+          <S>WSH</S>
+          <S>Microsoft-Windows-PDH</S>
+          <S>Microsoft-Windows-LiveId</S>
+          <S>Microsoft-Windows-RestartManager</S>
+          <S>Microsoft-Windows-Complus</S>
+          <S>Microsoft-Windows-LoadPerf</S>
+          <S>Microsoft-Windows-Perflib</S>
+          <S>Microsoft-Windows-Crypto-RSAEnh</S>
+          <S>Microsoft-Windows-MSDTC Client 2</S>
+          <S>Microsoft-Windows-RemoteApp and Desktop Connections</S>
+          <S>Microsoft-Windows-Spellchecking-Host</S>
+          <S>Microsoft-Filtering-FIPFS</S>
+          <S>Microsoft-Windows-Backup</S>
+          <S>Microsoft-Windows-WMI</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-IIS-WMSVC</S>
+          <S>Microsoft-Windows-TerminalServices-ClientActiveXCore</S>
+          <S>Microsoft-Windows-IPMIProvider</S>
+          <S>Microsoft-Windows-Security-EnterpriseData-FileRevocationManager</S>
+          <S>Microsoft-Windows-Immersive-Shell</S>
+          <S>Microsoft-Windows-EFS</S>
+          <S>Microsoft-Windows-DirectShow-KernelSupport</S>
+          <S>Microsoft-Windows-Crypto-DSSEnh</S>
+          <S>Microsoft-Windows-GenericRoaming</S>
+          <S>Microsoft-Windows-BestPractices</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CertEnroll</S>
+          <S>Microsoft-Windows-Crypto-RNG</S>
+          <S>Microsoft-Windows-CAPI2</S>
+          <S>Microsoft-Windows-MSDTC 2</S>
+          <S>Microsoft-Windows-ApplicationExperienceInfrastructure</S>
+          <S>Microsoft-Windows-IIS-W3SVC-WP</S>
+          <S>Microsoft-Office Server-Search</S>
+          <S>Microsoft-Windows-EapHost</S>
+          <S>Microsoft-Windows-Video-For-Windows</S>
+          <S>Microsoft-Windows-MSDTC</S>
+          <S>Microsoft-Windows-DirectoryServices-Deployment</S>
+          <S>Microsoft-Windows-PerfProc</S>
+          <S>Microsoft-Windows-CertificateServicesClient</S>
+          <S>Microsoft-Windows-XWizards</S>
+          <S>Microsoft-Windows-FileServices-ServerManager-EventProvider</S>
+          <S>Microsoft-Windows-MSDTC Client</S>
+          <S>Microsoft-Windows-SoftwareRestrictionPolicies</S>
+          <S>Microsoft-Windows-Folder Redirection</S>
+          <S>Microsoft-Windows-PerfDisk</S>
+          <S>Microsoft-Windows-FileShareShadowCopyProvider</S>
+          <S>Microsoft-Windows-EventSystem</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CredentialRoaming</S>
+          <S>Microsoft-Windows-User Profiles Service</S>
+          <S>Microsoft-Windows-Crypto-DPAPI</S>
+          <S>Microsoft-Windows-IIS-W3SVC-PerfCounters</S>
+          <S>Microsoft-Windows-propsys</S>
+          <S>Microsoft-Windows-DirectShow-Core</S>
+          <S>Microsoft-Windows-PerfCtrs</S>
+          <S>Microsoft-Windows-CertificationAuthorityClient-CertCli</S>
+          <S>Microsoft-Windows-Management-UI</S>
+          <S>Microsoft-Windows-Winsrv</S>
+          <S>Microsoft-Windows-CEIP</S>
+          <S>Application-Addon-Event-Provider</S>
+          <S>Microsoft-Windows-SmartCard-DeviceEnum</S>
+          <S>Microsoft-Windows-Audio</S>
+          <S>Microsoft-Windows-User-Loader</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-COMRuntime</S>
+          <S>Microsoft-Windows-AppModel-State</S>
+          <S>Microsoft-Windows-FederationServices-Deployment</S>
+          <S>Microsoft-Windows-EnrollmentWebService</S>
+          <S>Microsoft-Windows-Crypto-BCrypt</S>
+          <S>Microsoft-Windows-PerfNet</S>
+          <S>Error Instrument</S>
+          <S>Microsoft-Windows-MSMQ</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Microsoft-Windows-WAS-ListenerAdapter</S>
+          <S>Microsoft-Windows-ServerManager-MultiMachine</S>
+          <S>Microsoft-Windows-ASN1</S>
+          <S>Microsoft-Windows-AxInstallService</S>
+          <S>Microsoft-Windows-User Profiles General</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-Security-SPP</S>
+          <S>Microsoft-Windows-Crypto-CNG</S>
+          <S>Microsoft-Windows-Security-Netlogon</S>
+          <S>Microsoft-Windows-Crypto-NCrypt</S>
+          <S>Microsoft-Windows-CertificateServicesClient-AutoEnrollment</S>
+          <S>Microsoft-Windows-AppModel-Runtime</S>
+          <S>Microsoft-Windows-RPC-Events</S>
+          <S>Microsoft-Windows-EnrollmentPolicyWebService</S>
+          <S>Microsoft-Windows-PerfOS</S>
+          <S>Microsoft-Windows-Rdms-UI</S>
+          <S>Microsoft-Windows-ProcessExitMonitor</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">64</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">6361088</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2020-11-01T12:43:48.9189123-08:00</DT>
+      <DT N="LastWriteTime">2024-06-20T08:51:36.9154299-07:00</DT>
+      <I64 N="OldestRecordNumber">1</I64>
+      <I64 N="RecordCount">7324</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventOldestApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventOldestApplication.xml
@@ -1,0 +1,86 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">16384</I32>
+      <By N="Version">0</By>
+      <I32 N="Qualifiers">16384</I32>
+      <By N="Level">4</By>
+      <I32 N="Task">0</I32>
+      <I16 N="Opcode">0</I16>
+      <I64 N="Keywords">36028797018963968</I64>
+      <I64 N="RecordId">1271</I64>
+      <S N="ProviderName">Microsoft-Windows-Security-SPP</S>
+      <G N="ProviderId">e23b33b0-c8c9-472c-a5f9-f2bdfea0f156</G>
+      <S N="LogName">Application</S>
+      <I32 N="ProcessId">0</I32>
+      <I32 N="ThreadId">0</I32>
+      <S N="MachineName">WIN-AUPR2S24E9U</S>
+      <Nil N="UserId" />
+      <DT N="TimeCreated">2021-10-06T10:42:01-07:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">application</S>
+      <Obj N="MatchedQueryIds" RefId="1">
+        <TN RefId="1">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <Nil N="OpcodeDisplayName" />
+      <Nil N="TaskDisplayName" />
+      <Obj N="KeywordsDisplayNames" RefId="3">
+        <TN RefId="3">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>Classic</S>
+        </LST>
+      </Obj>
+      <Obj N="Properties" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="5">
+            <TN RefId="5">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">2121-09-12T17:42:01Z</S>
+            </Props>
+          </Obj>
+          <Obj RefId="6">
+            <TNRef RefId="5" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">RulesEngine</S>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">Successfully scheduled Software Protection service for re-start at 2121-09-12T17:42:01Z. Reason: RulesEngine.</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventOldestSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventOldestSystem.xml
@@ -1,0 +1,110 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">104</I32>
+      <By N="Version">0</By>
+      <Nil N="Qualifiers" />
+      <By N="Level">4</By>
+      <I32 N="Task">104</I32>
+      <I16 N="Opcode">0</I16>
+      <I64 N="Keywords">-9223372036854775808</I64>
+      <I64 N="RecordId">4030</I64>
+      <S N="ProviderName">Microsoft-Windows-Eventlog</S>
+      <G N="ProviderId">fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148</G>
+      <S N="LogName">System</S>
+      <I32 N="ProcessId">784</I32>
+      <I32 N="ThreadId">2948</I32>
+      <S N="MachineName">WIN-AUPR2S24E9U</S>
+      <Obj N="UserId" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-406381025-241472036-1068998058-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-406381025-241472036-1068998058</S>
+          <S N="Value">S-1-5-21-406381025-241472036-1068998058-500</S>
+        </Props>
+      </Obj>
+      <DT N="TimeCreated">2021-10-06T10:41:42.7509975-07:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">system</S>
+      <Obj N="MatchedQueryIds" RefId="2">
+        <TN RefId="2">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <S N="OpcodeDisplayName">Info</S>
+      <S N="TaskDisplayName">Log clear</S>
+      <Obj N="KeywordsDisplayNames" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Properties" RefId="5">
+        <TN RefId="5">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="6">
+            <TN RefId="6">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">Administrator</S>
+            </Props>
+          </Obj>
+          <Obj RefId="7">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">WIN-AUPR2S24E9U</S>
+            </Props>
+          </Obj>
+          <Obj RefId="8">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">System</S>
+            </Props>
+          </Obj>
+          <Obj RefId="9">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value"></S>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">The System log file was cleared.</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/OS/GetWinEventSystem.xml
@@ -1,0 +1,329 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">System</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System</ToString>
+        <I32>1</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x3;;;BO)(A;;0x5;;;SO)(A;;0x1;;;IU)(A;;0x3;;;SU)(A;;0x1;;;S-1-5-3)(A;;0x2;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\System.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>3ware</S>
+          <S>ACPI</S>
+          <S>ADP80XX</S>
+          <S>AeLookupSvc</S>
+          <S>AFD</S>
+          <S>AmdK8</S>
+          <S>AmdPPM</S>
+          <S>amdsata</S>
+          <S>amdsbs</S>
+          <S>amdxata</S>
+          <S>Application Management Group Policy</S>
+          <S>arcsas</S>
+          <S>AsyncMac</S>
+          <S>atapi</S>
+          <S>b06bdrv</S>
+          <S>BasicDisplay</S>
+          <S>BasicRender</S>
+          <S>beep</S>
+          <S>bfadfcoei</S>
+          <S>bfadi</S>
+          <S>Bowser</S>
+          <S>Browser</S>
+          <S>bxfcoe</S>
+          <S>bxois</S>
+          <S>cdrom</S>
+          <S>CertObj</S>
+          <S>cht4vbd</S>
+          <S>disk</S>
+          <S>Display</S>
+          <S>dmvsc</S>
+          <S>Dnsapi</S>
+          <S>Dnscache</S>
+          <S>ebdrv</S>
+          <S>elxfcoe</S>
+          <S>elxstor</S>
+          <S>eventlog</S>
+          <S>exFAT</S>
+          <S>EXIFS</S>
+          <S>FltMgr</S>
+          <S>FxPPM</S>
+          <S>HpSAMD</S>
+          <S>i8042prt</S>
+          <S>iaStorAV</S>
+          <S>iaStorV</S>
+          <S>ibbus</S>
+          <S>IIS Config</S>
+          <S>IISLOG</S>
+          <S>IISWMI</S>
+          <S>intelppm</S>
+          <S>IPMIDRV</S>
+          <S>isapnp</S>
+          <S>iScsiPrt</S>
+          <S>kbdclass</S>
+          <S>kbdhid</S>
+          <S>kdnic</S>
+          <S>lltdio</S>
+          <S>LmHosts</S>
+          <S>LSI_SAS</S>
+          <S>LSI_SAS2</S>
+          <S>LSI_SAS3</S>
+          <S>LSI_SSS</S>
+          <S>megasas</S>
+          <S>megasr</S>
+          <S>mlx4_bus</S>
+          <S>mouclass</S>
+          <S>mouhid</S>
+          <S>mrxsmb</S>
+          <S>MsBridge</S>
+          <S>MSiSCSI</S>
+          <S>MTConfig</S>
+          <S>Mup</S>
+          <S>mvumis</S>
+          <S>NdisImPlatform</S>
+          <S>NdisWan</S>
+          <S>NdisWanLegacy</S>
+          <S>NetBIOS</S>
+          <S>NetBT</S>
+          <S>Netlogon</S>
+          <S>netvsc</S>
+          <S>netvscvfpp</S>
+          <S>Ntfs</S>
+          <S>nvraid</S>
+          <S>nvstor</S>
+          <S>Parport</S>
+          <S>partmgr</S>
+          <S>pcmcia</S>
+          <S>Power</S>
+          <S>PptpMiniport</S>
+          <S>Processor</S>
+          <S>ql2300i</S>
+          <S>ql40xx2i</S>
+          <S>qlfcoei</S>
+          <S>RasAuto</S>
+          <S>Rasman</S>
+          <S>rdbss</S>
+          <S>RemoteAccess</S>
+          <S>rspndr</S>
+          <S>sbp2port</S>
+          <S>sercx</S>
+          <S>sercx2</S>
+          <S>Serial</S>
+          <S>sermouse</S>
+          <S>Server</S>
+          <S>SiSRaid2</S>
+          <S>SiSRaid4</S>
+          <S>SMSvcHost 4.0.0.0</S>
+          <S>SNMPTRAP</S>
+          <S>spaceport</S>
+          <S>spbcx</S>
+          <S>Srv</S>
+          <S>stexstor</S>
+          <S>StillImage</S>
+          <S>storahci</S>
+          <S>storflt</S>
+          <S>stornvme</S>
+          <S>storvsc</S>
+          <S>storvsp</S>
+          <S>System</S>
+          <S>Tcpip</S>
+          <S>Tcpip6</S>
+          <S>TCPMon</S>
+          <S>tunnel</S>
+          <S>UASPStor</S>
+          <S>UEFI</S>
+          <S>usbehci</S>
+          <S>VDS Basic Provider</S>
+          <S>VDS Dynamic Provider</S>
+          <S>VDS Virtual Disk Provider</S>
+          <S>vhdmp</S>
+          <S>Virtual Disk Service</S>
+          <S>vmbus</S>
+          <S>vmbusr</S>
+          <S>volmgr</S>
+          <S>Volsnap</S>
+          <S>vpci</S>
+          <S>vpcivsp</S>
+          <S>vsmraid</S>
+          <S>VSTXRAID</S>
+          <S>WacomPen</S>
+          <S>wdf01000</S>
+          <S>wecsvc</S>
+          <S>Win32k</S>
+          <S>Windows Disk Diagnostic</S>
+          <S>Windows Script Host</S>
+          <S>WinNat</S>
+          <S>WMIxWDM</S>
+          <S>Workstation</S>
+          <S>ReFS</S>
+          <S>Microsoft-Windows-IIS-W3SVC</S>
+          <S>Microsoft-Windows-Time-Service</S>
+          <S>Microsoft-Windows-Directory-Services-SAM</S>
+          <S>Microsoft-Windows-Kernel-Processor-Power</S>
+          <S>Microsoft-Windows-Hyper-V-Netvsc</S>
+          <S>Microsoft-Windows-Dhcp-Client</S>
+          <S>Microsoft-Windows-Kernel-Boot</S>
+          <S>LsaSrv</S>
+          <S>Microsoft-Windows-DistributedCOM</S>
+          <S>TPM</S>
+          <S>Microsoft-Windows-DNS-Client</S>
+          <S>Schannel</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-TerminalServices-SessionBroker-Client</S>
+          <S>Microsoft-Windows-RasServer</S>
+          <S>Microsoft-Windows-DriverFrameworks-UserMode</S>
+          <S>Microsoft-Windows-USB-USBXHCI</S>
+          <S>Microsoft-Windows-Kernel-Power</S>
+          <S>Microsoft-Windows-Diagnostics-Networking</S>
+          <S>Microsoft-Windows-MsLbfoSysEvtProvider</S>
+          <S>Microsoft-Windows-Fat-SQM</S>
+          <S>Microsoft-Windows-Ntfs</S>
+          <S>Microsoft-Windows-Subsys-SMSS</S>
+          <S>Microsoft-Windows-Serial-ClassExtension</S>
+          <S>Application Popup</S>
+          <S>Microsoft-Windows-exFAT-SQM</S>
+          <S>Microsoft-Windows-Kernel-Tm</S>
+          <S>Microsoft-Windows-Smartcard-Server</S>
+          <S>Microsoft-Windows-WAS</S>
+          <S>Microsoft-Windows-SetupPlatform</S>
+          <S>Microsoft-Windows-FunctionDiscoveryHost</S>
+          <S>Service Control Manager</S>
+          <S>Microsoft-Windows-GPIO-ClassExtension</S>
+          <S>Microsoft-Windows-TerminalServices-LocalSessionManager</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Results</S>
+          <S>Microsoft-Windows-NdisImPlatformSysEvtProvider</S>
+          <S>Microsoft-Windows-HAL</S>
+          <S>Microsoft-Windows-Devices-Background</S>
+          <S>Microsoft-Windows-Iphlpsvc</S>
+          <S>Microsoft-Windows-DHCPv6-Client</S>
+          <S>Microsoft-Windows-RasSstp</S>
+          <S>Microsoft-Windows-ServerManager-ConfigureSMRemoting</S>
+          <S>Microsoft-Windows-TerminalServices-ClientUSBDevices</S>
+          <S>Microsoft-Windows-LanguagePackSetup</S>
+          <S>Microsoft-Windows-SPB-ClassExtension</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Schedule</S>
+          <S>Microsoft-Windows-PrintService</S>
+          <S>Microsoft-Windows-ResourcePublication</S>
+          <S>Microsoft-Windows-Setup</S>
+          <S>Microsoft-Windows-Kernel-WHEA</S>
+          <S>Microsoft-Windows-HttpEvent</S>
+          <S>Microsoft-Windows-WinHttp</S>
+          <S>Microsoft-Windows-TPM-WMI</S>
+          <S>Microsoft-Windows-DfsSvc</S>
+          <S>Microsoft-Windows-NAPIPSecEnf</S>
+          <S>Microsoft-Windows-Ntfs-UBPM</S>
+          <S>Microsoft-Windows-WindowsUpdateClient</S>
+          <S>Microsoft-Windows-Kernel-Interrupt-Steering</S>
+          <S>Microsoft-Windows-TerminalServices-Printers</S>
+          <S>Microsoft-Windows-OfflineFiles</S>
+          <S>Microsoft-Windows-UserPnp</S>
+          <S>NetJoin</S>
+          <S>Microsoft-Windows-Security-Kerberos</S>
+          <S>Microsoft-Windows-SPB-HIDI2C</S>
+          <S>Microsoft-Windows-Resource-Exhaustion-Detector</S>
+          <S>Microsoft-Windows-Kernel-PnP</S>
+          <S>Microsoft-Windows-SCPNP</S>
+          <S>Microsoft-Windows-NetworkBridge</S>
+          <S>Microsoft-Windows-Kernel-General</S>
+          <S>Microsoft-Windows-SharedAccess_NAT</S>
+          <S>Microsoft-Windows-WinRM</S>
+          <S>Microsoft-Windows-WER-SystemErrorReporting</S>
+          <S>Microsoft-Windows-WPDClassInstaller</S>
+          <S>Microsoft-Windows-GroupPolicy</S>
+          <S>User32</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Client</S>
+          <S>Microsoft-Windows-Memory-Diagnostic-Task-Handler</S>
+          <S>Microsoft-Windows-IIS-IisMetabaseAudit</S>
+          <S>Microsoft-Windows-Servicing</S>
+          <S>Microsoft-Windows-WHEA-Logger</S>
+          <S>Microsoft-Windows-TerminalServices-RemoteConnectionManager</S>
+          <S>Microsoft-Windows-StartupRepair</S>
+          <S>Microsoft-Windows-IIS-APPHOSTSVC</S>
+          <S>Microsoft-Windows-Power-Troubleshooter</S>
+          <S>Microsoft-Windows-NDIS</S>
+          <S>Microsoft-Windows-UserModePowerService</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Server</S>
+          <S>Microsoft-Windows-IIS-IISReset</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-TerminalServices-ServerUSBDevices</S>
+          <S>Ntfs</S>
+          <S>Microsoft-Windows-TaskScheduler</S>
+          <S>Microsoft-Windows-FMS</S>
+          <S>Microsoft-Windows-MountMgr</S>
+          <S>Microsoft-Windows-Firewall</S>
+          <S>Microsoft-Windows-DiskDiagnostic</S>
+          <S>Microsoft-Windows-Ntfs-SQM</S>
+          <S>Microsoft-Windows-Serial-ClassExtension-V2</S>
+          <S>Microsoft-Windows-Bits-Client</S>
+          <S>Microsoft-Windows-Kernel-XDV</S>
+          <S>Microsoft-Windows-AppReadiness</S>
+          <S>Microsoft-Windows-MPRMSG</S>
+          <S>Microsoft-Windows-FilterManager</S>
+          <S>Microsoft-Windows-Dhcp-Nap-Enforcement-Client</S>
+          <S>Microsoft-Windows-Eventlog</S>
+          <S>Microsoft-Windows-W3LOGSVC</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">16</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">2166784</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2020-11-01T12:43:48.9189123-08:00</DT>
+      <DT N="LastWriteTime">2024-06-20T08:51:35.3841806-07:00</DT>
+      <I64 N="OldestRecordNumber">1</I64>
+      <I64 N="RecordCount">3244</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventApplication.xml
@@ -1,0 +1,387 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">Application</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Application</ToString>
+        <I32>0</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0x2;;;S-1-15-2-1)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\Application.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>.NET Runtime</S>
+          <S>.NET Runtime Optimization Service</S>
+          <S>Application</S>
+          <S>Application Error</S>
+          <S>Application Hang</S>
+          <S>Application Management</S>
+          <S>ASP.NET 4.0.30319.0</S>
+          <S>CardSpace 4.0.0.0</S>
+          <S>Chkdsk</S>
+          <S>Chrome</S>
+          <S>Desktop Window Manager</S>
+          <S>DiskQuota</S>
+          <S>Dwminit</S>
+          <S>ESE</S>
+          <S>ESE BACKUP</S>
+          <S>ESENT</S>
+          <S>ExchangeStoreDB</S>
+          <S>FfoSyncLog</S>
+          <S>FfoSystemProbe</S>
+          <S>Filtering ADConnector</S>
+          <S>FMS</S>
+          <S>ForeFrontActiveMonitoring</S>
+          <S>Group Policy Applications</S>
+          <S>Group Policy Client</S>
+          <S>Group Policy Data Sources</S>
+          <S>Group Policy Device Settings</S>
+          <S>Group Policy Drive Maps</S>
+          <S>Group Policy Environment</S>
+          <S>Group Policy Files</S>
+          <S>Group Policy Folder Options</S>
+          <S>Group Policy Folders</S>
+          <S>Group Policy Ini Files</S>
+          <S>Group Policy Internet Settings</S>
+          <S>Group Policy Local Users and Groups</S>
+          <S>Group Policy Mail Profiles</S>
+          <S>Group Policy Network Options</S>
+          <S>Group Policy Network Shares</S>
+          <S>Group Policy Power Options</S>
+          <S>Group Policy Printers</S>
+          <S>Group Policy Regional Options</S>
+          <S>Group Policy Registry</S>
+          <S>Group Policy Scheduled Tasks</S>
+          <S>Group Policy Services</S>
+          <S>Group Policy Shortcuts</S>
+          <S>Group Policy Standard Edition</S>
+          <S>Group Policy Start Menu Settings</S>
+          <S>GroupPolicy</S>
+          <S>Handwriting Recognition</S>
+          <S>HostableWebCore</S>
+          <S>IISADMIN</S>
+          <S>IISInfoCtrs</S>
+          <S>InferenceTrainingAssistant</S>
+          <S>Interactive Services detection</S>
+          <S>Microsoft Exchange Mailbox Transport Submission</S>
+          <S>Microsoft Exchange Server</S>
+          <S>Microsoft-Windows-Defrag</S>
+          <S>Microsoft-Windows-IIS-IISManager</S>
+          <S>Microsoft.Transactions.Bridge 4.0.0.0</S>
+          <S>MSComplianceAudit</S>
+          <S>MSExchange ActiveSync</S>
+          <S>MSExchange ADAccess</S>
+          <S>MSExchange Anti-spam Update</S>
+          <S>MSExchange Antimalware</S>
+          <S>MSExchange Antispam</S>
+          <S>MSExchange Assistants</S>
+          <S>MSExchange AuditLogPumper</S>
+          <S>MSExchange AuditLogSearch</S>
+          <S>MSExchange AuditStorageMonitor</S>
+          <S>MSExchange AuthAdmin</S>
+          <S>MSExchange Autodiscover</S>
+          <S>MSExchange Availability</S>
+          <S>MSExchange BackEndRehydration</S>
+          <S>MSExchange BigFunnel</S>
+          <S>MSExchange Bulk User Provisioning</S>
+          <S>MSExchange Certificate</S>
+          <S>MSExchange Certificate Authentication Module</S>
+          <S>MSExchange Certificate Deployment</S>
+          <S>MSExchange Certificate Notification</S>
+          <S>MSExchange ClassificationDefinitions</S>
+          <S>MSExchange Cluster</S>
+          <S>MSExchange Common</S>
+          <S>MSExchange Configuration Core</S>
+          <S>MSExchange Control Panel</S>
+          <S>MSExchange Delegated Authentication Module</S>
+          <S>MSExchange DiagnosticsAggregation</S>
+          <S>MSExchange EdgeSync</S>
+          <S>MSExchange Extensibility</S>
+          <S>MSExchange FailFast Module</S>
+          <S>MSExchange Front End HTTP Proxy</S>
+          <S>MSExchange IMAP4 backend service</S>
+          <S>MSExchange IMAP4 service</S>
+          <S>MSExchange Internet Proxy</S>
+          <S>MSExchange JobQueue</S>
+          <S>MSExchange KillSwitch</S>
+          <S>MSExchange LiveId Redirection Module</S>
+          <S>MSExchange LiveIdBasicAuthentication</S>
+          <S>MSExchange Mailbox Assistants Provider</S>
+          <S>MSExchange Mailbox Replication</S>
+          <S>MSExchange MailTips</S>
+          <S>MSExchange Management Application</S>
+          <S>MSExchange Messaging Policies</S>
+          <S>MSExchange Mid-Tier Storage</S>
+          <S>MSExchange Migration</S>
+          <S>MSExchange Migration Workflow</S>
+          <S>MSExchange Mitigation Service</S>
+          <S>MSExchange Net</S>
+          <S>MSExchange Notifications Broker</S>
+          <S>MSExchange OABRequestHandler</S>
+          <S>MSExchange OAuth</S>
+          <S>MSExchange Org Update generator</S>
+          <S>MSExchange Organization Redirection Module</S>
+          <S>MSExchange OrganizationConfiguration</S>
+          <S>MSExchange OutlookPolicyNudgeRules</S>
+          <S>MSExchange OutlookProtectionRules</S>
+          <S>MSExchange OWA</S>
+          <S>MSExchange PICW</S>
+          <S>MSExchange POP3 backend service</S>
+          <S>MSExchange POP3 service</S>
+          <S>MSExchange Provisioning MailboxAssistant</S>
+          <S>MSExchange RBAC</S>
+          <S>MSExchange RemotePowershell BackendCmdletProxy Module</S>
+          <S>MSExchange ReportingWebService</S>
+          <S>MSExchange Routing</S>
+          <S>MSExchange RPC Over HTTP Autoconfig</S>
+          <S>MSExchange SACL Watcher</S>
+          <S>MSExchange Shared Cache</S>
+          <S>MSExchange Store Driver Delivery</S>
+          <S>MSExchange Store Driver Submission</S>
+          <S>MSExchange Store Objects Service</S>
+          <S>MSExchange TextProcessing</S>
+          <S>MSExchange Topology</S>
+          <S>MSExchange TransportService</S>
+          <S>MSExchange Unified Messaging</S>
+          <S>MSExchange Unified Policy Sync</S>
+          <S>MSExchange UnifiedPolicyFileSync</S>
+          <S>MSExchange VariantConfiguration</S>
+          <S>MSExchange Web Services</S>
+          <S>MSExchange WorkloadManagement</S>
+          <S>MSExchange X400 Proxy</S>
+          <S>MSExchangeAB</S>
+          <S>MSExchangeADTopology</S>
+          <S>MSExchangeAL</S>
+          <S>MSExchangeAntispamUpdate</S>
+          <S>MSExchangeApplicationLogic</S>
+          <S>MSExchangeCluster</S>
+          <S>MSExchangeCompliance</S>
+          <S>MSExchangeDagMgmt</S>
+          <S>MSExchangeDelivery</S>
+          <S>MSExchangeDiagnostics</S>
+          <S>MSExchangeEdgeSync</S>
+          <S>MSExchangeEHALogSearchComponent</S>
+          <S>MSExchangeFastSearch</S>
+          <S>MSExchangeFrontEndTransport</S>
+          <S>MSExchangeGlobalLocatorCache</S>
+          <S>MSExchangeHM</S>
+          <S>MSExchangeHMHost</S>
+          <S>MSExchangeHMRecovery</S>
+          <S>MSExchangeIMAP4</S>
+          <S>MSExchangeIMAP4BE</S>
+          <S>MSExchangeInference</S>
+          <S>MSExchangeIS</S>
+          <S>MSExchangeIS Mailbox Store</S>
+          <S>MSExchangeIS Public Store</S>
+          <S>MSExchangeMailboxAssistants</S>
+          <S>MSExchangeMailboxReplication</S>
+          <S>MSExchangeMapiAddressBookAppPool</S>
+          <S>MSExchangeMapiMailboxAppPool</S>
+          <S>MSExchangeMig</S>
+          <S>MSExchangeMigDS</S>
+          <S>MSExchangeMitigation</S>
+          <S>MSExchangeMU</S>
+          <S>MSExchangeNotificationsBroker</S>
+          <S>MSExchangePOP3</S>
+          <S>MSExchangePOP3BE</S>
+          <S>MSExchangeRepl</S>
+          <S>MSExchangeRPC</S>
+          <S>MSExchangeSA</S>
+          <S>MSExchangeServiceHost</S>
+          <S>MSExchangeSetup</S>
+          <S>MSExchangeSubmission</S>
+          <S>MSExchangeThrottling</S>
+          <S>MSExchangeThrottlingClient</S>
+          <S>MSExchangeTransport</S>
+          <S>MSExchangeTransportDelivery</S>
+          <S>MSExchangeTransportLogSearch</S>
+          <S>MSExchangeTransportMailboxAssistants</S>
+          <S>MSExchangeTransportMailSubmission</S>
+          <S>MSExchangeTransportSearch</S>
+          <S>MSExchangeTransportSubmission</S>
+          <S>MSExchangeTransportSyncCommon</S>
+          <S>MSExchangeTransportSyncManager</S>
+          <S>MSExchangeTransportSyncWorker</S>
+          <S>MSExchangeTransportSyncWorkerFramework</S>
+          <S>MSExchangeUM</S>
+          <S>MSExchangeUMCR</S>
+          <S>MSExchangeWEB</S>
+          <S>MsiInstaller</S>
+          <S>RasClient</S>
+          <S>RPC Proxy</S>
+          <S>RPC/HTTP LB Service</S>
+          <S>SceCli</S>
+          <S>SceSrv</S>
+          <S>Search HostController</S>
+          <S>ServiceModel Audit 4.0.0.0</S>
+          <S>SideBySide</S>
+          <S>Software Installation</S>
+          <S>SpeechRuntime</S>
+          <S>System.IdentityModel 4.0.0.0</S>
+          <S>System.IO.Log 4.0.0.0</S>
+          <S>System.Runtime.Serialization 4.0.0.0</S>
+          <S>System.ServiceModel 4.0.0.0</S>
+          <S>usbperf</S>
+          <S>VBRuntime</S>
+          <S>VSS</S>
+          <S>VSSetup</S>
+          <S>WerSvc</S>
+          <S>Windows Error Reporting</S>
+          <S>WMI.NET Provider Extension</S>
+          <S>Wow64 Emulation Layer</S>
+          <S>WSH</S>
+          <S>Microsoft-Windows-PDH</S>
+          <S>Microsoft-Windows-LiveId</S>
+          <S>Microsoft-Windows-RestartManager</S>
+          <S>Microsoft-Windows-Complus</S>
+          <S>Microsoft-Windows-WindowsSystemAssessmentTool</S>
+          <S>Microsoft-Windows-LoadPerf</S>
+          <S>Microsoft-Windows-Perflib</S>
+          <S>Microsoft-Windows-Crypto-RSAEnh</S>
+          <S>Microsoft-Windows-MSDTC Client 2</S>
+          <S>Microsoft-Windows-RemoteApp and Desktop Connections</S>
+          <S>Microsoft-Windows-Spellchecking-Host</S>
+          <S>Microsoft-Filtering-FIPFS</S>
+          <S>Microsoft-Windows-Backup</S>
+          <S>Microsoft-Windows-WMI</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-IIS-WMSVC</S>
+          <S>Microsoft-Windows-TerminalServices-ClientActiveXCore</S>
+          <S>Microsoft-Windows-IPMIProvider</S>
+          <S>Microsoft-Windows-Security-EnterpriseData-FileRevocationManager</S>
+          <S>Microsoft-Windows-Immersive-Shell</S>
+          <S>Microsoft-Windows-EFS</S>
+          <S>Microsoft-Windows-DirectShow-KernelSupport</S>
+          <S>Microsoft-Windows-Crypto-DSSEnh</S>
+          <S>Microsoft-Windows-AAD</S>
+          <S>Microsoft-Windows-GenericRoaming</S>
+          <S>Microsoft-Windows-BestPractices</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CertEnroll</S>
+          <S>Microsoft-Windows-Crypto-RNG</S>
+          <S>Microsoft-Windows-CAPI2</S>
+          <S>Microsoft-Windows-MSDTC 2</S>
+          <S>Microsoft-Windows-ApplicationExperienceInfrastructure</S>
+          <S>Microsoft-Windows-IIS-W3SVC-WP</S>
+          <S>Microsoft-Office Server-Search</S>
+          <S>Microsoft-Windows-EapHost</S>
+          <S>Microsoft-Windows-Video-For-Windows</S>
+          <S>Microsoft-Windows-MSDTC</S>
+          <S>Microsoft-Windows-DirectoryServices-Deployment</S>
+          <S>Microsoft-Windows-PerfProc</S>
+          <S>Microsoft-Windows-CertificateServicesClient</S>
+          <S>Microsoft-Windows-XWizards</S>
+          <S>Microsoft-Windows-FileServices-ServerManager-EventProvider</S>
+          <S>Microsoft-Windows-MSDTC Client</S>
+          <S>Microsoft-Windows-SoftwareRestrictionPolicies</S>
+          <S>Microsoft-Windows-Folder Redirection</S>
+          <S>Microsoft-Windows-PerfDisk</S>
+          <S>Microsoft-Windows-Audit-CVE</S>
+          <S>Microsoft-Windows-FileShareShadowCopyProvider</S>
+          <S>Microsoft-Windows-EventSystem</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CredentialRoaming</S>
+          <S>Microsoft-Windows-User Profiles Service</S>
+          <S>Microsoft-Windows-Crypto-DPAPI</S>
+          <S>Microsoft-Windows-IIS-W3SVC-PerfCounters</S>
+          <S>Microsoft-Windows-propsys</S>
+          <S>Microsoft-Windows-DirectShow-Core</S>
+          <S>Microsoft-Windows-PerfCtrs</S>
+          <S>Microsoft-Windows-CertificationAuthorityClient-CertCli</S>
+          <S>Microsoft-Windows-Management-UI</S>
+          <S>Microsoft-Windows-Winsrv</S>
+          <S>Microsoft-Windows-Biometrics</S>
+          <S>Application-Addon-Event-Provider</S>
+          <S>Microsoft-Windows-SmartCard-DeviceEnum</S>
+          <S>Microsoft-Windows-Audio</S>
+          <S>Microsoft-Windows-User-Loader</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-COMRuntime</S>
+          <S>Microsoft-Windows-AppModel-State</S>
+          <S>Microsoft-Windows-FederationServices-Deployment</S>
+          <S>Microsoft-Windows-EnrollmentWebService</S>
+          <S>Microsoft-Windows-Crypto-BCrypt</S>
+          <S>Microsoft-Windows-Search</S>
+          <S>Microsoft-Windows-PerfNet</S>
+          <S>Error Instrument</S>
+          <S>Microsoft-Windows-MSMQ</S>
+          <S>Microsoft-Windows-PrintBRM</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Microsoft-Windows-WAS-ListenerAdapter</S>
+          <S>Microsoft-Windows-ServerManager-MultiMachine</S>
+          <S>Microsoft-Windows-ASN1</S>
+          <S>Microsoft-Windows-AxInstallService</S>
+          <S>Microsoft-Windows-User Profiles General</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-Security-SPP</S>
+          <S>Microsoft-Windows-Crypto-CNG</S>
+          <S>Microsoft-Windows-Security-Netlogon</S>
+          <S>Microsoft-Windows-Crypto-NCrypt</S>
+          <S>Microsoft-Windows-CertificateServicesClient-AutoEnrollment</S>
+          <S>Microsoft-Windows-AppModel-Runtime</S>
+          <S>Microsoft-Windows-RPC-Events</S>
+          <S>Microsoft-Windows-EnrollmentPolicyWebService</S>
+          <S>Microsoft-Windows-DeviceGuard</S>
+          <S>Microsoft-Windows-PerfOS</S>
+          <S>Microsoft-Windows-Rdms-UI</S>
+          <S>Microsoft-Windows-Search-ProfileNotify</S>
+          <S>Microsoft-Windows-ProcessExitMonitor</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">64</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">13701120</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2020-10-30T08:24:46.7355382-07:00</DT>
+      <DT N="LastWriteTime">2024-06-20T08:32:13.8239094-07:00</DT>
+      <I64 N="OldestRecordNumber">1</I64>
+      <I64 N="RecordCount">21809</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventOldestApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventOldestApplication.xml
@@ -1,0 +1,79 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">4111</I32>
+      <By N="Version">0</By>
+      <I32 N="Qualifiers">16384</I32>
+      <By N="Level">4</By>
+      <I32 N="Task">1</I32>
+      <I16 N="Opcode">0</I16>
+      <I64 N="Keywords">36028797018963968</I64>
+      <I64 N="RecordId">1250</I64>
+      <S N="ProviderName">Microsoft-Windows-MSDTC</S>
+      <G N="ProviderId">719be4ed-e9bc-4dd8-a7cf-c85ce8e4975d</G>
+      <S N="LogName">Application</S>
+      <I32 N="ProcessId">0</I32>
+      <I32 N="ThreadId">0</I32>
+      <S N="MachineName">WIN-S9MI90B3JAK</S>
+      <Nil N="UserId" />
+      <DT N="TimeCreated">2021-10-06T15:44:43.5360963-07:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">application</S>
+      <Obj N="MatchedQueryIds" RefId="1">
+        <TN RefId="1">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <Nil N="OpcodeDisplayName" />
+      <S N="TaskDisplayName">SVC</S>
+      <Obj N="KeywordsDisplayNames" RefId="3">
+        <TN RefId="3">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>Classic</S>
+        </LST>
+      </Obj>
+      <Obj N="Properties" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="5">
+            <TN RefId="5">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <BA N="Value">TQBTAEQAVABDAA==</BA>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">The MS DTC service is stopping.</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventOldestSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventOldestSystem.xml
@@ -1,0 +1,110 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">104</I32>
+      <By N="Version">0</By>
+      <Nil N="Qualifiers" />
+      <By N="Level">4</By>
+      <I32 N="Task">104</I32>
+      <I16 N="Opcode">0</I16>
+      <I64 N="Keywords">-9223372036854775808</I64>
+      <I64 N="RecordId">4762</I64>
+      <S N="ProviderName">Microsoft-Windows-Eventlog</S>
+      <G N="ProviderId">fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148</G>
+      <S N="LogName">System</S>
+      <I32 N="ProcessId">1012</I32>
+      <I32 N="ThreadId">4308</I32>
+      <S N="MachineName">WIN-S9MI90B3JAK</S>
+      <Obj N="UserId" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-1817384130-1785471511-337968274-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-1817384130-1785471511-337968274</S>
+          <S N="Value">S-1-5-21-1817384130-1785471511-337968274-500</S>
+        </Props>
+      </Obj>
+      <DT N="TimeCreated">2021-10-06T15:44:43.0986128-07:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">system</S>
+      <Obj N="MatchedQueryIds" RefId="2">
+        <TN RefId="2">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <S N="OpcodeDisplayName">Info</S>
+      <S N="TaskDisplayName">Log clear</S>
+      <Obj N="KeywordsDisplayNames" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Properties" RefId="5">
+        <TN RefId="5">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="6">
+            <TN RefId="6">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">Administrator</S>
+            </Props>
+          </Obj>
+          <Obj RefId="7">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">WIN-S9MI90B3JAK</S>
+            </Props>
+          </Obj>
+          <Obj RefId="8">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">System</S>
+            </Props>
+          </Obj>
+          <Obj RefId="9">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value"></S>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">The System log file was cleared.</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/OS/GetWinEventSystem.xml
@@ -1,0 +1,343 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">System</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System</ToString>
+        <I32>1</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x3;;;BO)(A;;0x5;;;SO)(A;;0x1;;;IU)(A;;0x3;;;SU)(A;;0x1;;;S-1-5-3)(A;;0x2;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\System.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>3ware</S>
+          <S>ACPI</S>
+          <S>ADP80XX</S>
+          <S>AFD</S>
+          <S>AmdK8</S>
+          <S>AmdPPM</S>
+          <S>amdsata</S>
+          <S>amdsbs</S>
+          <S>amdxata</S>
+          <S>Application Management Group Policy</S>
+          <S>arcsas</S>
+          <S>AsyncMac</S>
+          <S>atapi</S>
+          <S>b06bdrv</S>
+          <S>BasicRender</S>
+          <S>beep</S>
+          <S>bfadfcoei</S>
+          <S>bfadi</S>
+          <S>Bowser</S>
+          <S>Browser</S>
+          <S>bxfcoe</S>
+          <S>bxois</S>
+          <S>cdrom</S>
+          <S>cht4iscsi</S>
+          <S>cht4vbd</S>
+          <S>disk</S>
+          <S>Display</S>
+          <S>Dnsapi</S>
+          <S>Dnscache</S>
+          <S>ebdrv</S>
+          <S>elxfcoe</S>
+          <S>elxstor</S>
+          <S>eventlog</S>
+          <S>exFAT</S>
+          <S>EXIFS</S>
+          <S>FltMgr</S>
+          <S>HidBth</S>
+          <S>HpSAMD</S>
+          <S>i8042prt</S>
+          <S>iaStorAV</S>
+          <S>iaStorV</S>
+          <S>ibbus</S>
+          <S>IIS Config</S>
+          <S>IISLOG</S>
+          <S>IISWMI</S>
+          <S>intelppm</S>
+          <S>IPMIDRV</S>
+          <S>isapnp</S>
+          <S>iScsiPrt</S>
+          <S>kbdclass</S>
+          <S>kbdhid</S>
+          <S>kdnic</S>
+          <S>Lfsvc</S>
+          <S>lltdio</S>
+          <S>LmHosts</S>
+          <S>LSI_SAS</S>
+          <S>LSI_SAS2i</S>
+          <S>LSI_SAS3i</S>
+          <S>LSI_SSS</S>
+          <S>megasas</S>
+          <S>megasas2i</S>
+          <S>megasr</S>
+          <S>mlx4_bus</S>
+          <S>mouclass</S>
+          <S>mouhid</S>
+          <S>mrxsmb</S>
+          <S>MsBridge</S>
+          <S>MSExchange Server</S>
+          <S>mshidumdf</S>
+          <S>MSiSCSI</S>
+          <S>MTConfig</S>
+          <S>Mup</S>
+          <S>mvumis</S>
+          <S>NdisImPlatform</S>
+          <S>NdisWan</S>
+          <S>ndiswanlegacy</S>
+          <S>NetBIOS</S>
+          <S>NetBT</S>
+          <S>Netlogon</S>
+          <S>netvscvfpp</S>
+          <S>Ntfs</S>
+          <S>nvstor</S>
+          <S>Parport</S>
+          <S>partmgr</S>
+          <S>pcmcia</S>
+          <S>percsas2i</S>
+          <S>percsas3i</S>
+          <S>Power</S>
+          <S>PptpMiniport</S>
+          <S>Processor</S>
+          <S>ql2300i</S>
+          <S>ql40xx2i</S>
+          <S>qlfcoei</S>
+          <S>RasAuto</S>
+          <S>RasCfg</S>
+          <S>Rasman</S>
+          <S>rdbss</S>
+          <S>RemoteAccess</S>
+          <S>rspndr</S>
+          <S>sbp2port</S>
+          <S>scmbus</S>
+          <S>scmdisk0101</S>
+          <S>sercx</S>
+          <S>sercx2</S>
+          <S>Serial</S>
+          <S>sermouse</S>
+          <S>Server</S>
+          <S>SiSRaid2</S>
+          <S>SiSRaid4</S>
+          <S>SMSvcHost 4.0.0.0</S>
+          <S>SNMPTRAP</S>
+          <S>spaceport</S>
+          <S>spbcx</S>
+          <S>Srv</S>
+          <S>stexstor</S>
+          <S>StillImage</S>
+          <S>storahci</S>
+          <S>stornvme</S>
+          <S>System</S>
+          <S>Tcpip</S>
+          <S>Tcpip6</S>
+          <S>TCPMon</S>
+          <S>tunnel</S>
+          <S>UASPStor</S>
+          <S>UEFI</S>
+          <S>usbehci</S>
+          <S>usbser</S>
+          <S>VDS Basic Provider</S>
+          <S>VDS Dynamic Provider</S>
+          <S>VDS Virtual Disk Provider</S>
+          <S>Virtual Disk Service</S>
+          <S>volmgr</S>
+          <S>vpci</S>
+          <S>vsmraid</S>
+          <S>VSTXRAID</S>
+          <S>WacomPen</S>
+          <S>wdf01000</S>
+          <S>wecsvc</S>
+          <S>Win32k</S>
+          <S>Windows Disk Diagnostic</S>
+          <S>Windows Script Host</S>
+          <S>WinNat</S>
+          <S>WMIxWDM</S>
+          <S>Workstation</S>
+          <S>Microsoft-Windows-IIS-W3SVC</S>
+          <S>Microsoft-Windows-ReFS-v1</S>
+          <S>Microsoft-Windows-Time-Service</S>
+          <S>Microsoft-Windows-Directory-Services-SAM</S>
+          <S>Microsoft-Windows-Kernel-Processor-Power</S>
+          <S>Microsoft-Windows-Windows Defender</S>
+          <S>Microsoft-Windows-Hyper-V-Netvsc</S>
+          <S>Microsoft-Windows-Dhcp-Client</S>
+          <S>Microsoft-Windows-Kernel-Boot</S>
+          <S>LsaSrv</S>
+          <S>Microsoft-Windows-DistributedCOM</S>
+          <S>TPM</S>
+          <S>Microsoft-Windows-DNS-Client</S>
+          <S>Schannel</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-TerminalServices-SessionBroker-Client</S>
+          <S>Microsoft-Windows-RasServer</S>
+          <S>Microsoft-Windows-DriverFrameworks-UserMode</S>
+          <S>Microsoft-Windows-WindowsToGo-StartupOptions</S>
+          <S>Microsoft-Windows-Power-Meter-Polling</S>
+          <S>Microsoft-Windows-USB-USBXHCI</S>
+          <S>Microsoft-Windows-Kernel-Power</S>
+          <S>Microsoft-Windows-CoreSystem-NetProvision-JoinProviderOnline</S>
+          <S>Microsoft-Windows-Diagnostics-Networking</S>
+          <S>Microsoft-Windows-MsLbfoSysEvtProvider</S>
+          <S>Microsoft-Windows-Fat-SQM</S>
+          <S>Microsoft-Windows-Ntfs</S>
+          <S>Microsoft-Windows-Subsys-SMSS</S>
+          <S>Microsoft-Windows-OverlayFilter</S>
+          <S>Microsoft-Windows-Serial-ClassExtension</S>
+          <S>Application Popup</S>
+          <S>Microsoft-Windows-exFAT-SQM</S>
+          <S>Microsoft-Windows-Bluetooth-BthLEPrepairing</S>
+          <S>Microsoft-Windows-Kernel-Tm</S>
+          <S>Microsoft-Windows-Smartcard-Server</S>
+          <S>Microsoft-Windows-WAS</S>
+          <S>Microsoft-Windows-SetupPlatform</S>
+          <S>Microsoft-Windows-FunctionDiscoveryHost</S>
+          <S>Service Control Manager</S>
+          <S>Microsoft-Windows-GPIO-ClassExtension</S>
+          <S>Microsoft-Windows-TerminalServices-LocalSessionManager</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Results</S>
+          <S>Microsoft-Windows-NdisImPlatformSysEvtProvider</S>
+          <S>Microsoft-Windows-HAL</S>
+          <S>Microsoft-Windows-Devices-Background</S>
+          <S>Microsoft-Windows-Iphlpsvc</S>
+          <S>Microsoft-Windows-DHCPv6-Client</S>
+          <S>Microsoft-Windows-Fault-Tolerant-Heap</S>
+          <S>Microsoft-Windows-RasSstp</S>
+          <S>Microsoft-Windows-ServerManager-ConfigureSMRemoting</S>
+          <S>Microsoft-Windows-TerminalServices-ClientUSBDevices</S>
+          <S>Microsoft-Windows-Wallet</S>
+          <S>Microsoft-Windows-LanguagePackSetup</S>
+          <S>Microsoft-Windows-SPB-ClassExtension</S>
+          <S>Microsoft-Windows-IsolatedUserMode</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Schedule</S>
+          <S>Microsoft-Windows-PrintService</S>
+          <S>Microsoft-Windows-ResourcePublication</S>
+          <S>Microsoft-Windows-Setup</S>
+          <S>Microsoft-Windows-Kernel-WHEA</S>
+          <S>Microsoft-Windows-HttpEvent</S>
+          <S>Microsoft-Windows-WinHttp</S>
+          <S>Microsoft-Windows-TPM-WMI</S>
+          <S>Microsoft-Windows-DfsSvc</S>
+          <S>Microsoft-Windows-SDDC-Management</S>
+          <S>Microsoft-Windows-Audit-CVE</S>
+          <S>Microsoft-Windows-Ntfs-UBPM</S>
+          <S>Microsoft-Windows-WindowsUpdateClient</S>
+          <S>Microsoft-Windows-Kernel-Interrupt-Steering</S>
+          <S>Microsoft-Windows-TerminalServices-Printers</S>
+          <S>Microsoft-Windows-OfflineFiles</S>
+          <S>Microsoft-Windows-UserPnp</S>
+          <S>NetJoin</S>
+          <S>Microsoft-Windows-Security-Kerberos</S>
+          <S>Microsoft-Windows-SPB-HIDI2C</S>
+          <S>Microsoft-Windows-Resource-Exhaustion-Detector</S>
+          <S>Microsoft-Windows-Kernel-PnP</S>
+          <S>Microsoft-Windows-SCPNP</S>
+          <S>Microsoft-Windows-ResetEng</S>
+          <S>Microsoft-Windows-NetworkBridge</S>
+          <S>Microsoft-Windows-Kernel-General</S>
+          <S>Microsoft-Windows-SharedAccess_NAT</S>
+          <S>Microsoft-Windows-WinRM</S>
+          <S>Microsoft-Windows-EnhancedStorage-EhStorTcgDrv</S>
+          <S>Microsoft-Windows-WER-SystemErrorReporting</S>
+          <S>Microsoft-Windows-Kernel-IO</S>
+          <S>Microsoft-Windows-WPDClassInstaller</S>
+          <S>Microsoft-Windows-GroupPolicy</S>
+          <S>User32</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Client</S>
+          <S>Microsoft-Windows-Memory-Diagnostic-Task-Handler</S>
+          <S>Microsoft-Windows-IIS-IisMetabaseAudit</S>
+          <S>Microsoft-Windows-Servicing</S>
+          <S>Microsoft-Pef-WFP-MessageProvider</S>
+          <S>Microsoft-Windows-WHEA-Logger</S>
+          <S>Microsoft-Windows-TerminalServices-RemoteConnectionManager</S>
+          <S>Microsoft-Windows-StartupRepair</S>
+          <S>Microsoft-Windows-IIS-APPHOSTSVC</S>
+          <S>Volsnap</S>
+          <S>Microsoft-Windows-ReFS</S>
+          <S>Microsoft-Windows-Power-Troubleshooter</S>
+          <S>Microsoft-Windows-NDIS</S>
+          <S>Microsoft-Windows-UserModePowerService</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Intel-iaLPSS-GPIO</S>
+          <S>Intel-iaLPSS-I2C</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Server</S>
+          <S>Microsoft-Windows-IIS-IISReset</S>
+          <S>Microsoft-Windows-ScmDisk0101</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-TerminalServices-ServerUSBDevices</S>
+          <S>Ntfs</S>
+          <S>Microsoft-Windows-TaskScheduler</S>
+          <S>Microsoft-Windows-FMS</S>
+          <S>Microsoft-Windows-MountMgr</S>
+          <S>Microsoft-Windows-Firewall</S>
+          <S>Microsoft-Windows-DiskDiagnostic</S>
+          <S>Microsoft-Windows-Serial-ClassExtension-V2</S>
+          <S>Microsoft-Windows-Bits-Client</S>
+          <S>Microsoft-Windows-Kernel-XDV</S>
+          <S>Microsoft-Windows-AppReadiness</S>
+          <S>Microsoft-Windows-MPRMSG</S>
+          <S>Microsoft-Windows-FilterManager</S>
+          <S>Microsoft-Windows-Eventlog</S>
+          <S>Microsoft-Windows-W3LOGSVC</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">16</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">3215360</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2020-10-30T08:24:46.7190661-07:00</DT>
+      <DT N="LastWriteTime">2024-06-20T08:53:28.3234159-07:00</DT>
+      <I64 N="OldestRecordNumber">1</I64>
+      <I64 N="RecordCount">5864</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventApplication.xml
@@ -1,0 +1,385 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">Application</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Application</ToString>
+        <I32>0</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0x2;;;S-1-15-2-1)(A;;0x2;;;S-1-15-3-1024-3153509613-960666767-3724611135-2725662640-12138253-543910227-1950414635-4190290187)(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\Application.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>.NET Runtime</S>
+          <S>.NET Runtime Optimization Service</S>
+          <S>Application</S>
+          <S>Application Error</S>
+          <S>Application Hang</S>
+          <S>Application Management</S>
+          <S>ASP.NET 4.0.30319.0</S>
+          <S>CardSpace 4.0.0.0</S>
+          <S>Chkdsk</S>
+          <S>Chrome</S>
+          <S>DeliveryOptimization</S>
+          <S>Desktop Window Manager</S>
+          <S>DiskQuota</S>
+          <S>Dwminit</S>
+          <S>ESE</S>
+          <S>ESE BACKUP</S>
+          <S>ESENT</S>
+          <S>ExchangeStoreDB</S>
+          <S>FfoSyncLog</S>
+          <S>FfoSystemProbe</S>
+          <S>Filtering ADConnector</S>
+          <S>FMS</S>
+          <S>ForeFrontActiveMonitoring</S>
+          <S>Group Policy Applications</S>
+          <S>Group Policy Client</S>
+          <S>Group Policy Data Sources</S>
+          <S>Group Policy Device Settings</S>
+          <S>Group Policy Drive Maps</S>
+          <S>Group Policy Environment</S>
+          <S>Group Policy Files</S>
+          <S>Group Policy Folder Options</S>
+          <S>Group Policy Folders</S>
+          <S>Group Policy Ini Files</S>
+          <S>Group Policy Internet Settings</S>
+          <S>Group Policy Local Users and Groups</S>
+          <S>Group Policy Mail Profiles</S>
+          <S>Group Policy Network Options</S>
+          <S>Group Policy Network Shares</S>
+          <S>Group Policy Power Options</S>
+          <S>Group Policy Printers</S>
+          <S>Group Policy Regional Options</S>
+          <S>Group Policy Registry</S>
+          <S>Group Policy Scheduled Tasks</S>
+          <S>Group Policy Services</S>
+          <S>Group Policy Shortcuts</S>
+          <S>Group Policy Standard Edition</S>
+          <S>Group Policy Start Menu Settings</S>
+          <S>GroupPolicy</S>
+          <S>Handwriting Recognition</S>
+          <S>HostableWebCore</S>
+          <S>IISADMIN</S>
+          <S>IISInfoCtrs</S>
+          <S>InferenceTrainingAssistant</S>
+          <S>Microsoft Exchange Mailbox Transport Submission</S>
+          <S>Microsoft Exchange Server</S>
+          <S>Microsoft-Windows-Defrag</S>
+          <S>Microsoft-Windows-IIS-IISManager</S>
+          <S>Microsoft.Transactions.Bridge 4.0.0.0</S>
+          <S>MSComplianceAudit</S>
+          <S>MSExchange ActiveSync</S>
+          <S>MSExchange ADAccess</S>
+          <S>MSExchange Anti-spam Update</S>
+          <S>MSExchange Antimalware</S>
+          <S>MSExchange Antispam</S>
+          <S>MSExchange Assistants</S>
+          <S>MSExchange AuditLogPumper</S>
+          <S>MSExchange AuditLogSearch</S>
+          <S>MSExchange AuditStorageMonitor</S>
+          <S>MSExchange AuthAdmin</S>
+          <S>MSExchange Autodiscover</S>
+          <S>MSExchange Availability</S>
+          <S>MSExchange BackEndRehydration</S>
+          <S>MSExchange BigFunnel</S>
+          <S>MSExchange Bulk User Provisioning</S>
+          <S>MSExchange CalendarRepairAssistant</S>
+          <S>MSExchange Certificate</S>
+          <S>MSExchange Certificate Authentication Module</S>
+          <S>MSExchange Certificate Deployment</S>
+          <S>MSExchange Certificate Notification</S>
+          <S>MSExchange ClassificationDefinitions</S>
+          <S>MSExchange Cluster</S>
+          <S>MSExchange Common</S>
+          <S>MSExchange Configuration Core</S>
+          <S>MSExchange Control Panel</S>
+          <S>MSExchange Delegated Authentication Module</S>
+          <S>MSExchange DiagnosticsAggregation</S>
+          <S>MSExchange EdgeSync</S>
+          <S>MSExchange Extensibility</S>
+          <S>MSExchange FailFast Module</S>
+          <S>MSExchange Front End HTTP Proxy</S>
+          <S>MSExchange IMAP4 backend service</S>
+          <S>MSExchange IMAP4 service</S>
+          <S>MSExchange Internet Proxy</S>
+          <S>MSExchange JobQueue</S>
+          <S>MSExchange KillSwitch</S>
+          <S>MSExchange LiveId Redirection Module</S>
+          <S>MSExchange LiveIdBasicAuthentication</S>
+          <S>MSExchange Mailbox Assistants Provider</S>
+          <S>MSExchange Mailbox Replication</S>
+          <S>MSExchange MailTips</S>
+          <S>MSExchange Management Application</S>
+          <S>MSExchange Messaging Policies</S>
+          <S>MSExchange Mid-Tier Storage</S>
+          <S>MSExchange Migration</S>
+          <S>MSExchange Migration Workflow</S>
+          <S>MSExchange Mitigation Service</S>
+          <S>MSExchange Net</S>
+          <S>MSExchange Notifications Broker</S>
+          <S>MSExchange OABRequestHandler</S>
+          <S>MSExchange OAuth</S>
+          <S>MSExchange Organization Redirection Module</S>
+          <S>MSExchange OrganizationConfiguration</S>
+          <S>MSExchange OutlookPolicyNudgeRules</S>
+          <S>MSExchange OutlookProtectionRules</S>
+          <S>MSExchange OWA</S>
+          <S>MSExchange PICW</S>
+          <S>MSExchange POP3 backend service</S>
+          <S>MSExchange POP3 service</S>
+          <S>MSExchange Provisioning MailboxAssistant</S>
+          <S>MSExchange RBAC</S>
+          <S>MSExchange RemotePowershell BackendCmdletProxy Module</S>
+          <S>MSExchange Routing</S>
+          <S>MSExchange RPC Over HTTP Autoconfig</S>
+          <S>MSExchange SACL Watcher</S>
+          <S>MSExchange Shared Cache</S>
+          <S>MSExchange Store Driver Delivery</S>
+          <S>MSExchange Store Driver Submission</S>
+          <S>MSExchange Store Objects Service</S>
+          <S>MSExchange TextProcessing</S>
+          <S>MSExchange Topology</S>
+          <S>MSExchange TransportService</S>
+          <S>MSExchange Unified Messaging</S>
+          <S>MSExchange Unified Policy Sync</S>
+          <S>MSExchange UnifiedPolicyFileSync</S>
+          <S>MSExchange VariantConfiguration</S>
+          <S>MSExchange Web Services</S>
+          <S>MSExchange WorkloadManagement</S>
+          <S>MSExchange X400 Proxy</S>
+          <S>MSExchangeAB</S>
+          <S>MSExchangeADTopology</S>
+          <S>MSExchangeAL</S>
+          <S>MSExchangeAntispamUpdate</S>
+          <S>MSExchangeApplicationLogic</S>
+          <S>MSExchangeCluster</S>
+          <S>MSExchangeCompliance</S>
+          <S>MSExchangeDagMgmt</S>
+          <S>MSExchangeDelivery</S>
+          <S>MSExchangeDiagnostics</S>
+          <S>MSExchangeEdgeSync</S>
+          <S>MSExchangeEHALogSearchComponent</S>
+          <S>MSExchangeFastSearch</S>
+          <S>MSExchangeFrontEndTransport</S>
+          <S>MSExchangeGlobalLocatorCache</S>
+          <S>MSExchangeHM</S>
+          <S>MSExchangeHMHost</S>
+          <S>MSExchangeHMRecovery</S>
+          <S>MSExchangeIMAP4</S>
+          <S>MSExchangeIMAP4BE</S>
+          <S>MSExchangeInference</S>
+          <S>MSExchangeIS</S>
+          <S>MSExchangeIS Mailbox Store</S>
+          <S>MSExchangeIS Public Store</S>
+          <S>MSExchangeMailboxAssistants</S>
+          <S>MSExchangeMailboxReplication</S>
+          <S>MSExchangeMapiAddressBookAppPool</S>
+          <S>MSExchangeMapiMailboxAppPool</S>
+          <S>MSExchangeMig</S>
+          <S>MSExchangeMigDS</S>
+          <S>MSExchangeMitigation</S>
+          <S>MSExchangeMU</S>
+          <S>MSExchangePOP3</S>
+          <S>MSExchangePOP3BE</S>
+          <S>MSExchangeRepl</S>
+          <S>MSExchangeRPC</S>
+          <S>MSExchangeSA</S>
+          <S>MSExchangeServiceHost</S>
+          <S>MSExchangeSetup</S>
+          <S>MSExchangeSubmission</S>
+          <S>MSExchangeThrottling</S>
+          <S>MSExchangeThrottlingClient</S>
+          <S>MSExchangeTransport</S>
+          <S>MSExchangeTransportDelivery</S>
+          <S>MSExchangeTransportLogSearch</S>
+          <S>MSExchangeTransportMailboxAssistants</S>
+          <S>MSExchangeTransportMailSubmission</S>
+          <S>MSExchangeTransportSearch</S>
+          <S>MSExchangeTransportSubmission</S>
+          <S>MSExchangeTransportSyncCommon</S>
+          <S>MSExchangeTransportSyncManager</S>
+          <S>MSExchangeTransportSyncWorker</S>
+          <S>MSExchangeTransportSyncWorkerFramework</S>
+          <S>MSExchangeWEB</S>
+          <S>MsiInstaller</S>
+          <S>RasClient</S>
+          <S>RPC Proxy</S>
+          <S>RPC/HTTP LB Service</S>
+          <S>SceCli</S>
+          <S>SceSrv</S>
+          <S>Search HostController</S>
+          <S>ServiceModel Audit 4.0.0.0</S>
+          <S>SideBySide</S>
+          <S>Software Installation</S>
+          <S>SpeechRuntime</S>
+          <S>SrmSvc</S>
+          <S>System.IdentityModel 4.0.0.0</S>
+          <S>System.IO.Log 4.0.0.0</S>
+          <S>System.Runtime.Serialization 4.0.0.0</S>
+          <S>System.ServiceModel 4.0.0.0</S>
+          <S>usbperf</S>
+          <S>VBRuntime</S>
+          <S>VSS</S>
+          <S>VSSetup</S>
+          <S>WerSvc</S>
+          <S>Windows Error Reporting</S>
+          <S>WMI.NET Provider Extension</S>
+          <S>Wow64 Emulation Layer</S>
+          <S>WSH</S>
+          <S>Microsoft-Windows-PDH</S>
+          <S>Microsoft-Windows-LiveId</S>
+          <S>Microsoft-Windows-RestartManager</S>
+          <S>Microsoft-Windows-Complus</S>
+          <S>Microsoft-Windows-WindowsSystemAssessmentTool</S>
+          <S>Microsoft-Windows-LoadPerf</S>
+          <S>Microsoft-Windows-Perflib</S>
+          <S>Microsoft-Windows-Crypto-RSAEnh</S>
+          <S>Microsoft-Windows-MSDTC Client 2</S>
+          <S>Microsoft-Windows-RemoteApp and Desktop Connections</S>
+          <S>Microsoft-Windows-Spellchecking-Host</S>
+          <S>Microsoft-Filtering-FIPFS</S>
+          <S>Microsoft-Windows-Backup</S>
+          <S>Microsoft-Windows-WMI</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-IIS-WMSVC</S>
+          <S>Microsoft-Windows-TerminalServices-ClientActiveXCore</S>
+          <S>Microsoft-Windows-IPMIProvider</S>
+          <S>Microsoft-Windows-Security-EnterpriseData-FileRevocationManager</S>
+          <S>Microsoft-Windows-Immersive-Shell</S>
+          <S>Microsoft-Windows-EFS</S>
+          <S>Microsoft-Windows-DirectShow-KernelSupport</S>
+          <S>Microsoft-Windows-Crypto-DSSEnh</S>
+          <S>Microsoft-Windows-AAD</S>
+          <S>Microsoft-Windows-GenericRoaming</S>
+          <S>Microsoft-Windows-BestPractices</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CertEnroll</S>
+          <S>Microsoft-Windows-Crypto-RNG</S>
+          <S>Microsoft-Windows-CAPI2</S>
+          <S>Microsoft-Windows-MSDTC 2</S>
+          <S>Microsoft-Windows-ApplicationExperienceInfrastructure</S>
+          <S>Microsoft-Windows-IIS-W3SVC-WP</S>
+          <S>Microsoft-Office Server-Search</S>
+          <S>Microsoft-Windows-EapHost</S>
+          <S>Microsoft-Windows-Video-For-Windows</S>
+          <S>Microsoft-Windows-MSDTC</S>
+          <S>Microsoft-Windows-DirectoryServices-Deployment</S>
+          <S>Microsoft-Windows-PerfProc</S>
+          <S>Microsoft-Windows-CertificateServicesClient</S>
+          <S>Microsoft-Windows-XWizards</S>
+          <S>Microsoft-Windows-FileServices-ServerManager-EventProvider</S>
+          <S>Microsoft-Windows-MSDTC Client</S>
+          <S>Microsoft-Windows-SoftwareRestrictionPolicies</S>
+          <S>Microsoft-Windows-Folder Redirection</S>
+          <S>Microsoft-Windows-PerfDisk</S>
+          <S>Microsoft-Windows-Audit-CVE</S>
+          <S>Microsoft-Windows-FileShareShadowCopyProvider</S>
+          <S>Microsoft-Windows-EventSystem</S>
+          <S>Microsoft-Windows-CertificateServicesClient-CredentialRoaming</S>
+          <S>Microsoft-Windows-User Profiles Service</S>
+          <S>Microsoft-Windows-Crypto-DPAPI</S>
+          <S>Microsoft-Windows-IIS-W3SVC-PerfCounters</S>
+          <S>Microsoft-Windows-propsys</S>
+          <S>Microsoft-Windows-DirectShow-Core</S>
+          <S>Microsoft-Windows-PerfCtrs</S>
+          <S>Microsoft-Windows-CertificationAuthorityClient-CertCli</S>
+          <S>Microsoft-Windows-Management-UI</S>
+          <S>Microsoft-Windows-Winsrv</S>
+          <S>Microsoft-Windows-Biometrics</S>
+          <S>Application-Addon-Event-Provider</S>
+          <S>Microsoft-Windows-SmartCard-DeviceEnum</S>
+          <S>Microsoft-Windows-Audio</S>
+          <S>Microsoft-Windows-User-Loader</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-COMRuntime</S>
+          <S>Microsoft-Windows-AppModel-State</S>
+          <S>Microsoft-Windows-FederationServices-Deployment</S>
+          <S>Microsoft-Windows-EnrollmentWebService</S>
+          <S>Microsoft-Windows-Crypto-BCrypt</S>
+          <S>Microsoft-Windows-Search</S>
+          <S>Microsoft-Windows-PerfNet</S>
+          <S>Error Instrument</S>
+          <S>Microsoft-Windows-MSMQ</S>
+          <S>Microsoft-Windows-PrintBRM</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Microsoft-Windows-WAS-ListenerAdapter</S>
+          <S>Microsoft-Windows-ServerManager-MultiMachine</S>
+          <S>Microsoft-Windows-ASN1</S>
+          <S>Microsoft-Windows-AxInstallService</S>
+          <S>Microsoft-Windows-User Profiles General</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-Security-SPP</S>
+          <S>Microsoft-Windows-Crypto-CNG</S>
+          <S>Microsoft-Windows-Security-Netlogon</S>
+          <S>Microsoft-Windows-Crypto-NCrypt</S>
+          <S>Microsoft-Windows-CertificateServicesClient-AutoEnrollment</S>
+          <S>Microsoft-Windows-AppModel-Runtime</S>
+          <S>Microsoft-Windows-RPC-Events</S>
+          <S>Microsoft-Windows-EnrollmentPolicyWebService</S>
+          <S>Microsoft-Windows-DeviceGuard</S>
+          <S>Microsoft-Windows-PerfOS</S>
+          <S>Microsoft-Windows-DeliveryOptimization</S>
+          <S>Microsoft-Windows-Rdms-UI</S>
+          <S>Microsoft-Windows-Search-ProfileNotify</S>
+          <S>Microsoft-Windows-ProcessExitMonitor</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">64</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">20975616</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2024-06-20T10:47:15.2155814-04:00</DT>
+      <DT N="LastWriteTime">2024-06-20T10:47:15.2155814-04:00</DT>
+      <I64 N="OldestRecordNumber">84889</I64>
+      <I64 N="RecordCount">33282</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventOldestApplication.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventOldestApplication.xml
@@ -1,0 +1,93 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">16028</I32>
+      <Nil N="Version" />
+      <I32 N="Qualifiers">16388</I32>
+      <By N="Level">4</By>
+      <I32 N="Task">16</I32>
+      <Nil N="Opcode" />
+      <I64 N="Keywords">36028797018963968</I64>
+      <I64 N="RecordId">142609</I64>
+      <S N="ProviderName">MSExchangeTransportSubmission</S>
+      <Nil N="ProviderId" />
+      <S N="LogName">Application</S>
+      <Nil N="ProcessId" />
+      <Nil N="ThreadId" />
+      <S N="MachineName">Solo-E19A.Solo.com</S>
+      <Nil N="UserId" />
+      <DT N="TimeCreated">2024-06-18T05:42:06.00811-04:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">Application</S>
+      <Obj N="MatchedQueryIds" RefId="1">
+        <TN RefId="1">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <Nil N="OpcodeDisplayName" />
+      <S N="TaskDisplayName">Configuration</S>
+      <Obj N="KeywordsDisplayNames" RefId="3">
+        <TN RefId="3">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>Classic</S>
+        </LST>
+      </Obj>
+      <Obj N="Properties" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="5">
+            <TN RefId="5">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">Microsoft.Exchange.Transport.TransportServerConfiguration</S>
+            </Props>
+          </Obj>
+          <Obj RefId="6">
+            <TNRef RefId="5" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value"></S>
+            </Props>
+          </Obj>
+          <Obj RefId="7">
+            <TNRef RefId="5" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value"></S>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">A forced configuration update for Microsoft.Exchange.Transport.TransportServerConfiguration has successfully completed. Object details from  the last notification-based reload: . New details: </S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventOldestSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventOldestSystem.xml
@@ -1,0 +1,110 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogRecord</T>
+      <T>System.Diagnostics.Eventing.Reader.EventRecord</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogRecord</ToString>
+    <Props>
+      <I32 N="Id">104</I32>
+      <By N="Version">0</By>
+      <Nil N="Qualifiers" />
+      <By N="Level">4</By>
+      <I32 N="Task">104</I32>
+      <I16 N="Opcode">0</I16>
+      <I64 N="Keywords">-9223372036854775808</I64>
+      <I64 N="RecordId">8943</I64>
+      <S N="ProviderName">Microsoft-Windows-Eventlog</S>
+      <G N="ProviderId">fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148</G>
+      <S N="LogName">System</S>
+      <I32 N="ProcessId">1420</I32>
+      <I32 N="ThreadId">1688</I32>
+      <S N="MachineName">WIN-MOQT6B0G2B8</S>
+      <Obj N="UserId" RefId="1">
+        <TN RefId="1">
+          <T>System.Security.Principal.SecurityIdentifier</T>
+          <T>System.Security.Principal.IdentityReference</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>S-1-5-21-3679660373-2343198519-3656105545-500</ToString>
+        <Props>
+          <I32 N="BinaryLength">28</I32>
+          <S N="AccountDomainSid">S-1-5-21-3679660373-2343198519-3656105545</S>
+          <S N="Value">S-1-5-21-3679660373-2343198519-3656105545-500</S>
+        </Props>
+      </Obj>
+      <DT N="TimeCreated">2021-10-06T13:51:55.3244766-04:00</DT>
+      <Nil N="ActivityId" />
+      <Nil N="RelatedActivityId" />
+      <S N="ContainerLog">System</S>
+      <Obj N="MatchedQueryIds" RefId="2">
+        <TN RefId="2">
+          <T>System.UInt32[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Bookmark" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventBookmark</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System.Diagnostics.Eventing.Reader.EventBookmark</ToString>
+      </Obj>
+      <S N="LevelDisplayName">Information</S>
+      <S N="OpcodeDisplayName">Info</S>
+      <S N="TaskDisplayName">Log clear</S>
+      <Obj N="KeywordsDisplayNames" RefId="4">
+        <TN RefId="4">
+          <T>System.Collections.ObjectModel.ReadOnlyCollection`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST />
+      </Obj>
+      <Obj N="Properties" RefId="5">
+        <TN RefId="5">
+          <T>System.Collections.Generic.List`1[[System.Diagnostics.Eventing.Reader.EventProperty, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <Obj RefId="6">
+            <TN RefId="6">
+              <T>System.Diagnostics.Eventing.Reader.EventProperty</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">Administrator</S>
+            </Props>
+          </Obj>
+          <Obj RefId="7">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">WIN-MOQT6B0G2B8</S>
+            </Props>
+          </Obj>
+          <Obj RefId="8">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value">System</S>
+            </Props>
+          </Obj>
+          <Obj RefId="9">
+            <TNRef RefId="6" />
+            <ToString>System.Diagnostics.Eventing.Reader.EventProperty</ToString>
+            <Props>
+              <S N="Value"></S>
+            </Props>
+          </Obj>
+        </LST>
+      </Obj>
+    </Props>
+    <MS>
+      <S N="Message">The System log file was cleared.</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventSystem.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/OS/GetWinEventSystem.xml
@@ -1,0 +1,362 @@
+﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Diagnostics.Eventing.Reader.EventLogConfiguration</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>System.Diagnostics.Eventing.Reader.EventLogConfiguration</ToString>
+    <Props>
+      <S N="LogName">System</S>
+      <Obj N="LogType" RefId="1">
+        <TN RefId="1">
+          <T>System.Diagnostics.Eventing.Reader.EventLogType</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Administrative</ToString>
+        <I32>0</I32>
+      </Obj>
+      <Obj N="LogIsolation" RefId="2">
+        <TN RefId="2">
+          <T>System.Diagnostics.Eventing.Reader.EventLogIsolation</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>System</ToString>
+        <I32>1</I32>
+      </Obj>
+      <B N="IsEnabled">true</B>
+      <B N="IsClassicLog">true</B>
+      <S N="SecurityDescriptor">O:BAG:SYD:(A;;0xf0007;;;SY)(A;;0x7;;;BA)(A;;0x3;;;BO)(A;;0x5;;;SO)(A;;0x1;;;IU)(A;;0x3;;;SU)(A;;0x1;;;S-1-5-3)(A;;0x2;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)</S>
+      <S N="LogFilePath">%SystemRoot%\System32\Winevt\Logs\System.evtx</S>
+      <I64 N="MaximumSizeInBytes">20971520</I64>
+      <Obj N="LogMode" RefId="3">
+        <TN RefId="3">
+          <T>System.Diagnostics.Eventing.Reader.EventLogMode</T>
+          <T>System.Enum</T>
+          <T>System.ValueType</T>
+          <T>System.Object</T>
+        </TN>
+        <ToString>Circular</ToString>
+        <I32>0</I32>
+      </Obj>
+      <S N="OwningProviderName"></S>
+      <Obj N="ProviderNames" RefId="4">
+        <TN RefId="4">
+          <T>System.String[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>3ware</S>
+          <S>ACPI</S>
+          <S>ADP80XX</S>
+          <S>AFD</S>
+          <S>AmdK8</S>
+          <S>AmdPPM</S>
+          <S>amdsata</S>
+          <S>amdsbs</S>
+          <S>amdxata</S>
+          <S>Application Management Group Policy</S>
+          <S>arcsas</S>
+          <S>AsyncMac</S>
+          <S>atapi</S>
+          <S>b06bdrv</S>
+          <S>BasicRender</S>
+          <S>beep</S>
+          <S>bfadfcoei</S>
+          <S>bfadi</S>
+          <S>BthEnum</S>
+          <S>BthLEEnum</S>
+          <S>BthMini</S>
+          <S>BTHPORT</S>
+          <S>BTHUSB</S>
+          <S>bxfcoe</S>
+          <S>bxois</S>
+          <S>cdrom</S>
+          <S>cht4iscsi</S>
+          <S>cht4vbd</S>
+          <S>disk</S>
+          <S>Display</S>
+          <S>Dnsapi</S>
+          <S>Dnscache</S>
+          <S>ebdrv</S>
+          <S>elxfcoe</S>
+          <S>elxstor</S>
+          <S>eventlog</S>
+          <S>exFAT</S>
+          <S>EXIFS</S>
+          <S>FltMgr</S>
+          <S>HpSAMD</S>
+          <S>i8042prt</S>
+          <S>iaStorAVC</S>
+          <S>iaStorV</S>
+          <S>ibbus</S>
+          <S>IIS Config</S>
+          <S>IISLOG</S>
+          <S>IISWMI</S>
+          <S>intelppm</S>
+          <S>IPMIDRV</S>
+          <S>isapnp</S>
+          <S>iScsiPrt</S>
+          <S>ItSas35i</S>
+          <S>kbdclass</S>
+          <S>kbdhid</S>
+          <S>kdnic</S>
+          <S>Lfsvc</S>
+          <S>lltdio</S>
+          <S>LmHosts</S>
+          <S>LSI_SAS</S>
+          <S>LSI_SAS2i</S>
+          <S>LSI_SAS3i</S>
+          <S>LSI_SSS</S>
+          <S>megasas</S>
+          <S>megasas2i</S>
+          <S>megasas35i</S>
+          <S>megasr</S>
+          <S>mlx4_bus</S>
+          <S>mouclass</S>
+          <S>mouhid</S>
+          <S>mrxsmb</S>
+          <S>MsBridge</S>
+          <S>MSExchange Server</S>
+          <S>mshidumdf</S>
+          <S>MSiSCSI</S>
+          <S>MTConfig</S>
+          <S>Mup</S>
+          <S>mvumis</S>
+          <S>NdisImPlatform</S>
+          <S>NdisWan</S>
+          <S>ndiswanlegacy</S>
+          <S>NetBIOS</S>
+          <S>NetBT</S>
+          <S>Netlogon</S>
+          <S>Ntfs</S>
+          <S>nvdimm</S>
+          <S>nvstor</S>
+          <S>Parport</S>
+          <S>partmgr</S>
+          <S>pcmcia</S>
+          <S>percsas2i</S>
+          <S>percsas3i</S>
+          <S>pmem</S>
+          <S>PNPMEM</S>
+          <S>Power</S>
+          <S>PptpMiniport</S>
+          <S>Processor</S>
+          <S>qebdrv</S>
+          <S>qefcoe</S>
+          <S>qeois</S>
+          <S>ql2300i</S>
+          <S>ql40xx2i</S>
+          <S>qlfcoei</S>
+          <S>RasAuto</S>
+          <S>RasCfg</S>
+          <S>Rasman</S>
+          <S>rdbss</S>
+          <S>RemoteAccess</S>
+          <S>RFCOMM</S>
+          <S>rhproxy</S>
+          <S>rspndr</S>
+          <S>sbp2port</S>
+          <S>scmbus</S>
+          <S>sercx</S>
+          <S>sercx2</S>
+          <S>Serial</S>
+          <S>sermouse</S>
+          <S>Server</S>
+          <S>SiSRaid2</S>
+          <S>SiSRaid4</S>
+          <S>SmartSAMD</S>
+          <S>SMSvcHost 4.0.0.0</S>
+          <S>SNMPTRAP</S>
+          <S>spaceport</S>
+          <S>spbcx</S>
+          <S>Srv</S>
+          <S>stexstor</S>
+          <S>StillImage</S>
+          <S>storahci</S>
+          <S>stornvme</S>
+          <S>System</S>
+          <S>Tcpip</S>
+          <S>Tcpip6</S>
+          <S>TCPMon</S>
+          <S>tunnel</S>
+          <S>UASPStor</S>
+          <S>UEFI</S>
+          <S>usbehci</S>
+          <S>usbser</S>
+          <S>VDS Basic Provider</S>
+          <S>VDS Dynamic Provider</S>
+          <S>VDS Virtual Disk Provider</S>
+          <S>Virtual Disk Service</S>
+          <S>volmgr</S>
+          <S>vpci</S>
+          <S>vsmraid</S>
+          <S>VSTXRAID</S>
+          <S>WacomPen</S>
+          <S>wdf01000</S>
+          <S>wecsvc</S>
+          <S>Win32k</S>
+          <S>Windows Disk Diagnostic</S>
+          <S>Windows Script Host</S>
+          <S>WinNat</S>
+          <S>WMIxWDM</S>
+          <S>Workstation</S>
+          <S>Microsoft-Windows-IIS-W3SVC</S>
+          <S>Microsoft-Windows-ReFS-v1</S>
+          <S>Microsoft-Windows-Time-Service</S>
+          <S>Microsoft-Windows-CoreSystem-InitMachineConfig</S>
+          <S>Microsoft-Windows-Directory-Services-SAM</S>
+          <S>Microsoft-Windows-Kernel-Processor-Power</S>
+          <S>Microsoft-Windows-PersistentMemory-PmemDisk</S>
+          <S>Microsoft-Windows-Windows Defender</S>
+          <S>Microsoft-Windows-Hyper-V-Netvsc</S>
+          <S>Microsoft-Windows-Dhcp-Client</S>
+          <S>Microsoft-Windows-Kernel-Boot</S>
+          <S>LsaSrv</S>
+          <S>Microsoft-Windows-DistributedCOM</S>
+          <S>TPM</S>
+          <S>Microsoft-Windows-DNS-Client</S>
+          <S>Schannel</S>
+          <S>Microsoft-Windows-Wininit</S>
+          <S>Microsoft-Windows-TerminalServices-SessionBroker-Client</S>
+          <S>Microsoft-Windows-RasServer</S>
+          <S>Microsoft-Windows-DriverFrameworks-UserMode</S>
+          <S>Microsoft-Windows-WindowsToGo-StartupOptions</S>
+          <S>Microsoft-Windows-Power-Meter-Polling</S>
+          <S>Microsoft-Windows-USB-USBXHCI</S>
+          <S>Microsoft-Windows-Kernel-Power</S>
+          <S>Microsoft-Windows-CoreSystem-NetProvision-JoinProviderOnline</S>
+          <S>Microsoft-Windows-Diagnostics-Networking</S>
+          <S>Microsoft-Windows-MsLbfoSysEvtProvider</S>
+          <S>Microsoft-Windows-Fat-SQM</S>
+          <S>Microsoft-Windows-Ntfs</S>
+          <S>Microsoft-Windows-Subsys-SMSS</S>
+          <S>Microsoft-Windows-OverlayFilter</S>
+          <S>Microsoft-Windows-Serial-ClassExtension</S>
+          <S>Application Popup</S>
+          <S>Microsoft-Windows-exFAT-SQM</S>
+          <S>Microsoft-Windows-Bluetooth-BthLEPrepairing</S>
+          <S>Microsoft-Windows-Kernel-Tm</S>
+          <S>Microsoft-Windows-Smartcard-Server</S>
+          <S>Microsoft-Windows-WAS</S>
+          <S>Microsoft-Windows-Hyper-V-Hypervisor</S>
+          <S>Microsoft-Windows-SetupPlatform</S>
+          <S>Microsoft-Windows-FunctionDiscoveryHost</S>
+          <S>Service Control Manager</S>
+          <S>Microsoft-Windows-GPIO-ClassExtension</S>
+          <S>Microsoft-Windows-TerminalServices-LocalSessionManager</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Results</S>
+          <S>Microsoft-Windows-NdisImPlatformSysEvtProvider</S>
+          <S>Microsoft-Windows-HAL</S>
+          <S>Microsoft-Windows-Devices-Background</S>
+          <S>Microsoft-Windows-Iphlpsvc</S>
+          <S>Microsoft-Windows-DHCPv6-Client</S>
+          <S>Microsoft-Windows-WMPNSS-Service</S>
+          <S>Microsoft-Windows-Fault-Tolerant-Heap</S>
+          <S>Microsoft-Windows-RasSstp</S>
+          <S>Microsoft-Windows-ServerManager-ConfigureSMRemoting</S>
+          <S>Microsoft-Windows-TerminalServices-ClientUSBDevices</S>
+          <S>Microsoft-Windows-Wallet</S>
+          <S>Microsoft-Windows-LanguagePackSetup</S>
+          <S>Microsoft-Windows-SPB-ClassExtension</S>
+          <S>Microsoft-Windows-IsolatedUserMode</S>
+          <S>Microsoft-Windows-MemoryDiagnostics-Schedule</S>
+          <S>Microsoft-Windows-PrintService</S>
+          <S>Microsoft-Windows-ResourcePublication</S>
+          <S>Microsoft-Windows-Setup</S>
+          <S>Microsoft-Windows-USB-MAUSBHOST</S>
+          <S>Microsoft-Windows-Kernel-WHEA</S>
+          <S>Microsoft-Windows-HttpEvent</S>
+          <S>Microsoft-Windows-WinHttp</S>
+          <S>Microsoft-Windows-TPM-WMI</S>
+          <S>Microsoft-Windows-DfsSvc</S>
+          <S>Microsoft-Windows-Audit-CVE</S>
+          <S>Microsoft-Windows-Ntfs-UBPM</S>
+          <S>Microsoft-Antimalware-ShieldProvider</S>
+          <S>Microsoft-Windows-WindowsUpdateClient</S>
+          <S>Microsoft-Windows-Kernel-Interrupt-Steering</S>
+          <S>Microsoft-Windows-TerminalServices-Printers</S>
+          <S>Microsoft-Windows-OfflineFiles</S>
+          <S>Microsoft-Windows-UserPnp</S>
+          <S>NetJoin</S>
+          <S>Microsoft-Windows-Security-Kerberos</S>
+          <S>Microsoft-Windows-SPB-HIDI2C</S>
+          <S>Microsoft-Windows-Resource-Exhaustion-Detector</S>
+          <S>Microsoft-Windows-Kernel-PnP</S>
+          <S>Microsoft-Windows-SCPNP</S>
+          <S>Microsoft-Windows-ResetEng</S>
+          <S>Microsoft-Windows-NetworkBridge</S>
+          <S>Microsoft-Windows-Kernel-General</S>
+          <S>Microsoft-Windows-SharedAccess_NAT</S>
+          <S>Microsoft-Windows-WinRM</S>
+          <S>Microsoft-Windows-PersistentMemory-Nvdimm</S>
+          <S>Microsoft-Windows-FailoverClustering-Client</S>
+          <S>Microsoft-Windows-EnhancedStorage-EhStorTcgDrv</S>
+          <S>Microsoft-Windows-WER-SystemErrorReporting</S>
+          <S>Microsoft-Windows-Kernel-IO</S>
+          <S>Microsoft-Windows-USB-USBHUB3</S>
+          <S>Microsoft-Windows-WPDClassInstaller</S>
+          <S>Microsoft-Windows-GroupPolicy</S>
+          <S>User32</S>
+          <S>Microsoft-Windows-SpellChecker</S>
+          <S>Microsoft-Windows-EventCollector</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Client</S>
+          <S>Microsoft-Windows-Memory-Diagnostic-Task-Handler</S>
+          <S>Microsoft-Windows-IIS-IisMetabaseAudit</S>
+          <S>Microsoft-Windows-Servicing</S>
+          <S>Microsoft-Pef-WFP-MessageProvider</S>
+          <S>Microsoft-Windows-WHEA-Logger</S>
+          <S>Microsoft-Windows-TerminalServices-RemoteConnectionManager</S>
+          <S>Microsoft-Windows-StartupRepair</S>
+          <S>Microsoft-Windows-IIS-APPHOSTSVC</S>
+          <S>Volsnap</S>
+          <S>Microsoft-Windows-ReFS</S>
+          <S>Microsoft-Windows-Power-Troubleshooter</S>
+          <S>Microsoft-Windows-NDIS</S>
+          <S>Microsoft-Windows-UserModePowerService</S>
+          <S>Microsoft-Windows-Spell-Checking</S>
+          <S>Intel-iaLPSS-GPIO</S>
+          <S>Intel-iaLPSS-I2C</S>
+          <S>Microsoft-Windows-CorruptedFileRecovery-Server</S>
+          <S>Microsoft-Windows-IIS-IISReset</S>
+          <S>Microsoft-Windows-Winlogon</S>
+          <S>Microsoft-Windows-TerminalServices-ServerUSBDevices</S>
+          <S>Ntfs</S>
+          <S>Microsoft-Windows-TaskScheduler</S>
+          <S>Microsoft-Windows-FMS</S>
+          <S>Microsoft-Windows-MountMgr</S>
+          <S>Microsoft-Windows-Firewall</S>
+          <S>Microsoft-Windows-DiskDiagnostic</S>
+          <S>Microsoft-Windows-Serial-ClassExtension-V2</S>
+          <S>Microsoft-Windows-Bits-Client</S>
+          <S>Microsoft-Windows-Kernel-XDV</S>
+          <S>Microsoft-Windows-AppReadiness</S>
+          <S>Microsoft-Windows-MPRMSG</S>
+          <S>Microsoft-Windows-FilterManager</S>
+          <S>Microsoft-Windows-USB-CCID</S>
+          <S>Microsoft-Windows-Eventlog</S>
+          <S>Microsoft-Windows-W3LOGSVC</S>
+        </LST>
+      </Obj>
+      <Nil N="ProviderLevel" />
+      <Nil N="ProviderKeywords" />
+      <I32 N="ProviderBufferSize">64</I32>
+      <I32 N="ProviderMinimumNumberOfBuffers">0</I32>
+      <I32 N="ProviderMaximumNumberOfBuffers">16</I32>
+      <I32 N="ProviderLatency">1000</I32>
+      <Nil N="ProviderControlGuid" />
+    </Props>
+    <MS>
+      <I64 N="FileSize">5312512</I64>
+      <B N="IsLogFull">false</B>
+      <DT N="LastAccessTime">2024-06-20T10:43:24.3622285-04:00</DT>
+      <DT N="LastWriteTime">2024-06-20T10:43:24.3622285-04:00</DT>
+      <I64 N="OldestRecordNumber">1</I64>
+      <I64 N="RecordCount">14697</I64>
+    </MS>
+  </Obj>
+</Objs>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -107,8 +107,6 @@ Describe "Testing Health Checker by Mock Data Imports" {
         It "Event Log Size Test" {
             GetObject "Event Log - Application" |
                 Should -BeLike "--ERROR-- Not enough logs to cover 7 days. Last log entry is at *. This could cause issues with determining Root Cause Analysis."
-            GetObject "Event Log - System" |
-                Should -BeLike "--ERROR-- Not enough logs to cover 7 days. Last log entry is at *. This could cause issues with determining Root Cause Analysis."
         }
 
         It "TCP Keep Alive Time" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -52,6 +52,16 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Mock Get-LocalGroupMember { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetLocalGroupMember2.xml" }
             Mock Get-WindowsFeature { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWindowsFeature1.xml" }
             Mock Get-SmbServerConfiguration { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetSmbServerConfiguration1.xml" }
+            Mock Get-WinEvent -ParameterFilter { $LogName -eq "Application" -and $Oldest -eq $true -and $MaxEvents -eq 1 } -MockWith {
+                $r = Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventOldestApplication.xml"
+                $r.TimeCreated = ((Get-Date).AddDays(-1))
+                return $r
+            }
+            Mock Get-WinEvent -ParameterFilter { $LogName -eq "System" -and $Oldest -eq $true -and $MaxEvents -eq 1 } -MockWith {
+                $r = Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventOldestSystem.xml"
+                $r.TimeCreated = ((Get-Date).AddDays(-1))
+                return $r
+            }
             Mock Get-Service {
                 param(
                     [string]$ComputerName,
@@ -92,6 +102,13 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
         It "Message Queuing Feature" {
             TestObjectMatch "Messaging Queuing Feature" $true -WriteType "Yellow"
+        }
+
+        It "Event Log Size Test" {
+            GetObject "Event Log - Application" |
+                Should -BeLike "--ERROR-- Not enough logs to cover 7 days. Last log entry is at *. This could cause issues with determining Root Cause Analysis."
+            GetObject "Event Log - System" |
+                Should -BeLike "--ERROR-- Not enough logs to cover 7 days. Last log entry is at *. This could cause issues with determining Root Cause Analysis."
         }
 
         It "TCP Keep Alive Time" {

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -31,6 +31,19 @@ Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "G
 Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Test EEMS pattern service connectivity" } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\WebRequest_GetExchangeMitigations.xml" }
 Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Get TokenCacheModule version information" } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\IIS\GetVersionInformationCachTokn.xml" }
 
+Mock Get-WinEvent -ParameterFilter { $LogName -eq "Application" -and $Oldest -eq $true -and $MaxEvents -eq 1 } -MockWith {
+    $r = Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventOldestApplication.xml"
+    $r.TimeCreated = ((Get-Date).AddDays(-8))
+    return $r
+}
+Mock Get-WinEvent -ParameterFilter { $LogName -eq "System" -and $Oldest -eq $true -and $MaxEvents -eq 1 } -MockWith {
+    $r = Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventOldestSystem.xml"
+    $r.TimeCreated = ((Get-Date).AddDays(-8))
+    return $r
+}
+Mock Get-WinEvent -ParameterFilter { $ListLog -eq "Application" } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventApplication.xml" }
+Mock Get-WinEvent -ParameterFilter { $ListLog -eq "System" } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetWinEventSystem.xml" }
+
 # Handle IIS collection of files
 Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Getting applicationHost.config" } -MockWith { return Get-Content "$Script:MockDataCollectionRoot\Exchange\IIS\applicationHost.config" -Raw -Encoding UTF8 }
 


### PR DESCRIPTION
**Issue:**
If the application and system event logs are getting rolled over too quickly, the customer needs to be aware of this. 

**Reason:**
To bubble up some concerns with diagnostic information to be able to perform RCAs better for customers. 

**Fix:**
Check to see if the logs are at least 7 days old for the oldest entry in the log type. 

Resolved #2022 

**Validation:**
Lab tested/pester tested
