### PR TITLE
Add Dynamic Memory Check and Current CPU Usage

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -55,6 +55,18 @@ function Invoke-AnalyzerHardwareInformation {
     }
     Add-AnalyzedResultInformation @params
 
+    if ($null -ne $osInformation.PerformanceCounters) {
+        $counter = $osInformation.PerformanceCounters | Where-Object { $_.OriginalCounterLookup -eq "\Processor(_Total)\% Processor Time" }
+
+        if ($null -ne $counter) {
+            $params = $baseParams + @{
+                Name    = "Current Total Processor Usage"
+                Details = [System.Math]::Round($counter.CookedValue, 2)
+            }
+            Add-AnalyzedResultInformation @params
+        }
+    }
+
     $numberOfProcessors = $hardwareInformation.Processor.NumberOfProcessors
     $displayWriteType = "Green"
     $displayValue = $numberOfProcessors

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -275,4 +275,35 @@ function Invoke-AnalyzerHardwareInformation {
         AddHtmlOverviewValues = $true
     }
     Add-AnalyzedResultInformation @params
+
+    if ($hardwareInformation.ServerType -eq "HyperV" -or
+        $hardwareInformation.ServerType -eq "VMware") {
+        $params = $baseParams + @{
+            Name             = "Dynamic Memory Detected"
+            Details          = $false
+            DisplayWriteType = "Green"
+        }
+
+        if ($null -eq $osInformation.PerformanceCounters) {
+            $params.Details = "Unknown - No Performance Counters was able to be collected"
+            $params.DisplayWriteType = "Yellow"
+        } else {
+            if ($hardwareInformation.ServerType -eq "HyperV") {
+                $counterName = "\Hyper-V Dynamic Memory Integration Service\Maximum Memory, MBytes"
+            } else {
+                $counterName = "\VM Memory\Memory Reservation in MB"
+            }
+            $counter = $osInformation.PerformanceCounters | Where-Object { $_.OriginalCounterLookup -eq $counterName }
+
+            if ($null -eq $counter) {
+                $params.Details = "Unknown - Required Counter Not Loaded"
+                $params.DisplayWriteType = "Yellow"
+            } elseif (($counter.CookedValue / 1024) -ne $totalPhysicalMemory) {
+                $params.Details = "$true $($counter.CookedValue / 1024)GB is the allowed dynamic memory of the server. Not supported to have dynamic memory configured."
+                $params.DisplayWriteType = "Red"
+            }
+        }
+
+        Add-AnalyzedResultInformation @params
+    }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-OperatingSystemInformation.ps1
@@ -67,6 +67,17 @@ function Get-OperatingSystemInformation {
             Invoke-CatchActions
         }
 
+        $params = @{
+            MachineName       = $Server
+            Counter           = @(
+                "\Hyper-V Dynamic Memory Integration Service\Maximum Memory, MBytes", # This is used to determine if dynamic memory is set on the Hyper-V machine.
+                "\Processor(_Total)\% Processor Time",
+                "\VM Memory\Memory Reservation in MB" # used to determine if dynamic memory is set on the VMware machine.
+            )
+            CustomErrorAction = "SilentlyContinue" # Required because not all counters would be there.
+        }
+
+        $counters = Get-LocalizedCounterSamples @params
         $serverPendingReboot = (Get-ServerRebootPending -ServerName $Server -CatchActionFunction ${Function:Invoke-CatchActions})
         $timeZoneInformation = Get-TimeZoneInformation -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
         $tlsSettings = Get-AllTlsSettings -MachineName $Server -CatchActionFunction ${Function:Invoke-CatchActions}
@@ -94,6 +105,7 @@ function Get-OperatingSystemInformation {
             CredentialGuardCimInstance = $credentialGuardCimInstance
             WindowsFeature             = $windowsFeature
             EventLogInformation        = $eventLogInformation
+            PerformanceCounters        = $counters
         }
     }
 }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -85,7 +85,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Max Processor Speed" 2200
             TestObjectMatch "Physical Memory" 6
 
-            $Script:ActiveGrouping.Count | Should -Be 9
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - NIC Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Max Processor Speed" 2200
             TestObjectMatch "Physical Memory" 6
 
-            $Script:ActiveGrouping.Count | Should -Be 10
+            $Script:ActiveGrouping.Count | Should -Be 12
         }
 
         It "Display Results - NIC Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -85,8 +85,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "All Processor Cores Visible" "Passed" -WriteType "Green"
             TestObjectMatch "Max Processor Speed" 2200
             TestObjectMatch "Physical Memory" 6 -WriteType "Yellow"
+            TestObjectMatch "Dynamic Memory Detected" $false -WriteType "Green"
 
