### PR TITLE
Minor ConfigureExchangeHybridApplication adjustments

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Name" $env:COMPUTERNAME
             TestObjectMatch "Version" "Exchange 2019 CU11"
             TestObjectMatch "Build Number" "15.02.0986.005"
-            TestObjectMatch "End Of Life" $true -WriteType "Yellow" # This is going to change to red once we get 178 out
+            TestObjectMatch "End Of Life" $true -WriteType "Red" # This is going to change to red once we get 178 out - today (04/28/2025) this has changed to red
             TestObjectMatch "Server Role" "Mailbox"
             TestObjectMatch "Edition" "Warning - StandardEvaluation" -WriteType "Yellow"
             TestObjectMatch "Remaining Trial Period" "Error - 00:00:00" -WriteType "Red"

--- a/Hybrid/ConfigureExchangeHybridApplication/ConfigureExchangeHybridApplication.ps1
+++ b/Hybrid/ConfigureExchangeHybridApplication/ConfigureExchangeHybridApplication.ps1
@@ -454,9 +454,9 @@ begin {
                 $_.Fqdn -eq $localServerFqdn
             }).ServerRole -eq "Mailbox"
 
-        # Stop processing if the server where the script runs is an Edge Transport Server
+        # Stop processing if the server where the script runs isn't a Mailbox server
         if ($isLocalServerMailboxServer -eq $false) {
-            Write-Host "The selected configuration can't be executed from an Edge Transport Server - please run the script on a Mailbox Server" -ForegroundColor Red
+            Write-Host "Processing stopped: The selected configuration must be executed on a Mailbox server" -ForegroundColor Red
 
             return
         }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ nav:
   - Emerging Issues: Emerging-Issues.md
   - Admin:
     - Clear-MailboxPermission: Admin/Clear-MailboxPermission.md
-    - ConfigureExchangeHybridApplication: Hybrid/ConfigureExchangeHybridApplication.md
     - Cross-TenantMailboxMigrationValidation: Admin/CrossTenantMailboxMigrationValidation.md
     - Find-AmbiguousSids: Admin/Find-AmbiguousSids.md
     - Get-EASMailboxLogs: Admin/Get-EASMailboxLogs.md
@@ -81,6 +80,7 @@ nav:
     - FreeBusyChecker:
       - Diagnostics/FreeBusyChecker/FreeBusyChecker.md
   - Hybrid:
+    - ConfigureExchangeHybridApplication: Hybrid/ConfigureExchangeHybridApplication.md
     - Test-HMAEAS: Hybrid/Test-HMAEAS.md
   - M365:
     - MDO:


### PR DESCRIPTION
**Issue:**
- `ConfigureExchangeHybridApplication` documentation was shown under `Admin` instead of `Hybrid` section
- String that was shown when `ConfigureExchangeHybridApplication.ps1` was executed on a machine other than a Mailbox server mentioned that the script cannot be run on an Edge Transport server. 

**Reason:**
Bug fixes

**Fix:**
- Documentation was moved to the correct section
- String was adjusted to use a more generic wording

**Validation:**
Lab

