### PR TITLE
Handle Silent Errors inside of Get-ClusterNode

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceState.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeServerMaintenanceState.ps1
@@ -21,7 +21,9 @@ function Get-ExchangeServerMaintenanceState {
 
         try {
             $errorCount = $Error.Count
+            Write-Verbose "Trying to run Get-ClusterNode"
             $getClusterNode = Get-ClusterNode -Name $Server -ErrorAction Stop
+            Invoke-ErrorCatchActionLoopFromIndex $errorCount
         } catch {
             Write-Verbose "Failed to run Get-ClusterNode"
             Invoke-ErrorCatchActionLoopFromIndex $errorCount


### PR DESCRIPTION
**Issue:**
Customer reported an issue that should have been resolved, but it appears that we aren't entering the `catch` block any more to handle this.

**Reason:**
We don't assume that we are handling the errors, therefore, we want to know about it. 

**Fix:**
Add in an error detection after the call inside the `try` block as well. 

**Validation:**
Customer verified. 

