### PR TITLE
Added show detailed explanation parameter

### DIFF
--- a/M365/MDO/MDOThreatPolicyChecker.ps1
+++ b/M365/MDO/MDOThreatPolicyChecker.ps1
@@ -526,7 +526,7 @@ begin {
     SetWriteVerboseAction ${Function:Write-DebugLog}
     SetWriteWarningAction ${Function:Write-HostLog}
 
-    $BuildVersion = "25.01.23.2258"
+    $BuildVersion = ""
 
     Write-Host ("MDOThreatPolicyChecker.ps1 script version $($BuildVersion)") -ForegroundColor Green
 

--- a/docs/M365/MDO/MDOThreatPolicyChecker.md
+++ b/docs/M365/MDO/MDOThreatPolicyChecker.md
@@ -125,6 +125,7 @@ EmailAddress | Allows you to specify email address or multiple addresses separat
 IncludeMDOPolicies | Checks both EOP and MDO (Safe Attachment and Safe Links) policies for user(s) specified in the CSV file or EmailAddress parameter.
 OnlyMDOPolicies | Checks only MDO (Safe Attachment and Safe Links) policies for user(s) specified in the CSV file or EmailAddress parameter.
 ShowDetailedPolicies | In addition to the policy applied, show any policy details that are set to True, On, or not blank.
+ShowDetailedExplanation | Show specific explanation about why a policy is matched or not.
 SkipConnectionCheck | Skips connection check for Graph and Exchange Online.
 SkipVersionCheck | Skips the version check of the script.
 ScriptUpdateOnly | Just updates script version to latest one.


### PR DESCRIPTION
**Issue:**
Added show detailed explanation parameter. 
Added functionality to check for illogical inclusions or exclusions for Outbound spam policy, which was missing.
Corrected policy lookup based on rule name to look up policy based on the policy property in the rule. 

**Reason:**
Detailed explanation switch helps users understand output. 
Fixed missing functionality and made lookup more robust. 

**Fix:**
Added verification and show more details. 
Fixed above issues. 

**Validation:**
Tested in lab.

