### PR TITLE
Remove double colons

### DIFF
--- a/M365/MDO/MDOThreatPolicyChecker.ps1
+++ b/M365/MDO/MDOThreatPolicyChecker.ps1
@@ -786,7 +786,7 @@ process {
                             $spamMatchedRule = Test-Rules -Rules $hostedContentFilterRules -Email $stEmailAddress
                         }
                         if ($null -eq $spamMatchedRule) {
-                            Write-Host "`nAnti-spam::`n`tDefault policy"  -ForegroundColor Yellow
+                            Write-Host "`nAnti-spam:`n`tDefault policy"  -ForegroundColor Yellow
                             $hostedContentFilterPolicy = Get-HostedContentFilterPolicy "Default"
                         } else {
                             $hostedContentFilterPolicy = Get-HostedContentFilterPolicy $spamMatchedRule.Name


### PR DESCRIPTION
Fix typo

**Issue:**
we have a double colons on antispam and it should be only one.

**Reason:**
fix typo

**Fix:**
remove one colons


