### PR TITLE
Improve Update-Engines.ps1 to not download the same file again

### DIFF
--- a/Admin/Update-Engines.ps1
+++ b/Admin/Update-Engines.ps1
@@ -258,8 +258,7 @@ foreach ($p in $Platforms) {
                 Copy-Item $manifestPath -Destination $fullPkgDir
 
                 Write-Host "Download Complete: " $engine.Name
-            }
-            else {
+            } else {
                 Write-Host "Engine already up to date: " $engine.Name
             }
         }

--- a/Admin/Update-Engines.ps1
+++ b/Admin/Update-Engines.ps1
@@ -241,22 +241,27 @@ foreach ($p in $Platforms) {
             $fullPkgUrl = $engineUrl + $manifest.ManifestFile.Package.version + "/" + $manifest.ManifestFile.Package.FullPackage.name
             $fullPkgPath = ($fullPkgDir + $manifest.ManifestFile.Package.FullPackage.name)
 
-            $wc.DownloadFile($fullPkgUrl, $fullPkgPath)
+            if (((Test-Path $fullPkgPath) -ne $true) -or ((Get-Item $fullPkgPath).Length -ne $manifest.ManifestFile.Package.FullPackage.Size)) {
+                $wc.DownloadFile($fullPkgUrl, $fullPkgPath)
 
-            # Detect if there are any subdirectories
-            # needed for this engine
-            $subDirCount = $manifest.ManifestFile.Package.Files.Dir.Count
+                # Detect if there are any subdirectories
+                # needed for this engine
+                $subDirCount = $manifest.ManifestFile.Package.Files.Dir.Count
 
-            for ($i=0; $i -lt $subDirCount; $i++) {
-                CreatePath ($fullPkgDir + $manifest.ManifestFile.Package.Files.Dir[$i].name)
+                for ($i=0; $i -lt $subDirCount; $i++) {
+                    CreatePath ($fullPkgDir + $manifest.ManifestFile.Package.Files.Dir[$i].name)
+                }
+
+                ExtractCab $fullPkgPath $fullPkgDir
+
+                # Copy the downloaded manifest to the package directory
+                Copy-Item $manifestPath -Destination $fullPkgDir
+
+                Write-Host "Download Complete: " $engine.Name
             }
-
-            ExtractCab $fullPkgPath $fullPkgDir
-
-            # Copy the downloaded manifest to the package directory
-            Copy-Item $manifestPath -Destination $fullPkgDir
-
-            Write-Host "Download Complete: " $engine.Name
+            else {
+                Write-Host "Engine already up to date: " $engine.Name
+            }
         }
     }
 }


### PR DESCRIPTION
Duplicate of PR #2212 needed to redo to quickly correct the format for release. 

Issue:
Download of a new signature file takes >15minutes so Exchange isn't able to download the files in our network. -> timeout
When Update-Engines.ps1 is run by a scheduled task every 15min it will re-download the current file and overwrite the existing. While the download is in progress the file cannot be used by Exchange and signature Update will fail.

Fix:
do not download the file again when it already exists and has the correct size

Resolved https://github.com/microsoft/CSS-Exchange/issues/2108