### PR TITLE
Improve hybrid transport certificate testing

### DIFF
--- a/.build/cspell-words.txt
+++ b/.build/cspell-words.txt
@@ -115,6 +115,7 @@ nupkg
 odata
 onmicrosoft
 onprem
+onmschina
 OutlookiOS
 Perflib
 perfmon

--- a/.build/cspell-words.txt
+++ b/.build/cspell-words.txt
@@ -115,7 +115,6 @@ nupkg
 odata
 onmicrosoft
 onprem
-onmschina
 OutlookiOS
 Perflib
 perfmon

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -299,8 +299,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
     $sendConnectors = $exchangeInformation.ExchangeConnectors | Where-Object { $_.ConnectorType -eq "Send" }
 
     foreach ($sendConnector in $sendConnectors) {
-        $smartHostMatch = ($sendConnector.SmartHosts -like "*.mail.protection.outlook.com").Count -gt 0
-        $dnsMatch = $sendConnector.SmartHosts -eq 0 -and ($sendConnector.AddressSpaces.Address -like "*.mail.onmicrosoft.com").Count -gt 0
+        $smartHostMatch = ($sendConnector.SmartHosts -match "^[^.]+\.mail\.protection\.(outlook\.com|partner\.outlook\.cn|office365\.us)$").Count -gt 0
+        $dnsMatch = $sendConnector.SmartHosts -eq 0 -and ($sendConnector.AddressSpaces.Address -match "^[^.]+\.mail\.(onmicrosoft\.com|partner\.onmschina\.cn|onmicrosoft\.us)$").Count -gt 0
 
         if ($dnsMatch -or $smartHostMatch) {
             $exoConnector.Add($sendConnector)
@@ -315,12 +315,17 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
     $showMoreInfo = $false
 
     foreach ($connector in $exoConnector) {
-        # Misconfigured connector is if TLSCertificateName is not set or CloudServicesMailEnabled not set to true
-        if ($connector.CloudEnabled -eq $false -or
-            $connector.CertificateDetails.TlsCertificateNameStatus -eq "TlsCertificateNameEmpty") {
+
+        # If CloudServiceMailEnabled is not set to true it means the connector is misconfigured
+        # If no Fqdn is set on the connector, the Fqdn of the computer is used to perform best matching certificate selection
+        # There is a risk that the Fqdn is an internal one (e.g., server.contoso.local) which will lead to a broken hybrid mail flow in case that TlsCertificateName is not set
+        if (($connector.CloudEnabled -eq $false) -or
+            ($null -eq $connector.Fqdn -and
+            $connector.CertificateDetails.TlsCertificateNameStatus -eq "TlsCertificateNameEmpty")) {
             $params = $baseParams + @{
                 Name                   = "Send Connector - $($connector.Identity.ToString())"
-                Details                = "Misconfigured to send authenticated internal mail to M365." +
+                Details                = "Misconfigured to send authenticated internal mail to M365" +
+                "`r`n`t`t`tFqdn set: $($null -ne $connector.Fqdn)" +
                 "`r`n`t`t`tCloudServicesMailEnabled: $($connector.CloudEnabled)" +
                 "`r`n`t`t`tTLSCertificateName set: $($connector.CertificateDetails.TlsCertificateNameStatus -ne "TlsCertificateNameEmpty")"
                 DisplayCustomTabNumber = 2
@@ -342,11 +347,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             $showMoreInfo = $true
         }
 
-        if ($connector.TlsDomain -ne "mail.protection.outlook.com" -and
+        if ($connector.TlsDomain -notmatch "^mail\.protection\.(outlook\.com|partner\.outlook\.cn|office365\.us)$" -and
             $connector.TlsAuthLevel -eq "DomainValidation") {
             $params = $baseParams + @{
                 Name                   = "Send Connector - $($connector.Identity.ToString())"
-                Details                = "TLSDomain  not set to mail.protection.outlook.com"
+                Details                = "TLSDomain  not set to service domain (e.g.,mail.protection.outlook.com)"
                 DisplayCustomTabNumber = 2
                 DisplayWriteType       = "Yellow"
             }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -24,6 +24,10 @@ function Invoke-AnalyzerHybridInformation {
     $exchangeInformation = $HealthServerObject.ExchangeInformation
     $getHybridConfiguration = $HealthServerObject.OrganizationInformation.GetHybridConfiguration
 
+    # Check if the server is configured as sending or receiving transport server - if it is, the certificate used for hybrid mail flow must exist on the machine
+    $certificateShouldExistOnServer = $getHybridConfiguration.SendingTransportServers.DistinguishedName -contains $exchangeInformation.GetExchangeServer.DistinguishedName -or
+    $getHybridConfiguration.ReceivingTransportServers.DistinguishedName -contains $exchangeInformation.GetExchangeServer.DistinguishedName
+
     if ($exchangeInformation.BuildInformation.VersionInformation.BuildVersion -ge "15.0.0.0" -and
         $null -ne $getHybridConfiguration) {
 
@@ -354,10 +358,6 @@ function Invoke-AnalyzerHybridInformation {
                         }
                     } else {
                         $cloudConnectorTlsCertificateName = "Not set"
-
-                        # Check if the server is configured as sending or receiving transport server - if it is, the certificate used for hybrid mail flow must exist on the machine
-                        $certificateShouldExistOnServer = $getHybridConfiguration.SendingTransportServers.DistinguishedName -contains $exchangeInformation.GetExchangeServer.DistinguishedName -or
-                        $getHybridConfiguration.ReceivingTransportServers.DistinguishedName -contains $exchangeInformation.GetExchangeServer.DistinguishedName
 
                         Write-Verbose "Server is configured for hybrid mailflow and the transport certificate should exist on this server? $certificateShouldExistOnServer"
 

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -359,7 +359,7 @@ function Invoke-AnalyzerHybridInformation {
                     } else {
                         $cloudConnectorTlsCertificateName = "Not set"
 
-                        Write-Verbose "Server is configured for hybrid mailflow and the transport certificate should exist on this server? $certificateShouldExistOnServer"
+                        Write-Verbose "Server is configured for hybrid mail flow and the transport certificate should exist on this server? $certificateShouldExistOnServer"
 
                         if ($null -ne $connector.CertificateDetails.TlsCertificateName) {
                             $cloudConnectorTlsCertificateName = $connector.CertificateDetails.TlsCertificateName

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeConnectors.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeConnectors.ps1
@@ -30,6 +30,7 @@ function Get-ExchangeConnectors {
             $exchangeFactoryConnectorReturnObject = [PSCustomObject]@{
                 Identity           = $ConnectorObject.Identity
                 Name               = $ConnectorObject.Name
+                Fqdn               = $ConnectorObject.Fqdn
                 Enabled            = $ConnectorObject.Enabled
                 CloudEnabled       = $false
                 ConnectorType      = $null


### PR DESCRIPTION
**Issue:**
The transport certificate testing wasn't working accurately. HealthChecker, for example was looking for the hybrid transport certificate even if the computer was not configured as `SendingTransportServers` or `ReceivingTransportServers`. We also showed a warning if `TLSCertificateName` wasn't set on a send connector. This is a valid use-case as Exchange server allows implicit or explicit configuration. With an implicit configuration, Exchange Server looks for the best matching certificate is selected based on the Fqdn set on the connector.

Resolve #1932 
Resolve #1931 
Resolve #2035 

**Fix:**
Excluded the server from some of the checks related to TLS certificate if it doesn't exist in the `SendingTransportServers` or `ReceivingTransportServers` collection. Improved the TLSCertificateCheck to only show a red error if the `TLSCertificateName` is not set and the `Fqdn` is not set on the connector (computers Fqdn is used in this scenario and this could be an internal one).

**Validation:**
Lab

