### PR TITLE
Missing counter added to be displayed when not found

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -309,7 +309,7 @@ function Invoke-AnalyzerHardwareInformation {
             $counter = $osInformation.PerformanceCounters | Where-Object { $_.OriginalCounterLookup -eq $counterName }
 
             if ($null -eq $counter) {
-                $params.Details = "Unknown - Required Counter Not Loaded"
+                $params.Details = "Unknown - Required Counter Not Loaded. Missing Counter: $($counterName)"
                 $params.DisplayWriteType = "Yellow"
             } elseif (($counter.CookedValue / 1024) -ne $totalPhysicalMemory -and
             ($counter.CookedValue / 1024) -ne $totalPhysicalMemoryNotRounded) {


### PR DESCRIPTION
**Issue:**
Resolved #2256

**Reason:**
For scenarios where a counter is not found with Dynamic Memory, it'll display which specific counter it was looking for that it did not find.

**Fix:**
Displaying counter it is looking for.

**Validation:**

