### PR TITLE
Allow other features to work from a tools box

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Invoke-ConfirmExchangeShell.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-ConfirmExchangeShell.ps1
@@ -22,7 +22,8 @@ function Invoke-ConfirmExchangeShell {
 
     if ($Script:ExchangeShellComputer.ToolsOnly -and
         $Script:ServerNameList.ToLower().Contains($env:COMPUTERNAME.ToLower()) -and
-        -not ($LoadBalancingReport)) {
+        ($PSCmdlet.ParameterSetName -eq "HealthChecker" -or
+        $PSCmdlet.ParameterSetName -eq "MailboxReport")) {
         Write-Warning "Can't run Exchange Health Checker Against a Tools Server. Use the -Server Parameter and provide the server you want to run the script against."
         $Script:Logger.PreventLogCleanup = $true
         exit


### PR DESCRIPTION
**Issue:**
When trying to use the Vulnerability Report feature from a tools box, the script would fail with `WARNING: Can't run Exchange Health Checker Against a Tools Server. Use the -Server Parameter and provide the server you want to run the script against. `

**Reason:**
We should be able to run the script from a tools box.

**Fix:**
Addressed the code to only look at the `Server` parameter when we are in the `ParameterSetName` for `HealthChecker` or `MailboxReport`

Resolved #1666 

**Validation:**
Lab tested

