### PR TITLE
Fix execution without parameters and servername

### DIFF
--- a/Admin/Test-AMSI.ps1
+++ b/Admin/Test-AMSI.ps1
@@ -116,11 +116,11 @@ param(
     [Parameter(ParameterSetName = 'RestartIISAll', Mandatory = $true)]
     [switch]$RestartIIS,
     [Alias("ExchangeServerFQDN")]
-    [Parameter(ParameterSetName = 'TestAMSI', Mandatory = $false, ValueFromPipeline = $true)]
-    [Parameter(ParameterSetName = 'EnableAMSI', Mandatory = $false, ValueFromPipeline = $true)]
-    [Parameter(ParameterSetName = 'DisableAMSI', Mandatory = $false, ValueFromPipeline = $true)]
-    [Parameter(ParameterSetName = 'CheckAMSIConfig', Mandatory = $false, ValueFromPipeline = $true)]
-    [Parameter(ParameterSetName = 'RestartIIS', Mandatory = $false, ValueFromPipeline = $true)]
+    [Parameter(Position = 0, ParameterSetName = 'TestAMSI', Mandatory = $false, ValueFromPipeline = $true)]
+    [Parameter(Position = 0, ParameterSetName = 'EnableAMSI', Mandatory = $false, ValueFromPipeline = $true)]
+    [Parameter(Position = 0, ParameterSetName = 'DisableAMSI', Mandatory = $false, ValueFromPipeline = $true)]
+    [Parameter(Position = 0, ParameterSetName = 'CheckAMSIConfig', Mandatory = $false, ValueFromPipeline = $true)]
+    [Parameter(Position = 0, ParameterSetName = 'RestartIIS', Mandatory = $false, ValueFromPipeline = $true)]
     [string[]]$ServerList = $null,
     [Parameter(ParameterSetName = 'TestAMSIAll', Mandatory = $true)]
     [Parameter(ParameterSetName = 'CheckAMSIConfigAll', Mandatory = $true)]
@@ -153,6 +153,10 @@ param(
 )
 
 begin {
+
+    if (-not $ServerList -and $args.Count -gt 0) {
+        $ServerList = @($args[0])
+    }
 
     . $PSScriptRoot\..\Shared\Confirm-Administrator.ps1
     . $PSScriptRoot\..\Shared\Confirm-ExchangeShell.ps1


### PR DESCRIPTION
**Issue:**
When you execute the scritp without the parameter -ServerList  and you include a server the script throw an error: 

![image](https://github.com/user-attachments/assets/aae527f2-897e-449b-a1fb-2734af6ed79e)

**Reason:**
It is expected as it is associate to that parameter but if we use servername as parameter  0 it simplify the execution

**Fix:**
Change the script to use servername as the first parameter if no parameter is explicitly use. 

**Validation:**
Test in lab:
![image](https://github.com/user-attachments/assets/53974754-00f8-4182-89a6-79b69375ffa3)


