### PR TITLE
Named property name prefix leakage check has been reduced from 10 to …

### DIFF
--- a/M365/Test-MailboxExtendedProperty.ps1
+++ b/M365/Test-MailboxExtendedProperty.ps1
@@ -45,7 +45,7 @@ process {
     # The Guid of the InternetHeaders namespace.
     $internetHeadersNamespace = "00020386-0000-0000-C000-000000000046"
     # The length of the prefix to check for named properties with the same name.
-    $prefixLength = 10
+    $prefixLength = 5
 
     # Retrieve the named properties.
     $namedProps = Get-MailboxExtendedProperty -Identity $Identity


### PR DESCRIPTION
Named property name prefix leakage check has been reduced from 10 to 5

**Issue:**
Named property name prefix leakage check has been reduced from 10 to 5

**Reason:**
Backend has changed

**Fix:**
Reducing prefix length check to match backend check

**Validation:**
Provide if applicable

