### PR TITLE
Add Conversation Logs to ELC

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -14,6 +14,7 @@ param (
     [bool]$AppSysLogsToXml = $true,
     [switch]$AutoDLogs,
     [switch]$CollectFailoverMetrics,
+    [switch]$ConversationLogs,
     [switch]$DAGInformation,
     [switch]$DailyPerformanceLogs,
     [switch]$EASLogs,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -31,6 +31,7 @@ function Get-ArgumentList {
         AppSysLogsToXml                = $AppSysLogsToXml
         AutoDLogs                      = $AutoDLogs
         CollectAllLogsBasedOnLogAge    = $CollectAllLogsBasedOnLogAge
+        ConversationLogs               = $ConversationLogs
         DAGInformation                 = $DAGInformation
         DailyPerformanceLogs           = $DailyPerformanceLogs
         TransportLogging               = $TransportLogging

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -7,6 +7,7 @@ function Test-NoSwitchesProvided {
         $IISLogs -or
         $DailyPerformanceLogs -or
         $ManagedAvailabilityLogs -or
+        $ConversationLogs -or
         $EventBasedAssistantsLogs -or
         $ExPerfWiz -or
         $RPCLogs -or

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -36,6 +36,7 @@ function Test-PossibleCommonScenarios {
         $Script:MitigationService = $true
         $Script:MailboxAssistantsLogs = $true
         $Script:EventBasedAssistantsLogs = $true
+        $Script:ConversationLogs = $true
     }
 
     if ($TransportLogging) {

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -209,6 +209,11 @@ function Invoke-RemoteMain {
             Add-LogCopyFullTaskAction "$Script:localExInstall`Logging\EventBasedAssistants" "Event_Based_Assistants_Logs"
             Add-LogCopyFullTaskAction "$Script:localExInstall`Logging\EventBasedAssistantsCollection" "Event_Based_Assistants_Collection_Logs"
         }
+
+        if ($PassedInfo.ConversationLogs -and $Script:localServerObject.Mailbox) {
+            Add-DefaultLogCopyTaskAction "$Script:localExInstall`Logging\ConversationAggregationLog" "Conversation_Aggregation_Logs"
+            Add-DefaultLogCopyTaskAction "$Script:localExInstall`Logging\ConversationProcessingLog" "Conversation_Processing_Logs"
+        }
     }
 
     ############################################

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -70,6 +70,7 @@ AppSysLogs | Collects the Windows Event Application, System, and MSExchange Mana
 AppSysLogsToXml | Collects the Windows Event Application and System and saves them out to XML. The time range only is from the time the script run and the value set on `LogAge`. Default value: `$true`
 AutoDLogs | Enable to collect AutoDiscover Logs. Location: `V15\Logging\Autodiscover` and `V15\Logging\HttpProxy\Autodiscover`
 CollectFailoverMetrics | Enable to run the `CollectOverMetrics.ps1` script against the DAG. Only able to be run on an Exchange tools box or an Exchange Server.
+ConversationLogs | Enable to collect the Conversation Logs. Location: `V15\Logging\ConversationAggregationLog` and `V15\Logging\ConversationProcessingLog`
 DAGInformation | Enable to collect the DAG Information from all different DAGs that are in the list of servers.
 DailyPerformanceLogs | Enable to collect Daily Performance Logs. Default Location: `V15\Logging\Diagnostics\DailyPerformanceLogs`
 EASLogs | Enable to collect Exchange Active Sync Logging. Location: `V15\Logging\HttpProxy\Eas`


### PR DESCRIPTION
**Reason:**
Missing these logs to collect to assist with data review in a case.

**Fix:**
Collect the `ConversationProcessingLog` and `ConversationAggregationLog` logs in the default `Logging` directory. 

**Validation:**
Lab tested

