### PR TITLE
Add additional information to let admins know how to get the service display name

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -461,6 +461,17 @@ function Invoke-AnalyzerExchangeInformation {
                 Add-AnalyzedResultInformation @params
             }
         }
+
+        if ($exchangeInformation.DependentServices.Critical.Count -gt 0 -or
+            $exchangeInformation.DependentServices.Common.Count -gt 0 -or
+            $exchangeInformation.DependentServices.Misconfigured.Count -gt 0) {
+            $params = $baseParams + @{
+                Details                = "To determine what the display name of the service that is not properly configured or running, run 'Get-Service <Name>' to get more information."
+                DisplayCustomTabNumber = 2
+                DisplayWriteType       = "Yellow"
+            }
+            Add-AnalyzedResultInformation @params
+        }
     }
 
     if ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $false -and


### PR DESCRIPTION
**Issue:**
Admin wasn't sure what a service was or how to determine the display name seen in the GUI. Need to provide more information in the warning so they can attempt to find it. 

**Reason:**
To assist admins determining the name.

**Fix:**
Provide run `Get-Service <Name>` to determine more information. 

Resolved #2107 

**Validation:**
Lab tested

![image](https://github.com/microsoft/CSS-Exchange/assets/22776718/499eb93b-b40b-4a82-b590-9b2566efa8e1)

