### PR TITLE
Unified Content Auto Cleanup Check Added

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -115,7 +115,8 @@ function Get-ExchangeInformation {
         $configParams = @{
             ComputerName = $Server
             FileLocation = @("$([System.IO.Path]::Combine($serverExchangeBinDirectory, "EdgeTransport.exe.config"))",
-                "$([System.IO.Path]::Combine($serverExchangeBinDirectory, "Search\Ceres\Runtime\1.0\noderunner.exe.config"))")
+                "$([System.IO.Path]::Combine($serverExchangeBinDirectory, "Search\Ceres\Runtime\1.0\noderunner.exe.config"))",
+                "$([System.IO.Path]::Combine($serverExchangeBinDirectory, "Monitoring\Config\AntiMalware.xml"))")
         }
 
         if ($getExchangeServer.IsEdgeServer -eq $false -and
@@ -203,7 +204,7 @@ function Get-ExchangeInformation {
                 CatchActionFunction    = ${Function:Invoke-CatchActions}
                 ScriptBlock            = {
                     [PSCustomObject]@{
-                        LocalGroupMember  =  (Get-LocalGroupMember -SID "S-1-5-32-544" -ErrorAction Stop)
+                        LocalGroupMember  = (Get-LocalGroupMember -SID "S-1-5-32-544" -ErrorAction Stop)
                         ADGroupMembership = (Get-ADPrincipalGroupMembership (Get-ADComputer $env:COMPUTERNAME).DistinguishedName)
                     }
                 }

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/Antimalware.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E15/Exchange/Antimalware.xml
@@ -1,0 +1,938 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<Definition xsi:noNamespaceSchemaLocation="..\..\WorkItemDefinition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <MaintenanceDefinition
+    AssemblyPath="Microsoft.Exchange.Monitoring.ActiveMonitoring.Local.Components.dll"
+    TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Antimalware.AntimalwareDiscovery"
+    Name="Antimalware.Maintenance.Workitem"
+    ServiceName="Antimalware"
+    RecurrenceIntervalSeconds="0"
+    TimeoutSeconds="600"
+    MaxRetryAttempts="3"
+    Enabled ="true" >
+    <!-- To override the default values, add/modify the corresponding extension attributes.  
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPath = "D:\ExchangeTemp\TransportCts\UnifiedContent" 
+      CleanupFolderResponderFileRetentionPeriod = "05:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "00:10:00"
+    />-->
+    <ExtensionAttributes
+      CleanupFolderResponderFileRetentionPeriod = "1.00:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "04:00:00"
+    />
+  </MaintenanceDefinition>
+
+  <!--
+  For OverallConsecutiveSampleValueAboveThresholdMonitor,
+            TimeoutSeconds = 30;
+            SecondaryMonitoringThreshold = numberOfSamples;
+            MonitoringIntervalSeconds = (numberOfSamples + 1) * 300; ////EDS sends data to us every 5 minutes
+            RecurrenceIntervalSeconds = monitor.MonitoringIntervalSeconds / 2;
+  -->
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Minimum Threshold"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanMinimumMonitor"
+         ComponentName="AMScanners"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumRestartServiceResponder"
+         ComponentName="AMScanners"
+         AlertMask = "MessagesWithFewerEngineScansThanMinimumMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+          <ExtensionAttributes
+            WindowsServiceName="FMS"
+            ServiceStopTimeout="60"
+            ServiceStartTimeout="120"
+            ServiceStartDelay="2"
+            MinimumSecondsBetweenRestarts="7200"
+            MaximumAllowedRestartsInAnHour="2"
+            MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumEscalateResponder"
+         ComponentName="AMScanners"
+         AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+         TargetHealthState="Unhealthy"
+         EscalationTeam="FIPS"
+         EscalationLevel="Urgent"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanMinimumCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Expected"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanExpectedMonitor"
+         ComponentName="AMScanners"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedRestartServiceResponder"
+         ComponentName="AMScanners"
+         AlertMask = "MessagesWithFewerEngineScansThanExpectedMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedEscalateResponder"
+         ComponentName="AMScanners"
+         AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+         TargetHealthState="Unhealthy"
+         TargetResource="FIPS"
+         EscalationTeam="FIPS"
+         EscalationLevel="UrgentInTraining"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanExpectedCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Scan Time per Message - 90th Percentile"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanTimeMonitor"
+        ComponentName="AMScanTimeout"
+        MonitoringThreshold="5000"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanTimeRestartServiceResponder"
+        ComponentName="AMScanTimeout"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="ScanTimeCollectFIPSLogsResponder"
+        ComponentName="AMScanTimeout"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanTimeEscalateResponder"
+        ComponentName="AMScanTimeout"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationMessageUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationLevel="UrgentInTraining"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages with Scan Error Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanErrorsMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="10"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="ScanErrorsCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsMonitor"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanErrorsEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsMonitor"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationMessageUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+  
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages with Scan Error Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanErrorsHundredPercentMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="100"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="1800"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsHundredPercentDegradedRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsHundredPercentMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="1800"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanErrorsHundredPercentEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsHundredPercentMonitor"
+        AlertMask="ScanErrorsHundredPercentMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering scan error percentage is 100 for last 30 mins."
+        EscalationMessageUnhealthy="Malware filtering scan error percentage is 100 for last 30 mins."
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+        <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsHundredPercentUnHealthyRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsHundredPercentMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="1800"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Containing Malware Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesWithMalwareMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="4"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesWithMalwareRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithMalwareCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesWithMalwareEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationMessageUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesDeferredMonitor"
+        ComponentName="AMMessagesDeferred"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesDeferredRestartServiceResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesDeferredCollectFIPSLogsResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesDeferredEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is deferring too many messages"
+        EscalationMessageUnhealthy="Malware filtering is deferring too many messages"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Recovery Store Percentage Full"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="RecoveryStoreFullMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="RecoveryStoreFullRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="RecoveryStoreFullCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="RecoveryStoreFullEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationMessageUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Written to Recovery Store"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesInRecoveryStoreMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="3"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesInRecoveryStoreRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesInRecoveryStoreCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesInRecoveryStoreEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationMessageUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <CustomWorkItem 
+      RecipientFeatureTag="AntimalwareClean"
+      SenderFeatureTag="AntimalwareClean"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareCleanProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestCleanMail" Body="test">
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="SUM|v=0" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareCleanMonitor"
+        SampleMask="AntimalwareCleanProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MaxRetryAttempts = "0"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareCleanResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareCleanMonitor"
+        AlertMask="AntimalwareCleanMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareClean failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareClean failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  <CustomWorkItem 
+      RecipientFeatureTag="AntimalwareBlockAction"
+      SenderFeatureTag="AntimalwareBlockAction"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareBlockActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestBlockAction" Body="test">
+              <Attachment Filename="eicar" />
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="SUM|v=1|action=b" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareBlockActionMonitor"
+        SampleMask="AntimalwareBlockActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareBlockActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareBlockActionMonitor"
+        AlertMask="AntimalwareBlockActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareBlockAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareBlockAction failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  <CustomWorkItem 
+      RecipientFeatureTag="AntimalwareReplaceAction"
+      SenderFeatureTag="AntimalwareReplaceAction"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareReplaceActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select mailbox as per feature tag-->
+            <Message Subject="TestReplaceAction" Body="test">
+              <Attachment Filename="eicar" />
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="SUM|v=1|action=r" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareReplaceActionMonitor"
+        SampleMask="AntimalwareReplaceActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareReplaceActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareReplaceActionMonitor"
+        AlertMask="AntimalwareReplaceActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareReplaceAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareReplaceAction failed. 
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  <CustomWorkItem 
+      RecipientFeatureTag="AntimalwareBypassAction"
+      SenderFeatureTag="AntimalwareBypassAction"
+      FfoDataCenter="true"
+      ExoDataCenter="false"
+      OnPremise="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareBypassActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select mailbox as per feature tag-->
+            <Message Subject="TestBypassAction" Body="test">
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="SUM|action=p" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareBypassActionMonitor"
+        SampleMask="AntimalwareBypassActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareBypassActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareBypassActionMonitor"
+        AlertMask="AntimalwareBypassActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareBypassAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareBypassAction failed.
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;Failure Context:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;Execution Context:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentNDRUrgentMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.NDR"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentNDRUrgentEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentNDRUrgentMonitor"
+      AlertMask="AMAgentNDRUrgentMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware Agent rejected more than 5 messages."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Messages NDR'd in the last minute:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentPolicyDiscoveryMonitor"
+      ComponentName="AMADError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.MalwareFilterPolicyDiscovery"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentPolicyDiscoveryEscalateResponder"
+      ComponentName="AMADError"
+      AlertTypeId="AMAgentPolicyDiscoveryMonitor"
+      AlertMask="AMAgentPolicyDiscoveryMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Malware Filter Policy discovery failed."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Malware Filter Policy discovery failed. Total number of errors during the last minute: &lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentTenantConfigErrorMonitor"
+      ComponentName="AMTenantConfigError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.TenantConfigurationError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentTenantConfigErrorEscalateResponder"
+      ComponentName="AMTenantConfigError"
+      AlertTypeId="AMAgentTenantConfigErrorMonitor"
+      AlertMask="AMAgentTenantConfigErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Tenant Configuration Error"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;A tenant has atleast two Malware Filter Policies with the same name.&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="FlightingFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.FlightingFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="FlightingFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="FlightingFailureMonitor"
+      AlertMask="FlightingFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to determine if AM agent is enabled or not."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Failed to determine if AM agent V2 is enabled or not.
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentCategoryErrorMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.CategoryError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentCategoryErrorEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentCategoryErrorMonitor"
+      AlertMask="AMAgentCategoryErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware: All engine errors"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;All engines threw an error for atleast 5 messages in the last 5 mins:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+  
+</Definition>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/Antimalware.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E16/Exchange/Antimalware.xml
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<Definition xsi:noNamespaceSchemaLocation="..\..\WorkItemDefinition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <MaintenanceDefinition
+    AssemblyPath="Microsoft.Exchange.Monitoring.ActiveMonitoring.Local.Components.dll"
+    TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Antimalware.AntimalwareDiscovery"
+    Name="Antimalware.Maintenance.Workitem"
+    ServiceName="Antimalware"
+    RecurrenceIntervalSeconds="0"
+    TimeoutSeconds="600"
+    MaxRetryAttempts="3"
+    Enabled ="true" >
+    <!-- To override the default values, add/modify the corresponding extension attributes.  
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp;C:\TransportRoles\data\Temp" 
+      CleanupFolderResponderFileRetentionPeriod = "05:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "00:10:00"
+    />-->
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp\UnifiedContent;C:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp\UnifiedContent"
+      CleanupFolderResponderFileRetentionPeriod = "1.00:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "04:00:00"
+    />
+  </MaintenanceDefinition>
+
+  <!--
+  For OverallConsecutiveSampleValueAboveThresholdMonitor,
+            TimeoutSeconds = 30;
+            SecondaryMonitoringThreshold = numberOfSamples;
+            MonitoringIntervalSeconds = (numberOfSamples + 1) * 300; ////EDS sends data to us every 5 minutes
+            RecurrenceIntervalSeconds = monitor.MonitoringIntervalSeconds / 2;
+  -->
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Minimum Threshold"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanMinimumMonitor"
+         ComponentName="AMScanners"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumRestartServiceResponder"
+         ComponentName="AMScanners"
+         AlertMask = "MessagesWithFewerEngineScansThanMinimumMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+          <ExtensionAttributes
+            WindowsServiceName="FMS"
+            ServiceStopTimeout="60"
+            ServiceStartTimeout="120"
+            ServiceStartDelay="2"
+            MinimumSecondsBetweenRestarts="7200"
+            MaximumAllowedRestartsInAnHour="2"
+            MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumEscalateResponder"
+         ComponentName="AMScanners"
+         AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+         TargetHealthState="Unhealthy"
+         EscalationTeam="FIPS"
+         EscalationLevel="Urgent"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanMinimumCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Expected"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanExpectedMonitor"
+         ComponentName="AM_Scheduled"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedRestartServiceResponder"
+         ComponentName="AM_Scheduled"
+         AlertMask = "MessagesWithFewerEngineScansThanExpectedMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedEscalateResponder"
+         ComponentName="AM_Scheduled"
+         AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+         TargetHealthState="Unhealthy"
+         TargetResource="FIPS"
+         EscalationTeam="FIPS"
+         EscalationLevel="Scheduled"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanExpectedCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Scan Time per Message - 90th Percentile"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanTimeMonitor"
+        ComponentName="AM_Scheduled"
+        MonitoringThreshold="5000"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanTimeRestartServiceResponder"
+        ComponentName="AM_Scheduled"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="ScanTimeCollectFIPSLogsResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanTimeEscalateResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationMessageUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationLevel="Scheduled"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+        
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages with Scan Error Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanErrorsMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="8"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="780"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="180"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanErrorsEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsMonitor"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationMessageUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+  
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Containing Malware Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesWithMalwareMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="4"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="600"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesWithMalwareRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithMalwareCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesWithMalwareEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationMessageUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesDeferredMonitor"
+        ComponentName="AMScanningDown"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="10"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesDeferredRestartServiceResponder"
+        ComponentName="AMScanningDown"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesDeferredCollectFIPSLogsResponder"
+        ComponentName="AMScanningDown"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesDeferredEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is deferring too many messages"
+        EscalationMessageUnhealthy="Malware filtering is deferring too many messages"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesSlowDefersMonitor"
+        ComponentName="AMMessagesDeferred"
+        MonitoringThreshold="15"
+        SecondaryMonitoringThreshold="20"
+        Enabled="true" />
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesSlowDefersCollectFIPSLogsResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesSlowDefersEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationMessageUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Recovery Store Percentage Full"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="RecoveryStoreFullMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="RecoveryStoreFullRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="RecoveryStoreFullCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="RecoveryStoreFullEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationMessageUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Written to Recovery Store"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesInRecoveryStoreMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesInRecoveryStoreRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesInRecoveryStoreCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesInRecoveryStoreEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationMessageUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareClean"
+      SenderFeatureTag="AntimalwareClean"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareCleanProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestCleanMail" Body="test">
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=0" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareCleanMonitor"
+        SampleMask="AntimalwareCleanProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MaxRetryAttempts = "0"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareCleanResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareCleanMonitor"
+        AlertMask="AntimalwareCleanMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareClean failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareClean failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareBlockAction"
+      SenderFeatureTag="AntimalwareBlockAction"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareBlockActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestBlockAction" Body="test">
+              <Attachment Filename="eicar" />
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=1|action=b" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareBlockActionMonitor"
+        SampleMask="AntimalwareBlockActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareBlockActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareBlockActionMonitor"
+        AlertMask="AntimalwareBlockActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareBlockAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareBlockAction failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentNDRUrgentMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.NDR"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentNDRUrgentEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentNDRUrgentMonitor"
+      AlertMask="AMAgentNDRUrgentMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware Agent rejected more than 5 messages."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Messages NDR'd in the last minute:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentPolicyDiscoveryMonitor"
+      ComponentName="AMADError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.MalwareFilterPolicyDiscovery"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentPolicyDiscoveryEscalateResponder"
+      ComponentName="AMADError"
+      AlertTypeId="AMAgentPolicyDiscoveryMonitor"
+      AlertMask="AMAgentPolicyDiscoveryMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Malware Filter Policy discovery failed."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Malware Filter Policy discovery failed. Total number of errors during the last minute: &lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentTenantConfigErrorMonitor"
+      ComponentName="AMTenantConfigError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.TenantConfigurationError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentTenantConfigErrorEscalateResponder"
+      ComponentName="AMTenantConfigError"
+      AlertTypeId="AMAgentTenantConfigErrorMonitor"
+      AlertMask="AMAgentTenantConfigErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Tenant Configuration Error"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;A tenant has atleast two Malware Filter Policies with the same name.&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="FlightingFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.FlightingFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="FlightingFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="FlightingFailureMonitor"
+      AlertMask="FlightingFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to determine if AM agent is enabled or not."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Failed to determine if AM agent V2 is enabled or not.
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentCategoryErrorMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.CategoryError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentCategoryErrorEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentCategoryErrorMonitor"
+      AlertMask="AMAgentCategoryErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware: All engine errors"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;All engines threw an error for atleast 5 messages in the last 5 mins:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="ReputationFileHashPublisherFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="ReputationFileHashPublisher.PublishFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="ReputationFileHashPublisherFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="ReputationFileHashPublisherFailureMonitor"
+      AlertMask="ReputationFileHashPublisherFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to publish file hashes to reputation service."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+   <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      ComponentName="AntiSpam"
+      EventNotificationServiceName="AntiSpam"
+      EventNotificationComponent="HygieneDataSummaryGenerator.LogException"
+      MonitoringIntervalSeconds="1800"
+      MonitoringThreshold="3"
+      RecurrenceIntervalSeconds="900"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="HygieneDataSummaryGenerator.LogExceptionResponder"
+      ComponentName="AntiSpam"
+      AlertTypeId="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      AlertMask="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      EscalationTeam="AntiSpam"
+      EscalationSubjectUnhealthy="HygieneDataSummaryGenerator - Log Creation Exception Occurred."
+      EscalationMessageUnhealthy="{Probe.Error}"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+</Definition>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/Antimalware.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/Antimalware.xml
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<Definition xsi:noNamespaceSchemaLocation="..\..\WorkItemDefinition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <MaintenanceDefinition
+    AssemblyPath="Microsoft.Exchange.Monitoring.ActiveMonitoring.Local.Components.dll"
+    TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Antimalware.AntimalwareDiscovery"
+    Name="Antimalware.Maintenance.Workitem"
+    ServiceName="Antimalware"
+    RecurrenceIntervalSeconds="0"
+    TimeoutSeconds="600"
+    MaxRetryAttempts="3"
+    Enabled ="true" >
+    <!-- To override the default values, add/modify the corresponding extension attributes.  
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp;C:\TransportRoles\data\Temp" 
+      CleanupFolderResponderFileRetentionPeriod = "05:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "00:10:00"
+    />-->
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp\UnifiedContent;C:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp\UnifiedContent"
+      CleanupFolderResponderFileRetentionPeriod = "1.00:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "04:00:00"
+    />
+  </MaintenanceDefinition>
+
+  <!--
+  For OverallConsecutiveSampleValueAboveThresholdMonitor,
+            TimeoutSeconds = 30;
+            SecondaryMonitoringThreshold = numberOfSamples;
+            MonitoringIntervalSeconds = (numberOfSamples + 1) * 300; ////EDS sends data to us every 5 minutes
+            RecurrenceIntervalSeconds = monitor.MonitoringIntervalSeconds / 2;
+  -->
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Minimum Threshold"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanMinimumMonitor"
+         ComponentName="AMScanners"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumRestartServiceResponder"
+         ComponentName="AMScanners"
+         AlertMask = "MessagesWithFewerEngineScansThanMinimumMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+          <ExtensionAttributes
+            WindowsServiceName="FMS"
+            ServiceStopTimeout="60"
+            ServiceStartTimeout="120"
+            ServiceStartDelay="2"
+            MinimumSecondsBetweenRestarts="7200"
+            MaximumAllowedRestartsInAnHour="2"
+            MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumEscalateResponder"
+         ComponentName="AMScanners"
+         AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+         TargetHealthState="Unhealthy"
+         EscalationTeam="FIPS"
+         EscalationLevel="Urgent"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanMinimumCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Expected"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanExpectedMonitor"
+         ComponentName="AM_Scheduled"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedRestartServiceResponder"
+         ComponentName="AM_Scheduled"
+         AlertMask = "MessagesWithFewerEngineScansThanExpectedMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedEscalateResponder"
+         ComponentName="AM_Scheduled"
+         AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+         TargetHealthState="Unhealthy"
+         TargetResource="FIPS"
+         EscalationTeam="FIPS"
+         EscalationLevel="Scheduled"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanExpectedCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Scan Time per Message - 90th Percentile"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanTimeMonitor"
+        ComponentName="AM_Scheduled"
+        MonitoringThreshold="5000"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanTimeRestartServiceResponder"
+        ComponentName="AM_Scheduled"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="ScanTimeCollectFIPSLogsResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanTimeEscalateResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationMessageUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationLevel="Scheduled"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+        
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages with Scan Error Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanErrorsMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="8"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="780"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="180"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanErrorsEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsMonitor"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationMessageUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+  
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Containing Malware Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesWithMalwareMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="4"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="600"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesWithMalwareRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithMalwareCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesWithMalwareEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationMessageUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesDeferredMonitor"
+        ComponentName="AMScanningDown"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="10"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesDeferredRestartServiceResponder"
+        ComponentName="AMScanningDown"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesDeferredCollectFIPSLogsResponder"
+        ComponentName="AMScanningDown"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesDeferredEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is deferring too many messages"
+        EscalationMessageUnhealthy="Malware filtering is deferring too many messages"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesSlowDefersMonitor"
+        ComponentName="AMMessagesDeferred"
+        MonitoringThreshold="15"
+        SecondaryMonitoringThreshold="20"
+        Enabled="true" />
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesSlowDefersCollectFIPSLogsResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesSlowDefersEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationMessageUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Recovery Store Percentage Full"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="RecoveryStoreFullMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="RecoveryStoreFullRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="RecoveryStoreFullCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="RecoveryStoreFullEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationMessageUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Written to Recovery Store"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesInRecoveryStoreMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesInRecoveryStoreRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesInRecoveryStoreCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesInRecoveryStoreEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationMessageUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareClean"
+      SenderFeatureTag="AntimalwareClean"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareCleanProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestCleanMail" Body="test">
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=0" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareCleanMonitor"
+        SampleMask="AntimalwareCleanProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MaxRetryAttempts = "0"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareCleanResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareCleanMonitor"
+        AlertMask="AntimalwareCleanMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareClean failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareClean failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareBlockAction"
+      SenderFeatureTag="AntimalwareBlockAction"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareBlockActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestBlockAction" Body="test">
+              <Attachment Filename="eicar" />
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=1|action=b" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareBlockActionMonitor"
+        SampleMask="AntimalwareBlockActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareBlockActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareBlockActionMonitor"
+        AlertMask="AntimalwareBlockActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareBlockAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareBlockAction failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentNDRUrgentMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.NDR"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentNDRUrgentEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentNDRUrgentMonitor"
+      AlertMask="AMAgentNDRUrgentMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware Agent rejected more than 5 messages."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Messages NDR'd in the last minute:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentPolicyDiscoveryMonitor"
+      ComponentName="AMADError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.MalwareFilterPolicyDiscovery"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentPolicyDiscoveryEscalateResponder"
+      ComponentName="AMADError"
+      AlertTypeId="AMAgentPolicyDiscoveryMonitor"
+      AlertMask="AMAgentPolicyDiscoveryMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Malware Filter Policy discovery failed."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Malware Filter Policy discovery failed. Total number of errors during the last minute: &lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentTenantConfigErrorMonitor"
+      ComponentName="AMTenantConfigError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.TenantConfigurationError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentTenantConfigErrorEscalateResponder"
+      ComponentName="AMTenantConfigError"
+      AlertTypeId="AMAgentTenantConfigErrorMonitor"
+      AlertMask="AMAgentTenantConfigErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Tenant Configuration Error"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;A tenant has atleast two Malware Filter Policies with the same name.&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="FlightingFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.FlightingFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="FlightingFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="FlightingFailureMonitor"
+      AlertMask="FlightingFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to determine if AM agent is enabled or not."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Failed to determine if AM agent V2 is enabled or not.
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+  
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentCategoryErrorMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.CategoryError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentCategoryErrorEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentCategoryErrorMonitor"
+      AlertMask="AMAgentCategoryErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware: All engine errors"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;All engines threw an error for atleast 5 messages in the last 5 mins:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="ReputationFileHashPublisherFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="ReputationFileHashPublisher.PublishFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="ReputationFileHashPublisherFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="ReputationFileHashPublisherFailureMonitor"
+      AlertMask="ReputationFileHashPublisherFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to publish file hashes to reputation service."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+   <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      ComponentName="AntiSpam"
+      EventNotificationServiceName="AntiSpam"
+      EventNotificationComponent="HygieneDataSummaryGenerator.LogException"
+      MonitoringIntervalSeconds="1800"
+      MonitoringThreshold="3"
+      RecurrenceIntervalSeconds="900"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="HygieneDataSummaryGenerator.LogExceptionResponder"
+      ComponentName="AntiSpam"
+      AlertTypeId="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      AlertMask="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      EscalationTeam="AntiSpam"
+      EscalationSubjectUnhealthy="HygieneDataSummaryGenerator - Log Creation Exception Occurred."
+      EscalationMessageUnhealthy="{Probe.Error}"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+</Definition>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/Antimalware1.xml
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/Antimalware1.xml
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<Definition xsi:noNamespaceSchemaLocation="..\..\WorkItemDefinition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <MaintenanceDefinition
+    AssemblyPath="Microsoft.Exchange.Monitoring.ActiveMonitoring.Local.Components.dll"
+    TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Antimalware.AntimalwareDiscovery"
+    Name="Antimalware.Maintenance.Workitem"
+    ServiceName="Antimalware"
+    RecurrenceIntervalSeconds="0"
+    TimeoutSeconds="600"
+    MaxRetryAttempts="3"
+    Enabled ="true" >
+    <!-- To override the default values, add/modify the corresponding extension attributes.
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp;C:\TransportRoles\data\Temp"
+      CleanupFolderResponderFileRetentionPeriod = "05:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "00:10:00"
+    />-->
+    <ExtensionAttributes
+      CleanupFolderResponderFolderPaths = "D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp\UnifiedContent;D:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp\UnifiedContent"
+      CleanupFolderResponderFileRetentionPeriod = "1.00:00:00"
+      CleanupFolderResponderRecurrenceIntervalSeconds = "04:00:00"
+    />
+  </MaintenanceDefinition>
+
+  <!--
+  For OverallConsecutiveSampleValueAboveThresholdMonitor,
+            TimeoutSeconds = 30;
+            SecondaryMonitoringThreshold = numberOfSamples;
+            MonitoringIntervalSeconds = (numberOfSamples + 1) * 300; ////EDS sends data to us every 5 minutes
+            RecurrenceIntervalSeconds = monitor.MonitoringIntervalSeconds / 2;
+  -->
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Minimum Threshold"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanMinimumMonitor"
+         ComponentName="AMScanners"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumRestartServiceResponder"
+         ComponentName="AMScanners"
+         AlertMask = "MessagesWithFewerEngineScansThanMinimumMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+          <ExtensionAttributes
+            WindowsServiceName="FMS"
+            ServiceStopTimeout="60"
+            ServiceStartTimeout="120"
+            ServiceStartDelay="2"
+            MinimumSecondsBetweenRestarts="7200"
+            MaximumAllowedRestartsInAnHour="2"
+            MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanMinimumEscalateResponder"
+         ComponentName="AMScanners"
+         AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+         TargetHealthState="Unhealthy"
+         EscalationTeam="FIPS"
+         EscalationLevel="Urgent"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than minimum." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanMinimumCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanMinimumMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanMinimumMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-Malware Agent"
+      Counter="Messages with Fewer Engine Scans than Expected"
+      Instance="*"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false">
+      <Monitor
+         TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+         Name="MessagesWithFewerEngineScansThanExpectedMonitor"
+         ComponentName="AM_Scheduled"
+         MonitoringThreshold="60"
+         SecondaryMonitoringThreshold="3"
+         Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+
+      <Responder
+         TypeName="RestartServiceResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedRestartServiceResponder"
+         ComponentName="AM_Scheduled"
+         AlertMask = "MessagesWithFewerEngineScansThanExpectedMonitor"
+         RecurrenceIntervalSeconds= "30"
+         TimeoutSeconds="30"
+         WaitIntervalSeconds="600"
+         TargetHealthState="Degraded"
+         TargetResource="FIPS"
+         Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+
+      <Responder
+         TypeName="EscalateResponder"
+         Name="MessagesWithFewerEngineScansThanExpectedEscalateResponder"
+         ComponentName="AM_Scheduled"
+         AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+         AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+         TargetHealthState="Unhealthy"
+         TargetResource="FIPS"
+         EscalationTeam="FIPS"
+         EscalationLevel="Scheduled"
+         EscalationSubjectUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected."
+         EscalationMessageUnhealthy="AntimalwareAgent Alert: The messages are being scanned by fewer engines than expected." />
+
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithFewerEngineScansThanExpectedCollectFIPSLogsResponder"
+        ComponentName="AMScanners"
+        AlertTypeId="MessagesWithFewerEngineScansThanExpectedMonitor"
+        AlertMask="MessagesWithFewerEngineScansThanExpectedMonitor"
+        TargetHealthState="Unhealthy"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Scan Time per Message - 90th Percentile"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanTimeMonitor"
+        ComponentName="AM_Scheduled"
+        MonitoringThreshold="5000"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanTimeRestartServiceResponder"
+        ComponentName="AM_Scheduled"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="ScanTimeCollectFIPSLogsResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanTimeEscalateResponder"
+        ComponentName="AM_Scheduled"
+        AlertTypeId="ScanTimeMonitor"
+        AlertMask="ScanTimeMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationMessageUnhealthy="Malware filtering is taking too long (90th percentile)"
+        EscalationLevel="Scheduled"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages with Scan Error Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="ScanErrorsMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="8"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="780"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="ScanErrorsRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="180"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="ScanErrorsEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="ScanErrorsMonitor"
+        AlertMask="ScanErrorsMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationMessageUnhealthy="Malware filtering is returning too many scan errors"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Containing Malware Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesWithMalwareMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="4"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="600"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesWithMalwareRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="true">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesWithMalwareCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesWithMalwareEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesWithMalwareMonitor"
+        AlertMask="MessagesWithMalwareMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationMessageUnhealthy="An abnormally high rate of malware is being detected"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesDeferredMonitor"
+        ComponentName="AMScanningDown"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="10"
+        Enabled="true">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesDeferredRestartServiceResponder"
+        ComponentName="AMScanningDown"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesDeferredCollectFIPSLogsResponder"
+        ComponentName="AMScanningDown"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesDeferredEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesDeferredMonitor"
+        AlertMask="MessagesDeferredMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is deferring too many messages"
+        EscalationMessageUnhealthy="Malware filtering is deferring too many messages"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Deferred Percentage"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesSlowDefersMonitor"
+        ComponentName="AMMessagesDeferred"
+        MonitoringThreshold="15"
+        SecondaryMonitoringThreshold="20"
+        Enabled="true" />
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesSlowDefersCollectFIPSLogsResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesSlowDefersEscalateResponder"
+        ComponentName="AMMessagesDeferred"
+        AlertTypeId="MessagesSlowDefersMonitor"
+        AlertMask="MessagesSlowDefersMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationMessageUnhealthy="Malware filtering has been deferring 15% of messages for more than 1.5 hours"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Recovery Store Percentage Full"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="RecoveryStoreFullMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="90"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="RecoveryStoreFullRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="RecoveryStoreFullCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="RecoveryStoreFullEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="RecoveryStoreFullMonitor"
+        AlertMask="RecoveryStoreFullMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationMessageUnhealthy="Malware filtering recovery store is getting too full"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <PerformanceCounters>
+    <Counter
+      Object="MSExchange Anti-malware Agent"
+      Counter="Messages Written to Recovery Store"
+      Instance="*">
+      <Monitor
+        TypeName="OverallConsecutiveSampleValueAboveThresholdMonitor"
+        Name="MessagesInRecoveryStoreMonitor"
+        ComponentName="AMScanError"
+        MonitoringThreshold="25"
+        SecondaryMonitoringThreshold="3"
+        Enabled="false">
+        <StateTransitions>
+          <Transition ToState="Degraded" TimeoutInSeconds="0"/>
+          <Transition ToState="Unhealthy" TimeoutInSeconds="450"/>
+        </StateTransitions>
+      </Monitor>
+      <Responder
+        TypeName="RestartServiceResponder"
+        Name="MessagesInRecoveryStoreRestartServiceResponder"
+        ComponentName="AMScanError"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Degraded"
+        TargetResource="FIPS"
+        WaitIntervalSeconds="600"
+        Enabled="false">
+        <ExtensionAttributes
+          WindowsServiceName="FMS"
+          ServiceStopTimeout="60"
+          ServiceStartTimeout="120"
+          ServiceStartDelay="2"
+          MinimumSecondsBetweenRestarts="7200"
+          MaximumAllowedRestartsInAnHour="2"
+          MaximumAllowedRestartsInADay="10"/>
+      </Responder>
+      <Responder
+        TypeName="Microsoft.Exchange.Monitoring.ActiveMonitoring.Fips.Responders.CollectFIPSLogsResponder"
+        Name="MessagesInRecoveryStoreCollectFIPSLogsResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"/>
+      <Responder
+        TypeName="EscalateResponder"
+        Name="MessagesInRecoveryStoreEscalateResponder"
+        ComponentName="AMScanError"
+        AlertTypeId="MessagesInRecoveryStoreMonitor"
+        AlertMask="MessagesInRecoveryStoreMonitor"
+        TargetHealthState="Unhealthy"
+        TargetResource="FIPS"
+        EscalationTeam="FIPS"
+        EscalationSubjectUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationMessageUnhealthy="Malware filtering is sending too many messages to the recovery store"
+        EscalationLevel="Urgent"
+        Enabled="true"/>
+    </Counter>
+  </PerformanceCounters>
+
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareClean"
+      SenderFeatureTag="AntimalwareClean"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareCleanProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestCleanMail" Body="test">
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=0" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareCleanMonitor"
+        SampleMask="AntimalwareCleanProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MaxRetryAttempts = "0"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareCleanResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareCleanMonitor"
+        AlertMask="AntimalwareCleanMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareClean failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareClean failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+
+  <CustomWorkItem
+      RecipientFeatureTag="AntimalwareBlockAction"
+      SenderFeatureTag="AntimalwareBlockAction"
+      FfoDataCenter="true"
+      ExoDataCenter="true"
+      OnPremise="false"
+      DataCenterDedicated="false">
+    <Probe
+        TypeName="Microsoft.Forefront.Monitoring.ActiveMonitoring.Smtp.Probes.TransportSmtpProbe"
+        Name="AntimalwareBlockActionProbe"
+        ComponentName="AMSMTPProbe"
+        RecurrenceIntervalSeconds="1800"
+        TimeoutSeconds="300"
+        MaxRetryAttempts="1"
+        Enabled ="true">
+      <ExtensionAttributes>
+        <WorkContext>
+          <SendMail SmtpServerUri="127.0.0.1" SLA="00:03:00" Port="25" Timeout="240" Direction="Incoming" IgnoreSendMailFailure="true">
+            <MailFrom Select="1"/> <!-- select sender as per feature tag-->
+            <MailTo Select="1"/> <!-- select any one mailbox -->
+            <!--let the GenericWorkItem populate automatically from test tenant-->
+            <Message Subject="TestBlockAction" Body="test">
+              <Attachment Filename="eicar" />
+              <Header Tag="X-Exchange-Probe-Drop-Message" Value="FrontEnd-CAT-250" />
+            </Message>
+          </SendMail>
+          <Match>
+            <Notification Type="AgentInfo" MatchType="SubString" Value="AMA[SUM|v=1|action=b" Mandatory="false"/>
+          </Match>
+        </WorkContext>
+      </ExtensionAttributes>
+    </Probe>
+    <Monitor
+        TypeName="OverallConsecutiveProbeFailuresMonitor"
+        ComponentName="AMSMTPProbe"
+        Name="AntimalwareBlockActionMonitor"
+        SampleMask="AntimalwareBlockActionProbe"
+        RecurrenceIntervalSeconds= "0"
+        MonitoringIntervalSeconds="5400"
+        MonitoringThreshold = "3"/>
+    <Responder
+        TypeName="EscalateResponder"
+        Name="AntimalwareBlockActionResponder"
+        ComponentName="AMSMTPProbe"
+        AlertTypeId="AntimalwareBlockActionMonitor"
+        AlertMask="AntimalwareBlockActionMonitor"
+        TargetResource="AMAgent"
+        TargetHealthState="None"
+        EscalationTeam="FIPS"
+        EscalationLevel="Urgent"
+        EscalationSubjectUnhealthy="Antimalware Alert: AntimalwareBlockAction failed"
+        EscalationMessageUnhealthy="Antimalware Alert: AntimalwareBlockAction failed
+        &lt;br/&gt;Error:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;
+        &lt;br/&gt;Exception:&lt;pre&gt;{Probe.Exception}&lt;/pre&gt;
+        &lt;br/&gt;FailureContext:&lt;pre&gt;{Probe.FailureContext}&lt;/pre&gt;
+        &lt;br/&gt;ExecutionContext:&lt;pre&gt;{Probe.ExecutionContext}&lt;/pre&gt;"
+        Enabled="true"/>
+  </CustomWorkItem>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentNDRUrgentMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.NDR"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentNDRUrgentEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentNDRUrgentMonitor"
+      AlertMask="AMAgentNDRUrgentMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware Agent rejected more than 5 messages."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Messages NDR'd in the last minute:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentPolicyDiscoveryMonitor"
+      ComponentName="AMADError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.MalwareFilterPolicyDiscovery"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentPolicyDiscoveryEscalateResponder"
+      ComponentName="AMADError"
+      AlertTypeId="AMAgentPolicyDiscoveryMonitor"
+      AlertMask="AMAgentPolicyDiscoveryMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Malware Filter Policy discovery failed."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Malware Filter Policy discovery failed. Total number of errors during the last minute: &lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentTenantConfigErrorMonitor"
+      ComponentName="AMTenantConfigError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.TenantConfigurationError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentTenantConfigErrorEscalateResponder"
+      ComponentName="AMTenantConfigError"
+      AlertTypeId="AMAgentTenantConfigErrorMonitor"
+      AlertMask="AMAgentTenantConfigErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Tenant Configuration Error"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;A tenant has atleast two Malware Filter Policies with the same name.&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="UrgentInTraining"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="FlightingFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.FlightingFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="1"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="FlightingFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="FlightingFailureMonitor"
+      AlertMask="FlightingFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to determine if AM agent is enabled or not."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Failed to determine if AM agent V2 is enabled or not.
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="AMAgentCategoryErrorMonitor"
+      ComponentName="AMScanError"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="AntimalwareAgent.CategoryError"
+      MonitoringIntervalSeconds="300"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="300"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="AMAgentCategoryErrorEscalateResponder"
+      ComponentName="AMScanError"
+      AlertTypeId="AMAgentCategoryErrorMonitor"
+      AlertMask="AMAgentCategoryErrorMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Antimalware: All engine errors"
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;All engines threw an error for atleast 5 messages in the last 5 mins:&lt;pre&gt;{Monitor.TotalFailedCount}&lt;/pre&gt;
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Urgent"/>
+  </NTEvent>
+
+  <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="ReputationFileHashPublisherFailureMonitor"
+      ComponentName="AMService"
+      EventNotificationServiceName="Antimalware"
+      EventNotificationComponent="ReputationFileHashPublisher.PublishFailure"
+      MonitoringIntervalSeconds="60"
+      MonitoringThreshold="5"
+      TimeoutSeconds="30"
+      RecurrenceIntervalSeconds="60"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="ReputationFileHashPublisherFailureEscalateResponder"
+      ComponentName="AMService"
+      AlertTypeId="ReputationFileHashPublisherFailureMonitor"
+      AlertMask="ReputationFileHashPublisherFailureMonitor"
+      TargetHealthState="None"
+      EscalationTeam="FIPS"
+      EscalationSubjectUnhealthy="Failed to publish file hashes to reputation service."
+      EscalationMessageUnhealthy="
+      &lt;br/&gt;Details:&lt;pre&gt;{Probe.Error}&lt;/pre&gt;"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+   <NTEvent>
+    <Monitor
+      TypeName="OverallXFailuresMonitor"
+      Name="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      ComponentName="AntiSpam"
+      EventNotificationServiceName="AntiSpam"
+      EventNotificationComponent="HygieneDataSummaryGenerator.LogException"
+      MonitoringIntervalSeconds="1800"
+      MonitoringThreshold="3"
+      RecurrenceIntervalSeconds="900"
+      Enabled="true"/>
+    <Responder
+      TypeName="EscalateResponder"
+      Name="HygieneDataSummaryGenerator.LogExceptionResponder"
+      ComponentName="AntiSpam"
+      AlertTypeId="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      AlertMask="HygieneDataSummaryGenerator.LogExceptionMonitor"
+      EscalationTeam="AntiSpam"
+      EscalationSubjectUnhealthy="HygieneDataSummaryGenerator - Log Creation Exception Occurred."
+      EscalationMessageUnhealthy="{Probe.Error}"
+      EscalationLevel="Scheduled"/>
+  </NTEvent>
+
+</Definition>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -118,8 +118,10 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "EdgeTransport.exe.config Present" "True" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
             TestObjectMatch "EXO Connector Present" "False"
+            # For some reason by default Exchange 2013 doesn't have this setting. not going to look into it just going to make a not of it and move on.
+            TestObjectMatch "UnifiedContent Auto Cleanup Configured" $false -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 12
+            $Script:ActiveGrouping.Count | Should -Be 13
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E15.Main.Tests.ps1
@@ -119,7 +119,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2013" {
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
             TestObjectMatch "EXO Connector Present" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 11
+            $Script:ActiveGrouping.Count | Should -Be 12
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -120,7 +120,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
             TestObjectMatch "EXO Connector Present" "False"
 
-            $Script:ActiveGrouping.Count | Should -Be 11
+            $Script:ActiveGrouping.Count | Should -Be 12
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -121,8 +121,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "NodeRunner.exe memory limit" "0 MB" -WriteType "Green"
             TestObjectMatch "Open Relay Wild Card Domain" "Not Set"
             TestObjectMatch "EXO Connector Present" "True" # Custom EXO Connector with no TlsDomain TlsAuthLevel
+            TestObjectMatch "UnifiedContent Auto Cleanup Configured" $true -WriteType "Green"
 
-            $Script:ActiveGrouping.Count | Should -Be 13
+            $Script:ActiveGrouping.Count | Should -Be 14
         }
 
         It "Display Results - Security Settings" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -318,6 +318,10 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "EdgeTransport.exe.config Invalid Config Format" $true -WriteType "Red"
         }
 
