### PR TITLE
Update Test-ExchAVExclusions.ps1

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -420,6 +420,9 @@ while ($currentDiff -gt 0) {
         #Google Inc.
         $ModuleAllowList.add("Google.Protobuf.dll")
 
+		#International Components for Unicode
+		$ModuleAllowList.add("icu.dll")
+
         #Newtonsoft
         $ModuleAllowList.add("Newtonsoft.Json.dll")
         $ModuleAllowList.add("Newtonsoft.Json.Bson.dll")


### PR DESCRIPTION
From time to time we can see C:\Windows\System32\icu.DLL loaded in Exchange w3wp address space. Just to avoid false positive warning.
