### PR TITLE
Adding Save Debug Object for Diagnostics

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
@@ -5,6 +5,7 @@
 . $PSScriptRoot\..\..\..\Shared\JobManagementFunctions\GetJobManagementFunctions.ps1
 . $PSScriptRoot\..\..\..\Shared\JobManagementFunctions\Wait-JobQueue.ps1
 . $PSScriptRoot\..\..\..\Shared\ScriptBlockFunctions\RemoteSBLoggingFunctions.ps1
+. $PSScriptRoot\..\..\..\Shared\ScriptDebugFunctions.ps1
 
 <#
     This function handles how we need to call the Analyzer Engine. If that is done by a job or done on this main session.
@@ -39,6 +40,8 @@ function Invoke-AnalyzerEngineHandler {
             }
             Wait-JobQueue -ProcessReceiveJobAction ${Function:Invoke-RemotePipelineLoggingLocal}
             $getJobQueueResult = Get-JobQueueResult
+            Write-Verbose "Saving out the JobQueue"
+            Add-DebugObject -ObjectKeyName "GetJobQueue-AfterDataCollection" -ObjectValueEntry ((Get-JobQueue).Clone())
             Write-Verbose "All servers to complete analyzed results $($stopWatch.Elapsed.TotalSeconds) seconds"
 
             foreach ($key in $getJobQueueResult.Keys) {

--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
@@ -17,6 +17,7 @@
 . $PSScriptRoot\..\DataCollection\ExchangeInformation\Invoke-JobExchangeInformationLocal.ps1
 . $PSScriptRoot\..\..\..\Shared\JobManagementFunctions\Wait-JobQueue.ps1
 . $PSScriptRoot\..\..\..\Shared\ScriptBlockFunctions\RemoteSBLoggingFunctions.ps1
+. $PSScriptRoot\..\..\..\Shared\ScriptDebugFunctions.ps1
 
 <#
     TODO:
@@ -132,6 +133,7 @@ function Get-HealthCheckerDataCollection {
         $exchLocalKey = "Invoke-JobExchangeInformationLocal"
         $generationTime = Get-Date
         $exchCmdletServerJobData = @{}
+        Add-DebugObject -ObjectKeyName "GetExchangeServerList" -ObjectValueEntry $getExchangeServerList
 
         if ($ForceLegacy) {
             try {
@@ -184,6 +186,8 @@ function Get-HealthCheckerDataCollection {
             Wait-JobQueue -ProcessReceiveJobAction ${Function:Invoke-RemotePipelineLoggingLocal}
             $jobResults = Get-JobQueueResult
             Write-Verbose "Job Queue and Get Results time taken $($stopWatch.Elapsed.TotalSeconds) seconds"
+            Write-Verbose "Saving out the JobQueue prior to clearing it."
+            Add-DebugObject -ObjectKeyName "GetJobQueue-AfterDataCollection" -ObjectValueEntry ((Get-JobQueue).Clone())
             Clear-JobQueue
         }
 
@@ -221,7 +225,9 @@ function Get-HealthCheckerDataCollection {
                 OSInformationResult           = $jobResults["$osKey-$serverName"]
                 GenerationTime                = $generationTime
             }
-            $healthCheckerData.Add((Get-HealthCheckerDataObject @params))
+            $dataObject = Get-HealthCheckerDataObject @params
+            Add-DebugObject -ObjectKeyName "Get-HealthCheckerDataObject" -ObjectValueEntry $dataObject
+            $healthCheckerData.Add($dataObject)
         }
         Write-Verbose "Took $($stopWatch.Elapsed.TotalSeconds) seconds to create the Health Checker object list"
         return $healthCheckerData

--- a/Shared/ScriptDebugFunctions.ps1
+++ b/Shared/ScriptDebugFunctions.ps1
@@ -1,0 +1,34 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-DebugObject {
+    [CmdletBinding()]
+    param()
+    process {
+        if ($null -eq $Script:savedDebugObject) {
+            Write-Verbose "Creating Get-DebugObject Hashtable"
+            $Script:savedDebugObject = @{}
+        }
+        $Script:savedDebugObject
+    }
+}
+
+function Add-DebugObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ObjectKeyName,
+
+        [Parameter(Mandatory = $false)]
+        [object]$ObjectValueEntry
+    )
+    begin {
+        $getDebugObject = Get-DebugObject
+    }
+    process {
+        if (-not ($getDebugObject.ContainsKey($ObjectKeyName))) {
+            $getDebugObject.Add($ObjectKeyName, (New-Object System.Collections.Generic.List[object]))
+        }
+        $getDebugObject[$ObjectKeyName].Add($ObjectValueEntry)
+    }
+}


### PR DESCRIPTION
**Reason:**
A way to save objects in memory for when there is an issue, we save out the objects to file that was saved.

This will be able to address issues in the analyzer engine prior to the main xml file gets saved out for debugging. 

**Validation:**
Lab testing
Resolved #2339 
