### PR TITLE
Add GraphAPI application permissions support

### DIFF
--- a/M365/Test-MailboxExtendedProperty.ps1
+++ b/M365/Test-MailboxExtendedProperty.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-#Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.4.0" }
+#Requires -Modules @{ ModuleName="ExchangeOnlineManagement"; ModuleVersion="3.7.0" }
 
 <#
 .SYNOPSIS
@@ -14,7 +14,7 @@
     The identity of the user whose mailbox extended properties are to be retrieved.
 
 .PARAMETER Threshold
-    The quota threshold to check for having exceeded. Default is 0.9, which is 90% of the allowed quota.
+    The quota threshold to check for having exceeded. Default is 1.0, which is 100% of the allowed quota.
 
 .PARAMETER SelectFirst
     The number of sorted descending results to select, when checking any namespace or same name prefix quota. Default is 10.
@@ -30,7 +30,7 @@ param(
     $Identity,
     [Parameter(Mandatory = $false, Position = 1)]
     [ValidateRange(0.0, 1.0)]
-    [double]$Threshold = 0.9,
+    [double]$Threshold = 1.0,
     [Parameter(Mandatory = $false, Position = 2)]
     $SelectFirst = 10
 )

--- a/docs/M365/Remove-MailboxExtendedProperty.md
+++ b/docs/M365/Remove-MailboxExtendedProperty.md
@@ -19,8 +19,12 @@ Lastly, repeat the search to check the named properties no longer appear in the 
 Example to search the mailbox for messages with any named properties matching the specific pattern and remove them from the messages.
 ```PowerShell
     $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty
-    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty # Using Delegated permissions
+    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty# Using Delegated permissions
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
+    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
 ```
 
 ## Prerequisites
@@ -47,4 +51,14 @@ To connect to Graph, using delegated access, and you don't know the credentials 
 
 ```PowerShell
     Connect-MgGraph -TenantId 2bbb42ba-e564-4f7b-9765-e19bc80c6123 -ClientId 8af900d8-db73-4918-81ef-3d35a873b6b2 -Scopes "User.Read Mail.ReadWrite" -UseDeviceCode
+```
+
+To connect to Graph, using application access and a shared secret, to search by a tenant administrator against another mailbox in the tenant.
+
+```PowerShell
+    $clientId = "8af900d8-db73-4918-81ef-3d35a873b6b2"
+    $clientSecret = "<your secret>"
+    $secureClientSecret = ConvertTo-SecureString -String $clientSecret -AsPlainText -Force
+    $clientSecretCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureClientSecret
+    Connect-MgGraph -ClientSecretCredential $clientSecretCredential -TenantId 2bbb42ba-e564-4f7b-9765-e19bc80c6123
 ```

--- a/docs/M365/Remove-MailboxExtendedProperty.md
+++ b/docs/M365/Remove-MailboxExtendedProperty.md
@@ -16,15 +16,20 @@ Lastly, repeat the search to check the named properties no longer appear in the 
 
 ### Syntax:
 
-Example to search the mailbox for messages with any named properties matching the specific pattern and remove them from the messages.
+Example to search the mailbox for messages with any named properties matching the specific pattern and remove them from the messages, using delegated access.
 ```PowerShell
     $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
 
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty # Using Delegated permissions
-    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty# Using Delegated permissions
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty
+    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty
+```
 
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
-    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
+Example to search the mailbox for messages with any named properties matching the specific pattern and remove them from the messages, using application access.
+```PowerShell
+    $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com
+    .\Remove-MailboxExtendedProperty.ps1 -MessagesWithExtendedProperty $messagesWithExtendedProperty -UserPrincipalName fred@contoso.com
 ```
 
 ## Prerequisites

--- a/docs/M365/Search-MailboxExtendedProperty.md
+++ b/docs/M365/Search-MailboxExtendedProperty.md
@@ -29,7 +29,10 @@ There are some limitations: the search is limited to messages (extended properti
 Example to search the mailbox for messages with any named properties matching the specific pattern.
 ```PowerShell
     $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty # Using Delegated permissions
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
 ```
 
 ## Prerequisites
@@ -58,17 +61,27 @@ To connect to Graph, using delegated access, and you don't know the credentials 
     Connect-MgGraph -TenantId 2bbb42ba-e564-4f7b-9765-e19bc80c6123 -ClientId 8af900d8-db73-4918-81ef-3d35a873b6b2 -Scopes "User.Read Mail.ReadWrite" -UseDeviceCode
 ```
 
+To connect to Graph, using application access and a shared secret, to search by a tenant administrator against another mailbox in the tenant.
+
+```PowerShell
+    $clientId = "8af900d8-db73-4918-81ef-3d35a873b6b2"
+    $clientSecret = "<your secret>"
+    $secureClientSecret = ConvertTo-SecureString -String $clientSecret -AsPlainText -Force
+    $clientSecretCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureClientSecret
+    Connect-MgGraph -ClientSecretCredential $clientSecretCredential -TenantId 2bbb42ba-e564-4f7b-9765-e19bc80c6123
+```
+
 ### Install ExchangeOnlineManagement PowerShell module
 
 ``` PowerShell
-    Install-Module ExchangeOnlineManagement -RequiredVersion 3.4.0
+    Install-Module ExchangeOnlineManagement -RequiredVersion 3.7.0
 ```
 
 ### Install Microsoft Graph PowerShell modules
 
 ``` PowerShell
-    Install-Module Microsoft.Graph.Users -RequiredVersion 2.24.0
-    Install-Module Microsoft.Graph.Mail -RequiredVersion 2.24.0
+    Install-Module Microsoft.Graph.Users -RequiredVersion 2.25.0
+    Install-Module Microsoft.Graph.Mail -RequiredVersion 2.25.0
 ```
 
 ### Azure App registration

--- a/docs/M365/Search-MailboxExtendedProperty.md
+++ b/docs/M365/Search-MailboxExtendedProperty.md
@@ -26,13 +26,18 @@ There are some limitations: the search is limited to messages (extended properti
 
 ### Syntax:
 
-Example to search the mailbox for messages with any named properties matching the specific pattern.
+Example to search the mailbox for messages with any named properties matching the specific pattern, using delegated access.
 ```PowerShell
     $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
 
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty # Using Delegated permissions
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty
+```
 
-    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com # Using Application permissions
+Example to search the mailbox for messages with any named properties matching the specific pattern, using application access.
+```PowerShell
+    $mailboxExtendedProperty = Get-MailboxExtendedProperty -Identity fred@contoso.com | Where-Object { $_.PropertyName -like '*Some Pattern*' }
+
+    $messagesWithExtendedProperty = .\Search-MailboxExtendedProperty.ps1 -MailboxExtendedProperty $mailboxExtendedProperty -UserPrincipalName fred@contoso.com
 ```
 
 ## Prerequisites


### PR DESCRIPTION
**Issue:**
Tenant Admins want to be able to run the scripts against mailboxes without requiring the user to authenticate and consent, for the scenario where many mailboxes in the tenant have extended properties to remove.

**Reason:**
Requested by Tenant Admins who have tried the scripts.

**Fix:**
Add a new parameter to supply the UPN of the mailbox to run against. Provide details of how to authenticate with Graph API using application permissions.

**Validation:**
Tested scripts against test tenant.

