### PR TITLE
[MDO] Fix empty subject by sorting on the first to last  message and get first one (oldest should be the original)

### DIFF
--- a/M365/MDO/ResendFailedMail.ps1
+++ b/M365/MDO/ResendFailedMail.ps1
@@ -231,7 +231,7 @@ if ($failedMessages.count -ge 1000) {
 }
 
 if (-not $IncludeDuplicates) {
-    [array]$failedMessages = $failedMessages | Sort-Object MessageId -Unique
+    [array]$failedMessages = $failedMessages | Group-Object -Property MessageId | ForEach-Object { $_.Group | Sort-Object -Property Received | Select-Object -First 1 }
 }
 
 $verifiedAcceptedSenderMessages = New-Object System.Collections.Generic.List[object]


### PR DESCRIPTION
**Issue:**
If you have more that one copy in message trace not always shows subject

**Reason:**
With the current filter we do not take always the original one, the oldest one.

**Fix:**
Fix empty subject by sorting on the first to last  message and get first one (oldest should be the original and has the original subject)

**Validation:**
Check it in lab

