### PR TITLE
Computer Membership Fix update

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -315,7 +315,9 @@ function Invoke-AnalyzerExchangeInformation {
                 $displayMissingGroups.Add("Unable to determine Local System Membership as the results were blank.")
             }
 
-            if ($null -ne $exchangeInformation.ComputerMembership.ADGroupMembership) {
+            if ($exchangeInformation.ComputerMembership.ADGroupMembership -eq "NoAdModule") {
+                $displayMissingGroups.Add("Missing Active Directory Module. Run 'Install-WindowsFeature RSat-AD-PowerShell'")
+            } elseif ($null -ne $exchangeInformation.ComputerMembership.ADGroupMembership) {
                 foreach ($adGroup in $adGroupList) {
                     if (($null -eq ($exchangeInformation.ComputerMembership.ADGroupMembership.SID | Where-Object { $_.ToString() -eq $adGroup.SID }))) {
                         $displayMissingGroups.Add("$($adGroup.WellKnownName) - AD Group Membership")

--- a/docs/Diagnostics/HealthChecker/ExchangeComputerMembership.md
+++ b/docs/Diagnostics/HealthChecker/ExchangeComputerMembership.md
@@ -8,6 +8,7 @@ This check is done by using the ADModule with using the cmdlets `Get-LocalGroupM
 
 If an issue is detected, the group will display with where the problem is located. Either `Local System Membership` if the group isn't part of the local system account or `AD Group Membership` if the computer object isn't a member of the group provided.
 
+If the script is run from a computer that doesn't have Active Directory PowerShell module installed on it, `Get-ADComputer` will fail with the exception `CommandNotFoundException`. The output will then display that you should run `Install-WindowsFeature RSat-AD-PowerShell` on the computer to get the module installed. This is how you get this feature to then start reporting correctly.
 
 **Included in HTML Report?**
 


### PR DESCRIPTION
**Issue:**
After the refactoring of Computer Memberships in PR #2229, we got more information about what is failing in customer's environment. 
 
**Reason:**
Some computers didn't have the Active Directory PowerShell Module installed on the computer running the Health Checker, making this known and that it should be installed. The second is issue with `Get-ADPrincipalGroupMembership` stating it can't be run because the user isn't authenticated. Created some fallback logic to try to use `Get-ADObject` instead.

**Fix:**
Callout that we don't have Active Directory Module installed and that we should have it installed in order to properly check this feature.

Have fallback logic to run `Get-ADObject` instead for the `MemberOf` for the computer. 

Resolved #2242 
Resolved #2239

**Validation:**
Lab tested/Pester tested/Pending customer confirmation
