### PR TITLE
Allow exceptions to be displayed for ScriptUpdateOnly param

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -258,11 +258,23 @@ begin {
 
         if ($ScriptUpdateOnly) {
             Invoke-SetOutputInstanceLocation -FileName "HealthChecker-ScriptUpdateOnly"
+            $currentErrors = $Error.Count
             switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/HC-VersionsUrl" -Confirm:$false) {
                 ($true) { Write-Green("Script was successfully updated.") }
                 ($false) { Write-Yellow("No update of the script performed.") }
                 default { Write-Red("Unable to perform ScriptUpdateOnly operation.") }
             }
+
+            if ($currentErrors -ne $Error.Count) {
+                Write-Host ""
+                Write-Warning "Failed to get latest version of script details. Failing with this inner exception:"
+                Write-Host ""
+                $Error[$Error.Count - $currentErrors - 1] | Out-String | Write-Host -ForegroundColor Red
+                Write-Host ""
+                Write-Host "Address the above exception in order to get the script to auto update."
+            }
+
+            Invoke-ErrorCatchActionLoopFromIndex $currentErrors
             return
         }
 


### PR DESCRIPTION
**Issue:**
More information provided in #2230 

**Reason:**
Correctly log the exceptions to avoid emailing in regarding an exception that is handled

**Fix:**
Count the current errors prior to trying to get the updated version of the script with the `Invoke-ErrorCatchActionLoopFromIndex`. 

Resolved #2230 

**Validation:**
Lab tested

