### PR TITLE
Use long temp path name vs short name

### DIFF
--- a/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
+++ b/Shared/ScriptUpdateFunctions/Invoke-ScriptUpdate.ps1
@@ -28,7 +28,7 @@ function Invoke-ScriptUpdate {
 
     $oldName = [IO.Path]::GetFileNameWithoutExtension($scriptName) + ".old"
     $oldFullName = (Join-Path $scriptPath $oldName)
-    $tempFullName = (Join-Path $env:TEMP $scriptName)
+    $tempFullName = (Join-Path ((Get-Item $env:TEMP).FullName) $scriptName)
 
     if ($PSCmdlet.ShouldProcess("$scriptName", "Update script to latest version")) {
         try {


### PR DESCRIPTION
**Issue:**
In an internal lab where we had `BATRE~1.BAT` for the short name, we wouldn't be able to use the auto update code. Current thinking is that this is due to the ending of the file name and Defender thinking it is an extension. 

![image](https://github.com/user-attachments/assets/324231ea-d3ac-47f7-be02-9706c67fe8d3)


**Fix:**
Using the short name is causing some problems with the auto update logic causing that code to not work

**Validation:**
The internal lab no longer has an issue with using the update code when using the long name. 

