### PR TITLE
End Of Life now displayed for 2016/2019

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -105,6 +105,7 @@ function Invoke-AnalyzerExchangeInformation {
             Details                = $displayValue
             DisplayWriteType       = $displayWriteType
             DisplayCustomTabNumber = 2
+            DisplayTestingValue    = $true
             AddHtmlDetailRow       = $false
         }
         Add-AnalyzedResultInformation @params

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Extended Protection Enabled (Any VDir)" $false
             TestObjectMatch "Setting Overrides Detected" $false
             TestObjectMatch "Exchange Server Membership" "Passed"
-            $Script:ActiveGrouping.Count | Should -Be 16
+            $Script:ActiveGrouping.Count | Should -Be 17
         }
 
         It "Display Results - Organization Information" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -23,6 +23,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Name" $env:COMPUTERNAME
             TestObjectMatch "Version" "Exchange 2019 CU11"
             TestObjectMatch "Build Number" "15.02.0986.005"
+            TestObjectMatch "End Of Life" $true -WriteType "Yellow" # This is going to change to red once we get 178 out
             TestObjectMatch "Server Role" "Mailbox"
             TestObjectMatch "DAG Name" "Standalone Server"
             TestObjectMatch "AD Site" "Default-First-Site-Name"
@@ -34,7 +35,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Monitoring Overrides Detected" $false
             TestObjectMatch "Out of Date" $true -WriteType "Red"
             TestObjectMatch "Exchange Server Membership" "Passed"
-            $Script:ActiveGrouping.Count | Should -Be 16
+            $Script:ActiveGrouping.Count | Should -Be 17
         }
 
         It "Display Results - Organization Information" {


### PR DESCRIPTION
**Issue:**
This setting is now being triggered for 2016 and 2019. 

**Fix:**
Going to be a temp fix to prevent pipelines from failing. 

**Validation:**
Pester tested

