### PR TITLE
Don't show TLS 1.3 settings on unsupported OS #2062

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Scenarios.Tests.ps1
@@ -194,7 +194,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "TLS 1.0" "Misconfigured" -WriteType "Red"
             TestObjectMatch "TLS 1.1" "Misconfigured" -WriteType "Red"
             TestObjectMatch "TLS 1.2" "Enabled" -WriteType "Green"
-            TestObjectMatch "TLS 1.3" "Disabled" -WriteType "Green"
+            #TestObjectMatch "TLS 1.3" "Disabled" -WriteType "Green"
 
             TestObjectMatch "Display Link to Docs Page" "True" -WriteType "Yellow"
 


### PR DESCRIPTION
**Issue:**
Don't show TLS 1.3 settings on unsupported OS

**Reason:**
Customers are confused that Health Checker shows the TLS 1.3 settings on Server OS that don't support TLS 1.3 (e.g., Server 2016 or Server 2019). I've also seen cases where customers have explicitly set the TLS 1.3 registry keys (on unsupported OS) for client and server, to disable it. I don't think that this shouldn't cause any impact, however, we should improve HC to only show the TLS 1.3 section on Server 2022 or higher OS.

**Fix:**
File "Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1" was updated with following codes:

$tls13SupportedOS = @("Windows2012", "Windows2012R2", "Windows2016", "Windows2019") -notcontains $osInformation.BuildInformation.MajorVersion

$displayTlsSettings = $tlsKey -ne "1.3" -or ($tlsKey -eq "1.3" -and ($tls13SupportedOS  -or ($currentTlsVersion.TLSConfiguration -ne "Disabled")))

if ($displayTlsSettings) {
Add-AnalyzedResultInformation @params
}

**Validation:**
Executed the script in the lab environment to test the results.

Resolved #2062 

