### PR TITLE
Increase count due to expired cert today - extra display line

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -145,7 +145,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "AES256-CBC Protected Content Support" "Not Supported Build" -WriteType "Red"
             TestObjectMatch "SerializedDataSigning Enabled" "Unsupported Version" -WriteType "Red"
 
-            $Script:ActiveGrouping.Count | Should -Be 84
+            $Script:ActiveGrouping.Count | Should -Be 85
         }
 
         It "Display Results - Security Vulnerability" {


### PR DESCRIPTION
**Issue:**
Pester testing failing due to additional line showing up caused by expired cert.

**Reason:**
Need pester testing to work to allow other PRs to work.

**Fix:**
Increase the display count.

**Validation:**
Pester tested, verified the cert expired today.

