### PR TITLE
Added links to configuration output

### DIFF
--- a/M365/MDO/MDOThreatPolicyChecker.ps1
+++ b/M365/MDO/MDOThreatPolicyChecker.ps1
@@ -138,7 +138,7 @@ begin {
                 return $null
             }
         } else {
-            Write-Host "The EmailAddress of group $stGroupEmail was not found" -ForegroundColor Red
+            Write-Host "The EmailAddress of group $stGroupEmail was not found." -ForegroundColor Red
             return $null
         }
     }
@@ -481,15 +481,15 @@ begin {
 
     if ($ScriptUpdateOnly) {
         switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/MDOThreatPolicyChecker-VersionsURL" -Confirm:$false) {
-            ($true) { Write-Host ("Script was successfully updated") -ForegroundColor Green }
-            ($false) { Write-Host ("No update of the script performed") -ForegroundColor Yellow }
-            default { Write-Host ("Unable to perform ScriptUpdateOnly operation") -ForegroundColor Red }
+            ($true) { Write-Host ("Script was successfully updated.") -ForegroundColor Green }
+            ($false) { Write-Host ("No update of the script performed.") -ForegroundColor Yellow }
+            default { Write-Host ("Unable to perform ScriptUpdateOnly operation.") -ForegroundColor Red }
         }
         return
     }
 
     if ((-not($SkipVersionCheck)) -and (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/MDOThreatPolicyChecker-VersionsURL" -Confirm:$false)) {
-        Write-Host ("Script was updated. Please re-run the command") -ForegroundColor Yellow
+        Write-Host ("Script was updated. Please re-run the command.") -ForegroundColor Yellow
         return
     }
 }
@@ -502,17 +502,17 @@ process {
             $exoConnection = Get-ConnectionInformation -ErrorAction Stop
         } catch {
             Write-Host "Error checking EXO connection:`n$_" -ForegroundColor Red
-            Write-Host "Verify that you have ExchangeOnlineManagement module installed" -ForegroundColor Yellow
-            Write-Host "You need a connection To Exchange Online, you can use:" -ForegroundColor Yellow
+            Write-Host "Verify that you have ExchangeOnlineManagement module installed." -ForegroundColor Yellow
+            Write-Host "You need a connection to Exchange Online; you can use:" -ForegroundColor Yellow
             Write-Host "Connect-ExchangeOnline" -ForegroundColor Yellow
-            Write-Host "Exchange Online Powershell Module is required" -ForegroundColor Red
+            Write-Host "Exchange Online Powershell Module is required." -ForegroundColor Red
             exit
         }
         if ($null -eq $exoConnection) {
             Write-Host "Not connected to EXO" -ForegroundColor Red
-            Write-Host "You need a connection To Exchange Online, you can use:" -ForegroundColor Yellow
+            Write-Host "You need a connection to Exchange Online; you can use:" -ForegroundColor Yellow
             Write-Host "Connect-ExchangeOnline" -ForegroundColor Yellow
-            Write-Host "Exchange Online Powershell Module is required" -ForegroundColor Red
+            Write-Host "Exchange Online Powershell Module is required." -ForegroundColor Red
             exit
         } elseif ($exoConnection.count -eq 1) {
             Write-Host " "
@@ -521,7 +521,7 @@ process {
             Write-Host "Tenant Id: $($exoConnection.TenantId)"
             Write-Host "User: $($exoConnection.UserPrincipalName)"
         } else {
-            Write-Host "You have more than one EXO sessions. Please use just one session" -ForegroundColor Red
+            Write-Host "You have more than one EXO session. Please use just one session." -ForegroundColor Red
             exit
         }
 
@@ -533,14 +533,14 @@ process {
                 $graphConnection = Get-MgContext -ErrorAction Stop
             } catch {
                 Write-Host "Error checking Graph connection:`n$_" -ForegroundColor Red
-                Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded" -ForegroundColor Yellow
+                Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded." -ForegroundColor Yellow
                 Write-Host "You could use:" -ForegroundColor Yellow
                 Write-Host "`tConnect-MgGraph -Scopes 'Group.Read.All','User.Read.All' -TenantId $($exoConnection.TenantId)" -ForegroundColor Yellow
                 exit
             }
             if ($null -eq $graphConnection) {
                 Write-Host "Not connected to Graph" -ForegroundColor Red
-                Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded" -ForegroundColor Yellow
+                Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded." -ForegroundColor Yellow
                 Write-Host "You could use:" -ForegroundColor Yellow
                 Write-Host "`tConnect-MgGraph -Scopes 'Group.Read.All','User.Read.All' -TenantId $($exoConnection.TenantId)" -ForegroundColor Yellow
                 exit
@@ -552,18 +552,18 @@ process {
                     Write-Host "TenantID: $(($graphConnection).TenantId)"
                     Write-Host "Account: $(($graphConnection).Account)"
                 } else {
-                    Write-Host "We cannot continue without Graph Powershell session without Expected Scopes" -ForegroundColor Red
-                    Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded" -ForegroundColor Yellow
+                    Write-Host "We cannot continue without Graph Powershell session without Expected Scopes." -ForegroundColor Red
+                    Write-Host "Verify that you have Microsoft.Graph.Users and Microsoft.Graph.Groups modules installed and loaded." -ForegroundColor Yellow
                     Write-Host "You could use:" -ForegroundColor Yellow
                     Write-Host "`tConnect-MgGraph -Scopes 'Group.Read.All','User.Read.All' -TenantId $($exoConnection.TenantId)" -ForegroundColor Yellow
                     exit
                 }
             } else {
-                Write-Host "You have more than one Graph sessions. Please use just one session" -ForegroundColor Red
+                Write-Host "You have more than one Graph sessions. Please use just one session." -ForegroundColor Red
                 exit
             }
             if (($graphConnection.TenantId) -ne ($exoConnection.TenantId) ) {
-                Write-Host "`nThe Tenant Id from Graph and EXO are different. Please use the same tenant" -ForegroundColor Red
+                Write-Host "`nThe Tenant Id from Graph and EXO are different. Please use the same tenant." -ForegroundColor Red
                 exit
             }
         }
