### PR TITLE
Address math rounding issue for dynamic memory detection

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -252,6 +252,7 @@ function Invoke-AnalyzerHardwareInformation {
     }
 
     $totalPhysicalMemory = [System.Math]::Round($hardwareInformation.TotalMemory / 1024 / 1024 / 1024)
+    $totalPhysicalMemoryNotRounded = $hardwareInformation.TotalMemory / 1GB
     $displayWriteType = "Yellow"
     $displayDetails = [string]::Empty
 
@@ -310,7 +311,8 @@ function Invoke-AnalyzerHardwareInformation {
             if ($null -eq $counter) {
                 $params.Details = "Unknown - Required Counter Not Loaded"
                 $params.DisplayWriteType = "Yellow"
-            } elseif (($counter.CookedValue / 1024) -ne $totalPhysicalMemory) {
+            } elseif (($counter.CookedValue / 1024) -ne $totalPhysicalMemory -and
+            ($counter.CookedValue / 1024) -ne $totalPhysicalMemoryNotRounded) {
                 $params.Details = "$true $($counter.CookedValue / 1024)GB is the allowed dynamic memory of the server. Not supported to have dynamic memory configured."
                 $params.DisplayWriteType = "Red"
             }


### PR DESCRIPTION
**Issue:**
When a guest machine is given an amount of memory that isn't evenly divided by 1GB, we fail to properly detect if dynamic memory is being used because of rounding of the total memory. 

**Reason:**
Rounding of the total memory was being used to make it look more appealing in the display. 

**Fix:**
Compare against the rounded number as well as the unrounded number. If both don't match, then we likely have dynamic memory in place. 

Resolved #2203 

**Validation:**
Lab tested

