### PR TITLE
Address CSpell Update Typo

### DIFF
--- a/Diagnostics/ExchangeLogCollector/Helpers/Start-JobManager.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Start-JobManager.ps1
@@ -19,7 +19,7 @@ function Start-JobManager {
 
         [ScriptBlock]$RemotePipelineHandler
     )
-    <# It needs to be this way incase of different arguments being passed to different machines
+    <# It needs to be this way in case of different arguments being passed to different machines
         [array]ServersWithArguments
             [string]ServerName
             [object]ArgumentList #customized for your ScriptBlock

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -292,7 +292,7 @@ function Get-ExchangeInformation {
                             }
 
                             if (-not([string]::IsNullOrEmpty($serverId))) {
-                                $params["Server"] = "$($serverId):3268" # Needs to be a GC port incase we are looking for a group outside of this domain.
+                                $params["Server"] = "$($serverId):3268" # Needs to be a GC port in case we are looking for a group outside of this domain.
                             }
                             $adObject = Get-ADObject @params
 

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-IISWebApplication.ps1
@@ -11,7 +11,7 @@ function Get-IISWebApplication {
             $webConfigContent = $null
             $linkedConfigurationFilePath = $null
             $validWebConfig = $false # able to convert the file to xml type
-            # set back to default, just incase there is an exception below
+            # set back to default, just in case there is an exception below
             $webConfigExists = $false
             $configurationFilePath = [string]::Empty
             $siteName = $webApplication.ItemXPath | Select-String -Pattern "site\[\@name='(.+)'\s|\]"

--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Get-OrganizationInformation.ps1
@@ -39,7 +39,7 @@ function Get-OrganizationInformation {
         }
 
         # Pull out information from OrganizationConfig
-        # This is done incase Get-OrganizationConfig and we set a true boolean value of false
+        # This is done in case Get-OrganizationConfig and we set a true boolean value of false
         if ($null -ne $organizationConfig) {
             $mapiHttpEnabled = $organizationConfig.MapiHttpEnabled
             # Enabled Download Domains will not be there if running EMS from Exchange 2013.


### PR DESCRIPTION
**Issue:**
CSpell was recently updated and found `incase` to be a typo. 

**Fix:**
Correctly spell `in case`.

**Validation:**
CSpell now passes.