+        It "EdgeTransport.exe.config invalid config for UnifiedContent" {
+            TestObjectMatch "UnifiedContent Auto Cleanup Configured" "Error - EdgeTransport.exe.config Invalid Config Format" -WriteType "Red"
+        }
+
         It "TLS Settings" {
             SetActiveDisplayGrouping "Security Settings"
             TestObjectMatch "TLS 1.0" "Misconfigured" -WriteType "Red"
@@ -369,6 +373,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
                 -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Hardware\Physical_Win32_Processor1.xml" }
             Mock Get-ExSetupFileVersionInfo { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\ExSetup1.xml" }
             Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Getting applicationHost.config" } -MockWith { return Get-Content "$Script:MockDataCollectionRoot\Exchange\IIS\applicationHost2.config" -Raw -Encoding UTF8 }
+            Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Monitoring\Config\AntiMalware.xml" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\AntiMalware1.xml" -Raw -Encoding UTF8 }
 
             SetDefaultRunOfHealthChecker "Debug_Scenario3_Physical_Results.xml"
         }
@@ -406,6 +411,11 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
         It "HighPerformanceSet" {
             TestObjectMatch "HighPerformanceSet" $false -WriteType "Red"
+        }
+
+        It "UnifiedContent Auto Update" {
+            SetActiveDisplayGrouping "Frequent Configuration Issues"
+            TestObjectMatch "UnifiedContent Auto Cleanup Configured" $false -WriteType "Red"
         }
 
         It "Extended Protection" {

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -59,11 +59,13 @@ Mock Test-Path -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange
 Mock Test-Path -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\SharedWebConfig.config" } -MockWith { return $true }
 Mock Test-Path -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\EdgeTransport.exe.config" } -MockWith { return $true }
 Mock Test-Path -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Search\Ceres\Runtime\1.0\noderunner.exe.config" } -MockWith { return $true }
+Mock Test-Path -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Monitoring\Config\AntiMalware.xml" } -MockWith { return $true }
 
 Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\SharedWebConfig.config" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\IIS\DefaultWebSite_SharedWebConfig.config" -Raw -Encoding UTF8 }
 Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\ClientAccess\SharedWebConfig.config" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\IIS\ExchangeBackEnd_SharedWebConfig.config" -Raw -Encoding UTF8 }
 Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\EdgeTransport.exe.config" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\EdgeTransport.exe.config" -Raw -Encoding UTF8 }
 Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Search\Ceres\Runtime\1.0\noderunner.exe.config" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\noderunner.exe.config" -Raw -Encoding UTF8 }
