### PR TITLE
Add --dot to cspell check

### DIFF
--- a/.build/Build.ps1
+++ b/.build/Build.ps1
@@ -53,7 +53,7 @@ $allScriptFiles = Get-ChildItem -Path $repoRoot -Directory |
     ForEach-Object { $_.FullName }
 
 <#
-    Build the table of depedencies, and a separate table of commit times.
+    Build the table of dependencies, and a separate table of commit times.
 #>
 
 $dependencyHashtable = Get-ScriptDependencyHashtable -FileNames $allScriptFiles

--- a/.build/BuildFunctions/Get-DotSourcedScriptName.ps1
+++ b/.build/BuildFunctions/Get-DotSourcedScriptName.ps1
@@ -17,8 +17,8 @@ function Get-DotSourcedScriptName {
     process {
         $m = $Line | Select-String "\. (?:\.|\`$PSScriptRoot)\\(.*).ps1"
         if ($null -ne $m) {
-            $dotloadedScriptPath = $m.Matches[0].Groups[1].Value + ".ps1"
-            $dotloadedScriptPath
+            $dotLoadedScriptPath = $m.Matches[0].Groups[1].Value + ".ps1"
+            $dotLoadedScriptPath
         }
     }
 }

--- a/.build/BuildFunctions/Get-ScriptDependencyHashtable.ps1
+++ b/.build/BuildFunctions/Get-ScriptDependencyHashtable.ps1
@@ -24,8 +24,8 @@ function Get-ScriptDependencyHashtable {
 
             if ($currentFile.EndsWith(".ps1")) {
                 Select-String "\. (?:\.|\`$PSScriptRoot)\\(.*).ps1" $currentFile | ForEach-Object {
-                    $dotloadedScriptPath = $_.Matches[0].Groups[1].Value + ".ps1"
-                    $dotSourcedFile = (Get-Item (Join-Path $currentFolder $dotloadedScriptPath)).FullName
+                    $dotLoadedScriptPath = $_.Matches[0].Groups[1].Value + ".ps1"
+                    $dotSourcedFile = (Get-Item (Join-Path $currentFolder $dotLoadedScriptPath)).FullName
                     $deps[$currentFile] += $dotSourcedFile
                     if ($null -eq $deps[$dotSourcedFile]) {
                         $stack.Push($dotSourcedFile)

--- a/.build/CodeFormatter.ps1
+++ b/.build/CodeFormatter.ps1
@@ -105,7 +105,7 @@ foreach ($fileInfo in $filesToCheck) {
             }
             break
         } catch {
-            Write-Warning "Invoke-ScriptAnalyer failed on $($fileInfo.FullName). Error:"
+            Write-Warning "Invoke-ScriptAnalyzer failed on $($fileInfo.FullName). Error:"
             $_.Exception | Format-List | Out-Host
             Write-Warning "Retrying in 5 seconds."
             Start-Sleep -Seconds 5

--- a/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
+++ b/.build/CodeFormatterChecks/CheckScriptFileHasBOM.ps1
@@ -19,9 +19,9 @@ function CheckScriptFileHasBOM {
 
         https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding
 
-        "If you need to use non-Ascii characters in your scripts, save them as UTF-8 with BOM.
+        "If you need to use non-ASCII characters in your scripts, save them as UTF-8 with BOM.
         Without the BOM, Windows PowerShell misinterprets your script as being encoded in the
-        legacy "ANSI" codepage. Conversely, files that do have the UTF-8 BOM can be problematic
+        legacy "ANSI" CodePage. Conversely, files that do have the UTF-8 BOM can be problematic
         on Unix-like platforms."
 
         Since these scripts are purely for Exchange and Exchange Online, we expect they will usually

--- a/.build/Docs.ps1
+++ b/.build/Docs.ps1
@@ -3,6 +3,7 @@
 
 $repoRoot = Get-Item "$PSScriptRoot\.."
 $docsDir = "$repoRoot\docs"
+#cspell:words mkdocs
 $markDownFiles = Get-Content "$repoRoot\mkdocs.yml" | Select-String "(\S+\.md)" | ForEach-Object {
     $_.Matches.Groups[1].Value
 }

--- a/.build/HelpFunctions/Get-CommitFilesOnBranch.ps1
+++ b/.build/HelpFunctions/Get-CommitFilesOnBranch.ps1
@@ -14,8 +14,8 @@ function Get-CommitFilesOnBranch {
 
     Write-Verbose "Checking commits only"
     # Get all the commits between origin/$Branch and HEAD.
-    $gitlog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
-    $m = $gitlog | Select-String "^(\S+) (.*)$"
+    $gitLog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
+    $m = $gitLog | Select-String "^(\S+) (.*)$"
 
     foreach ($commitMatch in $m) {
         $commitHash = $commitMatch.Matches.Groups[1].Value

--- a/.build/SpellCheck.ps1
+++ b/.build/SpellCheck.ps1
@@ -36,7 +36,7 @@ function DoSpellCheck {
 
     $repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
 
-    cspell lint --config "$PSScriptRoot\cspell.json" --no-progress (Join-Path $repoRoot "**" "*.md") (Join-Path $repoRoot "**" "*.ps1")
+    cspell lint --dot --config "$PSScriptRoot\cspell.json" --no-progress (Join-Path $repoRoot "**" "*.md") (Join-Path $repoRoot "**" "*.ps1")
 }
 
 DoSpellCheck

--- a/.build/ValidateMerge.ps1
+++ b/.build/ValidateMerge.ps1
@@ -44,8 +44,8 @@ $allowMergeFiles = @()
 $filesAlreadyChecked = New-Object 'System.Collections.Generic.HashSet[string]'
 
 # Get all the commits between origin/$Branch and HEAD.
-$gitlog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
-$m = $gitlog | Select-String "^(\S+) (.*)$"
+$gitLog = git log --format="%H %cd" --date=rfc origin/$Branch..HEAD
+$m = $gitLog | Select-String "^(\S+) (.*)$"
 
 foreach ($commitMatch in $m) {
     $commitHash = $commitMatch.Matches.Groups[1].Value
@@ -77,11 +77,11 @@ foreach ($commitMatch in $m) {
         $topLevelDependents = New-Object 'System.Collections.Generic.HashSet[string]'
         while ($stack.Count -gt 0) {
             $currentFile = $stack.Pop()
-            $depdendents = $dependentsTable[$currentFile]
-            if ($null -eq $depdendents -or $depdendents.Count -eq 0) {
+            $dependents = $dependentsTable[$currentFile]
+            if ($null -eq $dependents -or $dependents.Count -eq 0) {
                 [void]$topLevelDependents.Add($currentFile)
             } else {
-                foreach ($dependent in $depdendents) {
+                foreach ($dependent in $dependents) {
                     [void]$stack.Push($dependent)
                 }
             }

--- a/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
+++ b/Setup/.NotPublished/ScrubSetupLog.NotPublished.ps1
@@ -132,7 +132,7 @@ function ScrubValuesAndReplace {
     $Script:logContent = $newContent
 }
 
-$scrubToDomainPossibleName = "Rey.Ben.Skywalker.Child.Solo.local"
+$scrubToDomainPossibleName = "Rey.Ben.SkyWalker.Child.Solo.local"
 
 #Scrub the data
 $loggedOnUserSls = $logContent | Select-String "Logged on user: (.+)."
@@ -196,7 +196,7 @@ $orgContainerMatch = $orgContainerSls.Line.Substring($index, $orgContainerSls.Li
 $orgContainer = $orgContainerMatch.Replace($orgContainerSls.Matches.Groups[1].Value, "SoloORG")
 
 ScrubValuesAndReplace -Match $orgContainerMatch -Replace $orgContainer
-ScrubValuesAndReplace -Match $orgContainersls.Matches.Groups[1].Value -Replace "SoloORG"
+ScrubValuesAndReplace -Match $orgContainerSls.Matches.Groups[1].Value -Replace "SoloORG"
 
 $serverFQDNSls = $logContent | Select-String "Evaluated \[Setting:ComputerNameDnsFullyQualified\].+\[Value:`"(.+)`"\] \[ParentValue:"
 $i = 1


### PR DESCRIPTION
**Issue:**
See #2144 

**Fix:**
Added `--dot` to the cmdlet for `cspell`

Resolved #2144

**Validation:**
All files that had issues are now included in the check