@@ -729,7 +729,10 @@ process {
                     $matchedRule = Test-Rules -Rules $eopStrictPresetRules -email $stEmailAddress
                 }
                 if ($eopStrictPresetRules -contains $matchedRule) {
-                    $allPolicyDetails += "`nFor malware, spam, and phishing:`n`tName: {0}`n`tPriority: {1}`n`tThe policy actions are not configurable." -f $matchedRule.Name, $matchedRule.Priority
+                    $allPolicyDetails += "`nFor malware, spam, and phishing:`n`tName: {0}`n`tPriority: {1}" -f $matchedRule.Name, $matchedRule.Priority
+                    if ($ShowDetailedPolicies) {
+                        $allPolicyDetails += "`n`tPreset policy settings are not configurable but documented here:`n`t`thttps://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365#anti-spam-anti-malware-and-anti-phishing-protection-in-eop"
+                    }
                     Write-Host $allPolicyDetails -ForegroundColor Green
                     $outboundSpamMatchedRule = $null
                     if ($hostedOutboundSpamFilterRules) {
@@ -744,7 +747,10 @@ process {
                         $matchedRule = Test-Rules -Rules $eopStandardPresetRules -email $stEmailAddress
                     }
                     if ($eopStandardPresetRules -contains $matchedRule) {
-                        $allPolicyDetails += "`nFor malware, spam, and phishing:`n`tName: {0}`n`tPriority: {1}`n`tThe policy actions are not configurable." -f $matchedRule.Name, $matchedRule.Priority
+                        $allPolicyDetails += "`nFor malware, spam, and phishing:`n`tName: {0}`n`tPriority: {1}" -f $matchedRule.Name, $matchedRule.Priority
+                        if ($ShowDetailedPolicies) {
+                            $allPolicyDetails += "`n`tPreset policy settings are not configurable but documented here:`n`t`thttps://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365#anti-spam-anti-malware-and-anti-phishing-protection-in-eop"
+                        }
                         Write-Host $allPolicyDetails -ForegroundColor Green
                         $outboundSpamMatchedRule = $allPolicyDetails = $null
                         if ($hostedOutboundSpamFilterRules) {
@@ -831,6 +837,9 @@ process {
                 }
                 if ($mdoStrictPresetRules -contains $matchedRule) {
                     Write-Host ("`nFor both Safe Attachments and Safe Links:`n`tName: {0}`n`tPriority: {1}" -f $matchedRule.Name, $matchedRule.Priority) -ForegroundColor Green
+                    if ($ShowDetailedPolicies) {
+                        Write-Host ("`tPreset policy settings are not configurable but documented here:`n`t`thttps://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365#microsoft-defender-for-office-365-security") -ForegroundColor Green
+                    }
                 } else {
                     # Check the Standard MDO rules secondly
                     $matchedRule = $null
@@ -839,6 +848,9 @@ process {
                     }
                     if ($mdoStandardPresetRules -contains $matchedRule) {
                         Write-Host ("`nFor both Safe Attachments and Safe Links:`n`tName: {0}`n`tPriority: {1}" -f $matchedRule.Name, $matchedRule.Priority) -ForegroundColor Green
+                        if ($ShowDetailedPolicies) {
+                            Write-Host ("`tPreset policy settings are not configurable but documented here:`n`t`thttps://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365#microsoft-defender-for-office-365-security") -ForegroundColor Green
+                        }
                     } else {
                         # No match in preset ATPProtectionPolicyRules, check custom SA/SL rules
                         $SAmatchedRule = $null


### PR DESCRIPTION
**Issue:**
Added link to preset policy settings for easier access. 

**Reason:**
When users request details of policies, the preset only has non-configurable settings and they can't be printed out so we now point to the page. 

**Fix:**
Within the existing output, a link was added in 4 places.

**Validation:**
Tested and it works with no issues.

