### PR TITLE
Add Event Based Assistants Logs to ELC

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -18,6 +18,7 @@ param (
     [switch]$DailyPerformanceLogs,
     [switch]$EASLogs,
     [switch]$ECPLogs,
+    [switch]$EventBasedAssistantsLogs,
     [switch]$EWSLogs,
     [Alias("ExchangeServerInfo")]
     [switch]$ExchangeServerInformation,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -36,6 +36,7 @@ function Get-ArgumentList {
         TransportLogging               = $TransportLogging
         EASLogs                        = $EASLogs
         ECPLogs                        = $ECPLogs
+        EventBasedAssistantsLogs       = $EventBasedAssistantsLogs
         EWSLogs                        = $EWSLogs
         ExchangeServerInformation      = $ExchangeServerInformation
         ExMon                          = $ExMon

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -7,6 +7,7 @@ function Test-NoSwitchesProvided {
         $IISLogs -or
         $DailyPerformanceLogs -or
         $ManagedAvailabilityLogs -or
+        $EventBasedAssistantsLogs -or
         $ExPerfWiz -or
         $RPCLogs -or
         $EASLogs -or

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -35,6 +35,7 @@ function Test-PossibleCommonScenarios {
         $Script:TransportProtocolLogs = $true
         $Script:MitigationService = $true
         $Script:MailboxAssistantsLogs = $true
+        $Script:EventBasedAssistantsLogs = $true
     }
 
     if ($TransportLogging) {
@@ -51,6 +52,7 @@ function Test-PossibleCommonScenarios {
         $Script:PipelineTracingLogs = $true
         $Script:TransportRules = $true
         $Script:AcceptedRemoteDomain = $true
+        $Script:EventBasedAssistantsLogs = $true
     }
 
     if ($TransportConnectivityLogs) {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -204,6 +204,11 @@ function Invoke-RemoteMain {
                 Add-LogCopyFullTaskAction $Script:localServerObject.TransportInfo.MBXLoggingInfo.PipelineTracingPath "Mailbox_Pipeline_Tracing_Logs"
             }
         }
+
+        if ($PassedInfo.EventBasedAssistantsLogs -and $Script:localServerObject.Mailbox) {
+            Add-LogCopyFullTaskAction "$Script:localExInstall`Logging\EventBasedAssistants" "Event_Based_Assistants_Logs"
+            Add-LogCopyFullTaskAction "$Script:localExInstall`Logging\EventBasedAssistantsCollection" "Event_Based_Assistants_Collection_Logs"
+        }
     }
 
     ############################################

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -74,6 +74,7 @@ DAGInformation | Enable to collect the DAG Information from all different DAGs t
 DailyPerformanceLogs | Enable to collect Daily Performance Logs. Default Location: `V15\Logging\Diagnostics\DailyPerformanceLogs`
 EASLogs | Enable to collect Exchange Active Sync Logging. Location: `V15\Logging\HttpProxy\Eas`
 ECPLogs | Enable to collect ECP Logs. Location: `V15\Logging\ECP` and `V15\Logging\HttpProxy\Ecp`
+EventBasedAssistantsLogs | Enable to collect Event Based Assistants Logs. Location: `V15\Logging\EventBasedAssistants` and `V15\Logging\EventBasedAssistantsCollection`
 EWSLogs | Enable to collect EWS Logs. Location: `V15\Logging\HttpProxy\Ews` and `V15\Logging\Ews`
 ExchangeServerInformation | Enable to collect Exchange Information like Get-ExchangeServer, Get-MailboxServer, etc... This is also collected when `-ServerInformation` is also enabled.
 ExMon | Enable to collect ExMon data from the server.


### PR DESCRIPTION
**Reason:**
Currently not collecting the Event Based Assistants Logs within Exchange Log Collector

**Fix:**
Add the new option to collect this data type to the script. Need this data for a case. 

**Validation:**
Lab tested

