### PR TITLE
Add msExchHomeServerName test to SetupAssist

### DIFF
--- a/Setup/SetupAssist/Checks/Domain/Test-ValidMailboxProperties.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ValidMailboxProperties.ps1
@@ -5,13 +5,14 @@
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Search-AllActiveDirectoryDomains.ps1
 
 function Test-ValidMailboxProperties {
-    $testName = "Valid Home MDB"
+    $validHomeMdbTestName = "Valid Home MDB" # Need to make sure the property value homeMDB is not null and points to a valid database object.
+    $validHomeServerTestName = "Valid Home Server Name" # Need to make sure the property value msExchHomeServerName is not null.
     $arbitration = 0x800000
     $discovery = 0x20000000
     $publicFolder = 0x1000000000
     $recipientTypes = $arbitration -bor $discovery -bor $publicFolder
     $filter = "(&(objectClass=user)(mailNickname=*)(msExchRecipientTypeDetails:1.2.840.113556.1.4.804:=$recipientTypes))"
-    $propsToLoad = @("distinguishedName", "homeMDB")
+    $propsToLoad = @("distinguishedName", "homeMDB", "msExchHomeServerName")
 
     $results = Search-AllActiveDirectoryDomains -Filter $filter -PropertiesToLoad $propsToLoad
 
@@ -20,9 +21,10 @@ function Test-ValidMailboxProperties {
 
         foreach ($result in $results) {
             $dbName = $result.Properties["homeMDB"]
+            $mailboxDN = $result.Properties["distinguishedName"]
             $params = @{
-                TestName      = $testName
-                Details       = ("Mailbox DN: $($result.Properties["distinguishedName"])`n" +
+                TestName      = $validHomeMdbTestName
+                Details       = ("Mailbox DN: $mailboxDN`n" +
                     "Database DN: $dbName")
                 ReferenceInfo = ("Run the following command in EMS.`n" +
                     "If EMS is down, launch PowerShell and run `"Add-PSSnapin *Exchange*`"`n" +
@@ -35,8 +37,27 @@ function Test-ValidMailboxProperties {
             } else {
                 New-TestResult @params -Result "Failed"
             }
+
+            $homeServer = $result.Properties["msExchHomeServerName"]
+            $params = @{
+                TestName      = $validHomeServerTestName
+                Details       = ("Mailbox DN: $mailboxDN`nHome Server Name: $homeServer")
+                ReferenceInfo = ("Run the following command in PowerShell or EMS.`n" +
+                    "Set-ADObject 'DN' -Add @{msExchHomeServerName='AnExchangeServer-ExchangeLegacyDN-Value'}")
+            }
+
+            if ((-not([string]::IsNullOrEmpty($homeServer)))) {
+                New-TestResult @params -Result "Passed"
+            } else {
+                New-TestResult @params -Result "Failed"
+            }
         }
     } else {
-        New-TestResult -TestName $testName -Result "Failed" -Details "Failed to find any critical mailboxes"
+        $params = @{
+            Result  = "Failed"
+            Details = "Failed to find any critical mailboxes"
+        }
+        New-TestResult @params -TestName $validHomeMdbTestName
+        New-TestResult @params -TestName $validHomeServerTestName
     }
 }

--- a/Setup/SetupAssist/Checks/Domain/Test-ValidMailboxProperties.ps1
+++ b/Setup/SetupAssist/Checks/Domain/Test-ValidMailboxProperties.ps1
@@ -4,7 +4,7 @@
 . $PSScriptRoot\..\New-TestResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Search-AllActiveDirectoryDomains.ps1
 
-function Test-ValidHomeMDB {
+function Test-ValidMailboxProperties {
     $testName = "Valid Home MDB"
     $arbitration = 0x800000
     $discovery = 0x20000000

--- a/Setup/SetupAssist/SetupAssist.ps1
+++ b/Setup/SetupAssist/SetupAssist.ps1
@@ -16,7 +16,7 @@ param(
 . $PSScriptRoot\Checks\Domain\Test-DomainMultiActiveSyncVirtualDirectories.ps1
 . $PSScriptRoot\Checks\Domain\Test-ExchangeADSetupLevel.ps1
 . $PSScriptRoot\Checks\Domain\Test-DomainOtherWellKnownObjects.ps1
-. $PSScriptRoot\Checks\Domain\Test-ValidHomeMdb.ps1
+. $PSScriptRoot\Checks\Domain\Test-ValidMailboxProperties.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-ExecutionPolicy.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-ExchangeServices.ps1
 . $PSScriptRoot\Checks\LocalServer\Test-InstallWatermark.ps1
@@ -56,7 +56,7 @@ function RunAllTests {
         "Test-PrerequisiteInstalled",
         "Test-DomainOtherWellKnownObjects",
         "Test-PendingReboot",
-        "Test-ValidHomeMDB",
+        "Test-ValidMailboxProperties",
         "Test-VirtualDirectoryConfiguration")
 
     foreach ($test in $tests) {


### PR DESCRIPTION
**Issue:**
Long running case for setup that took forever to get down to the public folder mailbox not having the property `msExchHomeServerName` set to a value, making us think it was a `MailUser` object and we needed to have the `ExternalEmailAddress` set on the object. However, this is not true. 

**Reason:**
Call out issue that can be quickly addressed. 

**Fix:**
Get the property `msExchHomeServerName` when we are getting the `homeMDB` value from the critical mailboxes as well. Then do a check for that. 

Also changed the file name to support more than just the one test type. 

**Validation:**
Lab tested