+Mock Get-Content -ParameterFilter { $Path -eq "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Monitoring\Config\AntiMalware.xml" } -MockWith { Get-Content "$Script:MockDataCollectionRoot\Exchange\AntiMalware.xml" -Raw -Encoding UTF8 }
 
 function Get-WebApplication { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\IIS\GetWebApplication.xml" }
 

--- a/docs/Diagnostics/HealthChecker/UnifiedContentCleanup.md
+++ b/docs/Diagnostics/HealthChecker/UnifiedContentCleanup.md
@@ -1,0 +1,13 @@
+# UnifiedContent Automatic Cleanup
+
+Within Exchange Monitoring, we have a probe that will attempt to clear out the old temp data that is generated from EdgeTransport.exe process. However, this probe definition is defined in the `%ExchangeInstallPath%\Bin\Monitoring\Config\AntiMalware.xml` with a hardcoded path options to look. By default, we are only looking at `"D:\ExchangeTemp\TransportCts\UnifiedContent;C:\Windows\Temp\UnifiedContent;C:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp\UnifiedContent"`. Therefore, if Exchange is not installed in at `C:\Program Files\Microsoft\Exchange Server\V15\` or if the `TemporaryStoragePath` of the `EdgeTransport.exe.config` value is anything other than `C:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp` the probe will not work as intended to clean up the data files.
+
+The only way to get the probe to automatically clean up the temp files is to add the correct location to the `%ExchangeInstallPath%\Bin\Monitoring\Config\AntiMalware.xml` file.
+
+**Included in HTML Report?**
+
+Yes
+
+**Additional resources:**
+
+[Exchange UnifiedContent folder fills up the drive](https://learn.microsoft.com/en-us/exchange/troubleshoot/administration/unifiedcontent-folder-fills-up-drive)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - HCScheduledTask: Diagnostics/HealthChecker/RunHCViaSchedTask.md
       - ADSiteCount: Diagnostics/HealthChecker/ADSiteCount.md
       - ExchangeComputerMembership: Diagnostics/HealthChecker/ExchangeComputerMembership.md
+      - UnifiedContentCleanup: Diagnostics/HealthChecker/UnifiedContentCleanup.md
     - ManagedAvailabilityTroubleshooter: Diagnostics/ManagedAvailabilityTroubleshooter.md
     - Test-ExchAVExclusions: Diagnostics/Test-ExchAVExclusions.md
   - Hybrid:


### PR DESCRIPTION
**Issue:**
Unified Content temp data cleanup paths are hardcoded. Therefore, when the temp data path is not in the hardcoded paths, data is not cleaned up automatically causing drive space issues.

**Reason:**
There are a few cases on this and articles. Going to call this out to make it more aware for customers to catch this as the problem. 

**Fix:**
Include data collection of the `Antimalware.xml` file to be able to see the current hardcoded values then compare to the `TemporaryStoragePath` in the `EdgeTransport.exe.config` file. 

Resolved #2067
Resolved #1086

**Validation:**
Lab Tested/Pester tested
