### PR TITLE
Allow trailing back-slashes in paths and use proper join-path/io class to handle paths 

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -27,9 +27,7 @@
 	This optional parameter allows the target Exchange server to be specified.  If it is not the
 	local server is assumed.
 .PARAMETER OutputFilePath
-	This optional parameter allows an output directory to be specified.  If it is not the local
-	directory is assumed.  This parameter must not end in a \.  To specify the folder "logs" on
-	the root of the E: drive you would use "-OutputFilePath E:\logs", not "-OutputFilePath E:\logs\".
+	This optional parameter allows an output directory to be specified. Default location is the current directory.
 .PARAMETER MailboxReport
 	This optional parameter gives a report of the number of active and passive databases and
 	mailboxes on the server.
@@ -93,9 +91,7 @@ param(
     [string[]]$Server = ($env:COMPUTERNAME),
 
     [Parameter(Mandatory = $false, HelpMessage = "Provide the location of where the output files should go.")]
-    [ValidateScript( {
-            -not $_.ToString().EndsWith('\') -and (Test-Path $_)
-        })]
+    [ValidateScript( { Test-Path $_ })]
     [string]$OutputFilePath = ".",
 
     [Parameter(Mandatory = $true, ParameterSetName = "MailboxReport", HelpMessage = "Enable the MailboxReport feature data collection against the server.")]
@@ -115,9 +111,7 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = "HTMLReport", HelpMessage = "Provide the directory where the XML files are located at from previous runs of the Health Checker to Import the data from.")]
     [Parameter(Mandatory = $false, ParameterSetName = "AnalyzeDataOnly", HelpMessage = "Provide the directory where the XML files are located at from previous runs of the Health Checker to Import the data from.")]
     [Parameter(Mandatory = $false, ParameterSetName = "VulnerabilityReport", HelpMessage = "Provide the directory where the XML files are located at from previous runs of the Health Checker to Import the data from.")]
-    [ValidateScript( {
-            -not $_.ToString().EndsWith('\')
-        })]
+    [ValidateScript( { Test-Path $_ })]
     [string]$XMLDirectoryPath = ".",
 
     [Parameter(Mandatory = $true, ParameterSetName = "HTMLReport", HelpMessage = "Enable the HTMLReport feature to run against the XML files from previous runs of the Health Checker script.")]

--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -39,7 +39,7 @@ function Get-ErrorsThatOccurred {
             try {
                 $Error |
                     ConvertTo-Json |
-                    Out-File ("$Script:OutputFilePath\HealthChecker-Errors.json")
+                    Out-File (Join-Path -Path $Script:OutputFilePath -Childpath 'HealthChecker-Errors.json')
             } catch {
                 Write-Red("Failed to export the HealthChecker-Errors.json")
                 Invoke-CatchActions

--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -39,7 +39,7 @@ function Get-ErrorsThatOccurred {
             try {
                 $Error |
                     ConvertTo-Json |
-                    Out-File (Join-Path -Path $Script:OutputFilePath -Childpath 'HealthChecker-Errors.json')
+                    Out-File (Join-Path -Path $Script:OutputFilePath -ChildPath 'HealthChecker-Errors.json')
             } catch {
                 Write-Red("Failed to export the HealthChecker-Errors.json")
                 Invoke-CatchActions

--- a/Diagnostics/HealthChecker/Helpers/Invoke-SetOutputInstanceLocation.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Invoke-SetOutputInstanceLocation.ps1
@@ -18,6 +18,6 @@ function Invoke-SetOutputInstanceLocation {
         $endName = "-{0}{1}" -f $Server, $endName
     }
 
-    $Script:OutputFullPath = "{0}\{1}{2}" -f $Script:OutputFilePath, $FileName, $endName
-    $Script:OutXmlFullPath = $Script:OutputFullPath.Replace(".txt", ".xml")
+    $Script:OutputFullPath = Join-Path -Path $Script:OutputFilePath -ChildPath ('{0}{1}' -f $FileName, $endName)
+    $Script:OutXmlFullPath = [System.IO.Path]::ChangeExtension($Script:OutputFullPath, 'xml')
 }


### PR DESCRIPTION
**Issue:**
For $XMLDirectoryPath, you check if the path does not end in a back-slash. For $OutputFilePath, you do the same as well as test the path. The description mentions the trailing "requirement" of one, but not the other - inconsistent. Test-Path for both suffices. 

**Reason:**
Accepting trailing slashes is convenient, as tab-completion adds trailing back-slash automatically. Also removes inconsistency.

**Fix:**
Use Test-Path for both in parameter validation. Used Join-Path etc to properly construct paths, and [System.IO.Path]::changeExtension instead of string operations.

**Validation:**
Tested against local and remote servers, using local and UNC paths

