### PR TITLE
Detection for recommended transport retry configuration

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -349,6 +349,26 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
         Add-AnalyzedResultInformation @params
     }
 
+    if ($null -ne $exchangeInformation.GetTransportService) {
+        if ($exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections -lt 40) {
+            $params = $baseParams + @{
+                Name             = "MaxPerDomainOutboundConnections"
+                Details          = "Value set to $($exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections), which is less than the recommended value of 40. `r`n`t`tMore details: https://aka.ms/HC-TransportRetryConfigCheck"
+                DisplayWriteType = "Yellow"
+            }
+            Add-AnalyzedResultInformation @params
+        }
+
+        if ($exchangeInformation.GetTransportService.MessageRetryInterval -gt [System.TimeSpan]::FromMinutes(5)) {
+            $params = $baseParams + @{
+                Name             = "MessageRetryInterval"
+                Details          = "Value set to $($exchangeInformation.GetTransportService.MessageRetryInterval), which is greater than the recommended value of 5 minutes. `r`n`t`tMore details: https://aka.ms/HC-TransportRetryConfigCheck"
+                DisplayWriteType = "Yellow"
+            }
+            Add-AnalyzedResultInformation @params
+        }
+    }
+
     $edgeKey = $exchangeInformation.ApplicationConfigFileStatus.Keys | Where-Object { $_ -like "*\EdgeTransport.exe.config" }
     $antiMalwareKey = $exchangeInformation.FileContentInformation.Keys | Where-Object { $_ -like "*\Monitoring\Config\AntiMalware.xml" }
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -154,6 +154,13 @@ function Get-ExchangeInformation {
                 Write-Verbose "Failed to run Test-ServiceHealth"
                 Invoke-CatchActions
             }
+
+            try {
+                $getTransportService = Get-TransportService -Identity $Server -ErrorAction Stop
+            } catch {
+                Write-Verbose "Failed to run Get-TransportService"
+                Invoke-CatchActions
+            }
         }
 
         Write-Verbose "Checking if FIP-FS is affected by the pattern issue"
@@ -225,6 +232,7 @@ function Get-ExchangeInformation {
             ExtendedProtectionConfig                 = $extendedProtectionConfig
             ExchangeConnectors                       = $exchangeConnectors
             ExchangeServicesNotRunning               = [array]$exchangeServicesNotRunning
+            GetTransportService                      = $getTransportService
             ApplicationPools                         = $applicationPools
             RegistryValues                           = $registryValues
             ServerMaintenance                        = $serverMaintenance

--- a/docs/Diagnostics/HealthChecker/TransportRetryConfigCheck.md
+++ b/docs/Diagnostics/HealthChecker/TransportRetryConfigCheck.md
@@ -1,0 +1,24 @@
+# Transport Retry Configuration Check
+
+This check verifies that the Transport Service retry configuration and max outbound connections per domain are set to the recommended values. When these values are not set to the recommended values, it can cause mail queueing or longer than expected delivery time when a transient failure occurs.
+
+This check validates the following settings in the `Get-TransportService` configuration:
+
+- `MaxPerDomainOutboundConnections` is set to 40 or greater
+- `MessageRetryInterval` is set to 5 minutes or less
+
+## MaxPerDomainOutboundConnections
+
+This setting controls the number of outbound connections that can be open for a single destination domain at one time. When this setting is too low and connections are exhausted, it will cause mail to queue up in the transport service and cause delays in mail delivery. This is most noticeable when mail is sent to a single destination such as in an Office 365 hybrid environment.
+
+## MessageRetryInterval
+
+This setting controls the interval at which the transport service will retry sending a message that has failed to send due to a transient error. When this setting is too high, it can cause mail to queue up unnecessarily. Retrying sooner in most cases will allow the message to be delivered in a timely manner.
+
+## Included in HTML Report?
+
+Yes
+
+## Additional resources
+
+[Email messages are stuck in Exchange Server queues for several minutes](https://aka.ms/TransportRetryConfig)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - ADSiteCount: Diagnostics/HealthChecker/ADSiteCount.md
       - ExchangeComputerMembership: Diagnostics/HealthChecker/ExchangeComputerMembership.md
       - UnifiedContentCleanup: Diagnostics/HealthChecker/UnifiedContentCleanup.md
+      - TransportRetryConfigCheck: Diagnostics/HealthChecker/TransportRetryConfigCheck.md
     - ManagedAvailabilityTroubleshooter: Diagnostics/ManagedAvailabilityTroubleshooter.md
     - Test-ExchAVExclusions: Diagnostics/Test-ExchAVExclusions.md
   - Hybrid:


### PR DESCRIPTION
**Issue:**
PR introduces detection for our recommended retry configuration for Transport service.

**Reason:**
The default retry interval is too long and can cause longer than expected mail delivery times when a transient error occurs at the SMTP layer. 

Our recommended retry configuration is published here: [https://aka.ms/TransportRetryConfig](https://aka.ms/TransportRetryConfig)

**Fix:**
Checks to make sure the recommended values are set correctly for

- MaxPerDomainOutboundConnections
- MessageRetryInterval

Resolved #2207 

**Validation:**
.\build.ps1
