### PR TITLE
Addressing Computer Membership Unknown Issues with Remote Computer

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -305,16 +305,24 @@ function Invoke-AnalyzerExchangeInformation {
                 Where-Object { $_.WellKnownName -in @("Exchange Trusted Subsystem", "Exchange Servers") }
             $displayMissingGroups = New-Object System.Collections.Generic.List[string]
 
-            foreach ($localGroup in $localGroupList) {
-                if (($null -eq ($exchangeInformation.ComputerMembership.LocalGroupMember.SID | Where-Object { $_.ToString() -eq $localGroup.SID } ))) {
-                    $displayMissingGroups.Add("$($localGroup.WellKnownName) - Local System Membership")
+            if ($null -ne $exchangeInformation.ComputerMembership.LocalGroupMember) {
+                foreach ($localGroup in $localGroupList) {
+                    if (($null -eq ($exchangeInformation.ComputerMembership.LocalGroupMember.SID | Where-Object { $_.ToString() -eq $localGroup.SID } ))) {
+                        $displayMissingGroups.Add("$($localGroup.WellKnownName) - Local System Membership")
+                    }
                 }
+            } else {
+                $displayMissingGroups.Add("Unable to determine Local System Membership as the results were blank.")
             }
 
-            foreach ($adGroup in $adGroupList) {
-                if (($null -eq ($exchangeInformation.ComputerMembership.ADGroupMembership.SID | Where-Object { $_.ToString() -eq $adGroup.SID }))) {
-                    $displayMissingGroups.Add("$($adGroup.WellKnownName) - AD Group Membership")
+            if ($null -ne $exchangeInformation.ComputerMembership.ADGroupMembership) {
+                foreach ($adGroup in $adGroupList) {
+                    if (($null -eq ($exchangeInformation.ComputerMembership.ADGroupMembership.SID | Where-Object { $_.ToString() -eq $adGroup.SID }))) {
+                        $displayMissingGroups.Add("$($adGroup.WellKnownName) - AD Group Membership")
+                    }
                 }
+            } else {
+                $displayMissingGroups.Add("Unable to determine AD Group Membership as the results were blank.")
             }
 
             if ($displayMissingGroups.Count -ge 1) {


### PR DESCRIPTION
**Issue:**
Getting a lot of results for `Unknown - Wasn't able to get the Computer Membership information`. This appears to be due to remote execution of the AD Module cmdlets. Trying a different approach to see if they work or not. 

**Reason:**
AD Module cmdlets don't work inside Invoke-Command

**Fix:**
Moved the `Get-ADPrincipalGroupMembership` and `Get-ADComputer` outside of the `Invoke-ScriptBlockHandler` to see if that works. This should resolve the issues but going to leave them open to verify. 

#2128 
#2221 
#2110

**Validation:**
Lab tested
