### PR TITLE
Remove Confirm-Administrator from Gen Logging

### DIFF
--- a/Security/src/ConfigureFipFsTextExtractionOverrides/ConfigureFipFsTextExtractionOverrides.ps1
+++ b/Security/src/ConfigureFipFsTextExtractionOverrides/ConfigureFipFsTextExtractionOverrides.ps1
@@ -88,8 +88,15 @@ begin {
     . $PSScriptRoot\ConfigurationAction\Invoke-TextExtractionOverride.ps1
     . $PSScriptRoot\..\Shared\Get-ProcessedServerList.ps1
     . $PSScriptRoot\..\..\..\Shared\Confirm-ExchangeManagementShell.ps1
+    . $PSScriptRoot\..\..\..\Shared\Confirm-Administrator.ps1
     . $PSScriptRoot\..\..\..\Shared\GenericScriptStartLogging.ps1
+    . $PSScriptRoot\..\..\..\Shared\Show-Disclaimer.ps1
     . $PSScriptRoot\..\..\..\Shared\ScriptUpdateFunctions\GenericScriptUpdate.ps1
+
+    if (-not(Confirm-Administrator)) {
+        Write-Host "The script needs to be executed in elevated mode. Start the PowerShell as an administrator." -ForegroundColor Yellow
+        exit
+    }
 
     $includeExchangeServerNames = New-Object System.Collections.Generic.List[string]
 } process {

--- a/Shared/GenericScriptStartLogging.ps1
+++ b/Shared/GenericScriptStartLogging.ps1
@@ -9,9 +9,7 @@
 . $PSScriptRoot\OutputOverrides\Write-Progress.ps1
 . $PSScriptRoot\OutputOverrides\Write-Verbose.ps1
 . $PSScriptRoot\OutputOverrides\Write-Warning.ps1
-. $PSScriptRoot\Confirm-Administrator.ps1
 . $PSScriptRoot\LoggerFunctions.ps1
-. $PSScriptRoot\Show-Disclaimer.ps1
 
 function Write-DebugLog ($Message) {
     $Script:DebugLogger = $Script:DebugLogger | Write-LoggerInstance $Message
@@ -40,9 +38,4 @@ if ($Script:DualLoggingEnabled) {
     SetWriteHostAction ${Function:Write-HostLogAndDebugLog}
 } else {
     SetWriteHostAction ${Write-DebugLog}
-}
-
-if (-not(Confirm-Administrator)) {
-    Write-Host "The script needs to be executed in elevated mode. Start the PowerShell as an administrator." -ForegroundColor Yellow
-    exit
 }


### PR DESCRIPTION
**Issue:**
It isn't required to have `Confirm-Administrator` in order to do logging, therefore it should be removed from `GenericScriptStartLogging.ps1`

**Fix:**

Resolved #2204

**Validation:**
Build tested

