### PR TITLE
Handle error to get domain values for Cve-2022-21978 check

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-SecurityCve-2022-21978.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-SecurityCve-2022-21978.ps1
@@ -6,10 +6,10 @@
 function Get-SecurityCve-2022-21978 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [object]$DomainsAcls,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [object]$ExchangeWellKnownSecurityGroups,
 
         [Parameter(Mandatory = $true)]
@@ -81,6 +81,13 @@ function Get-SecurityCve-2022-21978 {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $domainResults = New-Object 'System.Collections.Generic.List[object]'
     } process {
+        Write-Verbose "DomainsAcls is null $($null -eq $DomainsAcls) | ExchangeWellKnownSecurityGroups is null $($null -eq $ExchangeWellKnownSecurityGroups)"
+
+        if ($null -eq $DomainsAcls -or
+            $null -eq $ExchangeWellKnownSecurityGroups) {
+            Write-Verbose "Return now because we don't have everything we need to determine CVE Results"
+            return
+        }
         # Set the SID on the GroupList
         foreach ($group in $groupLists) {
             $wkObject = $ExchangeWellKnownSecurityGroups | Where-Object { $_.WellKnownName -eq $group.Name }


### PR DESCRIPTION
**Issue:**
See #2112 

**Reason:**
This prevents the script from failing out because `Get-SecurityCve-2022-21978` no longer requires `DomainsAcls` and `ExchangeWellKnownSecurityGroups` parameters

**Fix:**
Don't require the parameters to be mandatory and then return if one of the parameters is null. 
Resolved #2112 

**Validation:**
Lab tested by setting the passed value to be null. 

