### PR TITLE
Import-PublicFolderMailboxes improvements

### DIFF
--- a/PublicFolders/Hybrid/Import-PublicFolderMailboxes.ps1
+++ b/PublicFolders/Hybrid/Import-PublicFolderMailboxes.ps1
@@ -42,6 +42,7 @@ function WriteInfoMessage() {
 ## Retrieve public folder mailboxes
 function GetPublicFolderMailBoxes() {
     $publicFolderMailboxes = Get-RemoteMailbox -PublicFolder -ResultSize:Unlimited -ErrorAction:SilentlyContinue -WarningAction:SilentlyContinue
+    $publicFolderMailboxes = $publicFolderMailboxes | Where-Object { -not $_.IsExcludedFromServingHierarchy } | Select-Object -First 10
 
     # Return the results
     if ($null -eq $publicFolderMailboxes -or ([array]($publicFolderMailboxes)).Count -lt 1) {


### PR DESCRIPTION
* Only import up to 10 hierarchy serving mailboxes. More than that is pointless.
* Use the same DC for all changes to avoid errors due to replication latency.