### PR TITLE
Include SU/CU Installed Date

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -60,6 +60,14 @@ function Invoke-AnalyzerExchangeInformation {
     }
     Add-AnalyzedResultInformation @params
 
+    if ($null -ne $exchangeInformation.BuildInformation.ExchangeSetup.InstallTime) {
+        $params = $baseParams + @{
+            Name    = "Latest Install Time (SU/CU)"
+            Details = $exchangeInformation.BuildInformation.ExchangeSetup.InstallTime
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
     if ($exchangeInformation.BuildInformation.VersionInformation.Supported -eq $false) {
         $daysOld = ($date - $exchangeInformation.BuildInformation.VersionInformation.ReleaseDate).Days
 

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -129,19 +129,20 @@ function Invoke-AnalyzerExchangeInformation {
         Add-AnalyzedResultInformation @params
     }
 
-    if ($null -ne $exchangeInformation.BuildInformation.KBsInstalled) {
+    if ($null -ne $exchangeInformation.BuildInformation.KBsInstalledInfo.PackageName) {
         Add-AnalyzedResultInformation -Name "Exchange IU or Security Hotfix Detected" @baseParams
         $problemKbFound = $false
         $problemKbName = "KB5029388"
 
-        foreach ($kb in $exchangeInformation.BuildInformation.KBsInstalled) {
+        foreach ($kbInfo in $exchangeInformation.BuildInformation.KBsInstalledInfo) {
+            $kbName = $kbInfo.PackageName
             $params = $baseParams + @{
-                Details                = $kb
+                Details                = "$kbName - Installed on $($kbInfo.InstalledDate)"
                 DisplayCustomTabNumber = 2
             }
             Add-AnalyzedResultInformation @params
 
-            if ($kb.Contains($problemKbName)) {
+            if ($kbName.Contains($problemKbName)) {
                 $problemKbFound = $true
             }
         }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -139,6 +139,7 @@ function Invoke-AnalyzerExchangeInformation {
             $params = $baseParams + @{
                 Details                = "$kbName - Installed on $($kbInfo.InstalledDate)"
                 DisplayCustomTabNumber = 2
+                TestingName            = "Exchange IU"
             }
             Add-AnalyzedResultInformation @params
 

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-MarchSuSpecial.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-MarchSuSpecial.ps1
@@ -20,8 +20,8 @@ function Invoke-AnalyzerSecurityCve-MarchSuSpecial {
     #Description: March 2021 Exchange vulnerabilities Security Update (SU) check for outdated version (CUs)
     #Affected Exchange versions: Exchange 2013, Exchange 2016, Exchange 2016 (we only provide this special SU for these versions)
     #Fix: Update to a supported CU and apply KB5000871
-    $march2021SUInstalled = $null -ne $SecurityObject.ExchangeInformation.BuildInformation.KBsInstalled -and
-    $SecurityObject.ExchangeInformation.BuildInformation.KBsInstalled -like "*KB5000871*"
+    $march2021SUInstalled = $null -ne $SecurityObject.ExchangeInformation.BuildInformation.KBsInstalledInfo.PackageName -and
+    $SecurityObject.ExchangeInformation.BuildInformation.KBsInstalledInfo.PackageName -like "*KB5000871*"
     $ex2019 = "Exchange2019"
     $ex2016 = "Exchange2016"
     $ex2013 = "Exchange2013"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -59,7 +59,7 @@ function Get-ExchangeInformation {
             CU                 = $versionInformation.CU
             ExchangeSetup      = $exSetupDetails
             VersionInformation = $versionInformation
-            KBsInstalled       = [array](Get-ExchangeUpdates -Server $Server -ExchangeMajorVersion $versionInformation.MajorVersion)
+            KBsInstalledInfo   = [array](Get-ExchangeUpdates -Server $Server -ExchangeMajorVersion $versionInformation.MajorVersion)
         }
 
         $dependentServices = (Get-ExchangeDependentServices -MachineName $Server)

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeUpdates.ps1
@@ -30,14 +30,18 @@ function Get-ExchangeUpdates {
         $IU = $RegKey.GetSubKeyNames()
         if ($null -ne $IU) {
             Write-Verbose "Detected fixes installed on the server"
-            $fixes = @()
+            $installedUpdates = New-Object System.Collections.Generic.List[object]
             foreach ($key in $IU) {
                 $IUKey = $RegKey.OpenSubKey($key)
                 $IUName = $IUKey.GetValue("PackageName")
                 Write-Verbose "Found: $IUName"
-                $fixes += $IUName
+                $IUInstalledDate = $IUKey.GetValue("InstalledDate")
+                $installedUpdates.Add(([PSCustomObject]@{
+                            PackageName   = $IUName
+                            InstalledDate = $IUInstalledDate
+                        }))
             }
-            return $fixes
+            return $installedUpdates
         } else {
             Write-Verbose "No IUs found in the registry"
         }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
@@ -63,6 +63,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-WmiObjectHandler -Exactly 6
             Assert-MockCalled Invoke-ScriptBlockHandler -Exactly 5
             Assert-MockCalled Get-RemoteRegistryValue -Exactly 25
+            Assert-MockCalled Get-RemoteRegistrySubKey -Exactly 1
             Assert-MockCalled Get-NETFrameworkVersion -Exactly 1
             Assert-MockCalled Get-DotNetDllFileVersions -Exactly 1
             Assert-MockCalled Get-NicPnpCapabilitiesSetting -Exactly 1
@@ -75,7 +76,6 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-AllTlsSettings -Exactly 1
             Assert-MockCalled Get-SmbServerConfiguration -Exactly 1
             Assert-MockCalled Get-ExchangeAppPoolsInformation -Exactly 1
-            Assert-MockCalled Get-ExchangeUpdates -Exactly 1
             Assert-MockCalled Get-ExchangeDomainsAclPermissions -Exactly 1
             Assert-MockCalled Get-ExchangeAdSchemaClass -Exactly 2
             Assert-MockCalled Get-ExchangeServer -Exactly 1

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -140,6 +140,20 @@ Mock Get-RemoteRegistryValue {
     }
 }
 
+Mock Get-RemoteRegistrySubKey {
+    param(
+        [string]$MachineName,
+        [string]$SubKey
+    )
+
+    switch ($SubKey) {
+        "SOFTWARE\Microsoft\Updates\Exchange 2013" { return $null }
+        "SOFTWARE\Microsoft\Updates\Exchange 2016" { return $null }
+        "SOFTWARE\Microsoft\Updates\Exchange 2019" { return $null }
+        default { throw "Failed to find SubKey: $SubKey" }
+    }
+}
+
 Mock Get-NETFrameworkVersion {
     return [PSCustomObject]@{
         FriendlyName  = "4.8"
@@ -197,10 +211,6 @@ Mock Get-SmbServerConfiguration {
 
 Mock Get-ExchangeAppPoolsInformation {
     return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeAppPoolsInformation.xml"
-}
-
-Mock Get-ExchangeUpdates {
-    return $null
 }
 
 Mock Get-ExchangeAdSchemaClass -ParameterFilter { $SchemaClassName -eq "ms-Exch-Storage-Group" } {

--- a/Shared/Get-ExSetupFileVersionInfo.ps1
+++ b/Shared/Get-ExSetupFileVersionInfo.ps1
@@ -15,14 +15,20 @@ function Get-ExSetupFileVersionInfo {
     $exSetupDetails = [string]::Empty
     function Get-ExSetupDetailsScriptBlock {
         try {
-            Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+            $getCommand = Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+            $getItem = Get-Item -ErrorAction SilentlyContinue $getCommand[0].FileName
+            $getCommand | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
+            $getCommand
         } catch {
             try {
                 Write-Verbose "Failed to find ExSetup by environment path locations. Attempting manual lookup."
                 $installDirectory = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction Stop).MsiInstallPath
 
                 if ($null -ne $installDirectory) {
-                    Get-Command ([System.IO.Path]::Combine($installDirectory, "bin\ExSetup.exe")) -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+                    $getCommand = Get-Command ([System.IO.Path]::Combine($installDirectory, "bin\ExSetup.exe")) -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+                    $getItem = Get-Item -ErrorAction SilentlyContinue $getCommand[0].FileName
+                    $getCommand | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
+                    $getCommand
                 }
             } catch {
                 Write-Verbose "Failed to find ExSetup, need to fallback."


### PR DESCRIPTION
**Issue:**
It is helpful to know when the SU/CU were last installed. We currently don't have this collected, so instead of going back and confirming this information, we can just collect it and display it with Health Checker. 

**Reason:**
Avoid additional data to be collected. 

**Fix:**
Resolved #2127 

**Validation:**
Lab tested/Pester tested

