### PR TITLE
Health Checker Address End Of Life to include link and remove Installed on For SUs

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -84,6 +84,7 @@ function Invoke-AnalyzerExchangeInformation {
     }
 
     $extendedSupportDate = $exchangeInformation.BuildInformation.VersionInformation.ExtendedSupportDate
+    $exchangeFriendlyName = $exchangeInformation.BuildInformation.VersionInformation.FriendlyName
     if ($extendedSupportDate -le ([DateTime]::Now.AddYears(1))) {
         $displayWriteType = "Yellow"
 
@@ -91,8 +92,12 @@ function Invoke-AnalyzerExchangeInformation {
             $displayWriteType = "Red"
         }
 
-        $displayValue = "$($exchangeInformation.BuildInformation.VersionInformation.ExtendedSupportDate.ToString("MMM dd, yyyy",
+        if (($exchangeFriendlyName -match '2010|2013|2016|2019')) {
+            $displayValue = "$($exchangeInformation.BuildInformation.VersionInformation.ExtendedSupportDate.ToString("MMM dd, yyyy",
             [System.Globalization.CultureInfo]::CreateSpecificCulture("en-US"))) - Please note the End Of Life date. Reference our blog for more information: https://aka.ms/HC-UpgradeToSE"
+        } else {
+            $displayValue = "Please note the End Of Life date and plan your migration accordingly."
+        }
 
         if ($extendedSupportDate -le ([DateTime]::Now)) {
             $displayValue = "Error: Your Exchange server reached end of life on " +

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -92,7 +92,7 @@ function Invoke-AnalyzerExchangeInformation {
         }
 
         $displayValue = "$($exchangeInformation.BuildInformation.VersionInformation.ExtendedSupportDate.ToString("MMM dd, yyyy",
-            [System.Globalization.CultureInfo]::CreateSpecificCulture("en-US"))) - Please note of the End Of Life date and plan to migrate soon."
+            [System.Globalization.CultureInfo]::CreateSpecificCulture("en-US"))) - Please note the End Of Life date. Reference our blog for more information: https://aka.ms/HC-UpgradeToSE"
 
         if ($extendedSupportDate -le ([DateTime]::Now)) {
             $displayValue = "Error: Your Exchange server reached end of life on " +
@@ -146,7 +146,7 @@ function Invoke-AnalyzerExchangeInformation {
         foreach ($kbInfo in $exchangeInformation.BuildInformation.KBsInstalledInfo) {
             $kbName = $kbInfo.PackageName
             $params = $baseParams + @{
-                Details                = "$kbName - Installed on $($kbInfo.InstalledDate)"
+                Details                = "$kbName"
                 DisplayCustomTabNumber = 2
                 TestingName            = "Exchange IU"
             }


### PR DESCRIPTION
2 issues addressed

**Issue 1:**
Wording of the 'End Of Life' output

**Reason:**
The 'migrate soon' wording was confusing to some end users since we do not have a supported version to migrate to yet. Also, created and added an aka.ms link to the "Upgrading your organization from current versions to Exchange Server SE" blog post for reference.

**Fix:**
Change Line 95 From
   "Please note of the End Of Life date and plan to migrate soon."
To
   "Please note the End Of Life date. Reference our blog for more information: https://aka.ms/HC-UpgradeToSE"

**Issue 2:**
Incorrect IU/Hotfix 'Installed Date' value

**Reason:**
Info is redundant as we already have "Latest Install Time" noted right above in the output. Also, the dates for each IU/Hotfix were being listed incorrectly with the same value as "Latest Install Time", regardless of actual install date.

**Fix:**
Changed Line 149 From
   "$kbName - Installed on $($kbInfo.InstalledDate)"
To
   "$kbName"

**Validation:**
Tested in lab