-            $Script:ActiveGrouping.Count | Should -Be 9
+            $Script:ActiveGrouping.Count | Should -Be 11
         }
 
         It "Display Results - NIC Settings" {
@@ -218,7 +219,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Manufacturer" "My Custom PC"
             TestObjectMatch "Model" "CHG-GG"
 
-            $Script:ActiveGrouping.Count | Should -Be 12
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
 
         It "Display Results - NIC Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -97,6 +97,18 @@ Describe "Testing Health Checker by Mock Data Imports" {
                 $obj.Add($suObject)
                 return $obj
             }
+            Mock Get-LocalizedCounterSamples {
+                $objList = New-Object System.Collections.Generic.List[object]
+                $objList.Add(([PSCustomObject]@{
+                            OriginalCounterLookup = "\Processor(_Total)\% Processor Time"
+                            CookedValue           = 55.55555
+                        }))
+                $objList.Add(([PSCustomObject]@{
+                            OriginalCounterLookup = "\Hyper-V Dynamic Memory Integration Service\Maximum Memory, MBytes"
+                            CookedValue           = 24576
+                        }))
+                return $objList
+            }
 
             SetDefaultRunOfHealthChecker "Debug_Scenario1_Results.xml"
         }
@@ -118,6 +130,11 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Critical Pla" ($displayFormat -f "pla", "Stopped", "Manual") -WriteType "Red"
             TestObjectMatch "Critical HostControllerService" ($displayFormat -f "HostControllerService", "Stopped", "Disabled") -WriteType "Red"
             TestObjectMatch "Common MSExchangeDagMgmt" ($displayFormat -f "MSExchangeDagMgmt", "Stopped", "Automatic") -WriteType "Yellow"
+        }
+
+        It "Dynamic Memory Set" {
+            SetActiveDisplayGrouping "Processor/Hardware Information"
+            TestObjectMatch "Dynamic Memory Detected" "True 24GB is the allowed dynamic memory of the server. Not supported to have dynamic memory configured." -WriteType "Red"
         }
 
         It "Http Proxy Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
@@ -71,7 +71,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-DnsClient -Exactly 1
             Assert-MockCalled Get-NetAdapterRss -Exactly 1
             Assert-MockCalled Get-HotFix -Exactly 1
-            Assert-MockCalled Get-LocalizedCounterSamples -Exactly 1
+            Assert-MockCalled Get-LocalizedCounterSamples -Exactly 2
             Assert-MockCalled Get-ServerRebootPending -Exactly 1
             Assert-MockCalled Get-AllTlsSettings -Exactly 1
             Assert-MockCalled Get-SmbServerConfiguration -Exactly 1

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -191,10 +191,6 @@ Mock Get-HotFix {
     return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetHotFix.xml"
 }
 
-Mock Get-LocalizedCounterSamples {
-    return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetCounterSamples.xml"
-}
-
 Mock Get-ServerRebootPending {
     return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetServerRebootPending.xml"
 }
@@ -264,6 +260,21 @@ Mock Get-ExchangeDiagnosticInfo -ParameterFilter { $Process -eq "Microsoft.Excha
     -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeDiagnosticInfo_ADTopVariantConfiguration.xml" }
 Mock Get-ExchangeDiagnosticInfo -ParameterFilter { $Process -eq "EdgeTransport" -and $Component -eq "ResourceThrottling" } `
     -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetExchangeDiagnosticInfo_EdgeTransportResourceThrottling.xml" }
+
+Mock Get-LocalizedCounterSamples -ParameterFilter { $Counter -eq "\Network Interface(*)\Packets Received Discarded" } `
+    -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\OS\GetCounterSamples.xml" }
+Mock Get-LocalizedCounterSamples {
+    $objList = New-Object System.Collections.Generic.List[object]
+    $objList.Add(([PSCustomObject]@{
+                OriginalCounterLookup = "\Processor(_Total)\% Processor Time"
+                CookedValue           = 55.55555
+            }))
+    $objList.Add(([PSCustomObject]@{
+                OriginalCounterLookup = "\Hyper-V Dynamic Memory Integration Service\Maximum Memory, MBytes"
+                CookedValue           = 6144
+            }))
+    return $objList
+}
 
 # Need to use function instead of Mock for Exchange cmdlets
 function Get-ExchangeServer {


### PR DESCRIPTION
**Issue:**
A common issue is that admins will try to have dynamic memory on the guest machines for Exchange. This is not supported when, as we can see performance issues caused by this feature. This check should be able to determine if Dynamic memory is being used if using HyperV or VMware. 

**Fix:**
Include data collection for the performance counter that will detect problem. If it doesn't equal the memory that is installed on the server, then we likely have dynamic memory applied. 

Resolved #1680 
Resolved #957 

**Validation:**
Lab Tested/Pester Tested

