### PR TITLE
HC-EXOconnector doesn't cover all scenarios for routing mail from Onprem to EXO.

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -372,7 +372,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 "`r`n`t`t`tCloudServicesMailEnabled: $($connector.CloudEnabled)" +
                 "`r`n`t`t`tTLSCertificateName set: $($connector.CertificateDetails.TlsCertificateNameStatus -ne "TlsCertificateNameEmpty")"
                 DisplayCustomTabNumber = 2
-                DisplayWriteType       = "Red"
+                DisplayWriteType       = "Yellow"
             }
             Add-AnalyzedResultInformation @params
             $showMoreInfo = $true

--- a/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
+++ b/docs/Diagnostics/HealthChecker/ExoConnectorCheck.md
@@ -1,6 +1,6 @@
 # Exchange Online Connector Check
 
-This is a simple check that can be performed from the Exchange On Prem side to quickly determine if the EXO connector is misconfigured. This does not completely determine if the connector is misconfigured, as Health Checker script is not designed to connect to Exchange Online to properly determine if everything is correctly configured for the way you want your mail flow to work.
+This is a simple check that can be performed from the Exchange On Prem side to quickly determine if the EXO connector is misconfigured. This does not completely determine if the connector is misconfigured, as Health Checker script is not designed to connect to Exchange Online to properly determine if everything is correctly configured for the way you want your mail flow to work. It does not take into account if you are routing your OnPrem mail through EXO to External domains and may flag the connector as not properly configured because `CloudServicesMailEnabled` is not set to `$true`. It is only here to check for Internal mail between OnPrem and your tenant EXO mailboxes.
 
 A Send Connector is determined to be destined for Exchange Online if one of the following is true:
 


### PR DESCRIPTION
HC-EXOconnector doesn't cover all scenarios for routing mail from Onprem to EXO.

**Issue:**
Display for HCEXOConnecoter can't cover all scenarios for routing mail from Onprem to EXO.

**Reason:**
Reduce confusion.

**Fix:**
Updated output to be Yellow instead of Red and documentation in https://aka.ms/hc-exoconnectorissue

**Validation:**

