### PR TITLE
Adding Write-Progress to determine where we are at with Multi-Threading

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
@@ -25,17 +25,32 @@ function Invoke-AnalyzerEngineHandler {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $finalResultsProcessed = @{}
         $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $progressAnalyzerParams = @{
+            Activity        = "Setting up jobs to queue for analysis"
+            ParentId        = 0
+            Id              = 1
+            Status          = [string]::Empty
+            PercentComplete = -1
+        }
+        $analysisCounter = 1
     }
     process {
         if ($RunType -eq "CurrentSession") {
             foreach ($healthServerObject in $ServerDataCollection) {
                 $singleServerStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $progressAnalyzerParams.Activity = "Analysis to execute in current PowerShell session"
+                $progressAnalyzerParams.Status = "Executing analysis on $($healthServerObject.ServerName)"
+                $progressAnalyzerParams.PercentComplete = ($analysisCounter++ / $ServerDataCollection.Count * 100)
+                Write-Progress @progressAnalyzerParams
                 $analyzedResults = Invoke-JobAnalyzerEngine -HealthServerObject $healthServerObject
                 Write-Verbose "$($healthServerObject.ServerName) Analyzer Engine took $($singleServerStopWatch.Elapsed.TotalSeconds) seconds"
                 $finalResultsProcessed.Add($healthServerObject.ServerName, $analyzedResults.HCAnalyzedResults)
             }
         } else {
             foreach ($healthServerObject in $ServerDataCollection) {
+                $progressAnalyzerParams.Status = "Add job for Server $($healthServerObject.ServerName)"
+                $progressAnalyzerParams.PercentComplete = ($analysisCounter++ / $ServerDataCollection.Count * 100)
+                Write-Progress @progressAnalyzerParams
                 Add-JobAnalyzerEngine -HealthServerObject $healthServerObject -ExecutingServer $healthServerObject.ServerName #TODO: Improve this logic
             }
             Wait-JobQueue -ProcessReceiveJobAction ${Function:Invoke-RemotePipelineLoggingLocal}
@@ -52,6 +67,7 @@ function Invoke-AnalyzerEngineHandler {
         }
     }
     end {
+        Write-Progress @progressAnalyzerParams -Completed
         Write-Verbose "Completed $($MyInvocation.MyCommand) and took $($stopWatch.Elapsed.TotalSeconds) seconds"
         return $finalResultsProcessed
     }

--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -191,14 +191,18 @@ begin {
     }
 
     $Script:ServerNameList = New-Object System.Collections.Generic.List[string]
-    $Script:Logger = Get-NewLoggerInstance -LogName "HealthChecker-Debug" `
-        -LogDirectory $Script:OutputFilePath `
-        -AppendDateTime $false `
-        -ErrorAction SilentlyContinue
+    $loggerParams = @{
+        LogName        = "HealthChecker-Debug"
+        LogDirectory   = $Script:OutputFilePath
+        AppendDateTime = $true
+        ErrorAction    = "SilentlyContinue"
+    }
+    $Script:Logger = Get-NewLoggerInstance @loggerParams
     SetProperForegroundColor
     SetWriteVerboseAction ${Function:Write-DebugLog}
     SetWriteWarningAction ${Function:Write-DebugLog}
     SetWriteErrorAction ${Function:Write-DebugLog}
+    SetWriteProgressAction ${Function:Write-DebugLog}
     Get-PSSessionDetails
 } process {
     $Server | ForEach-Object { $Script:ServerNameList.Add($_.ToUpper()) }

--- a/Shared/JobManagementFunctions/Wait-JobQueue.ps1
+++ b/Shared/JobManagementFunctions/Wait-JobQueue.ps1
@@ -10,12 +10,6 @@
 .DESCRIPTION
     From all the jobs that were added to the queue from Add-JobQueue, it will attempt to execute all the jobs and store them back in the hashtable
     This is the function that you call to execute a batch of jobs that you wish to complete before moving onto the next job.
-    TODO:
-        Add in logic for Write-Progress, we want to know how many jobs are running and a summary of what they are.
-        Improve the debug logic here
-        Add in timeout logic to timeout job requests
-        Add in logic for maxJobsRunning
-        Add in Read ME page for this section of code
 #>
 
 function Wait-JobQueue {
@@ -32,6 +26,9 @@ function Wait-JobQueue {
         if ($getJobQueue.Count -eq 0) {
             throw "No Jobs in Queue"
         }
+
+        Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+        $stopwatchMain = [System.Diagnostics.Stopwatch]::StartNew()
     }
     process {
         do {
@@ -42,16 +39,43 @@ function Wait-JobQueue {
                 Invoke-TryStartJobQueue
             }
 
-            # Check all the current jobs running to see if they have finished
-            [array]$completedJobsToProcess = $getJobQueue.Values | Where-Object { $null -ne $_.Job -and $_.JobEndTime -eq [DateTime]::MinValue  -and $_.Job.State -ne "Running" }
+            [array]$completedJobs = $getJobQueue.Values | Where-Object { $null -ne $_.Job -and $_.JobEndTime -ne [DateTime]::MinValue -and $_.Job.State -eq "Completed" }
+            [array]$completedJobsToProcess = $getJobQueue.Values | Where-Object { $null -ne $_.Job -and $_.JobEndTime -eq [DateTime]::MinValue -and $_.Job.State -ne "Running" }
 
-            if ($completedJobsToProcess.Count -gt 0) {
+            $jobQueueProgressParams = @{
+                Activity         = "Waiting for $($getJobQueue.Values.Count) Total Jobs to Complete"
+                Status           = "$($completedJobs.Count) jobs completed. Running for $($stopwatchMain.Elapsed.TotalSeconds) seconds."
+                CurrentOperation = [string]::Empty
+                ParentId         = 0
+                Id               = 1
+                PercentComplete  = ($completedJobs.Count * 100 / $getJobQueue.Values.Count)
+            }
+
+            if ($completedJobsToProcess.Count -eq 0) {
+                Write-Progress @jobQueueProgressParams
+            } else {
+                $jobReceivedCompleted = 0
                 foreach ($jobInfo in $completedJobsToProcess) {
                     $JobError = $null
+                    $jobReceivedCompleted++
+                    $jobQueueProgressParams.CurrentOperation = "Receiving Job '$($jobInfo.JobId)' $jobReceivedCompleted of $($completedJobsToProcess.Count)"
+                    Write-Progress @jobQueueProgressParams
+
                     Write-Verbose "Attempting to receive job $($jobInfo.JobId)"
                     $jobInfo.JobEndTime = [DateTime]::Now
+                    $receiveJobStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
                     $result = Receive-Job $jobInfo.Job -ErrorVariable "JobError"
+                    Write-Verbose "Receive-Job took $($receiveJobStopWatch.Elapsed.TotalSeconds) seconds to complete"
+
+                    if ($jobInfo.Job.ChildJobs.Progress.Count -gt 1) {
+                        $lastProgress = $jobInfo.Job.ChildJobs.Progress | Select-Object -Last 1
+                        if ($lastProgress) {
+                            Write-Progress -Activity $lastProgress.Activity -ParentId 1 -Id ($jobInfo.Job.Id + 1) -Completed
+                        }
+                    }
+
                     Write-Verbose "Successfully received the job"
+
                     if ($null -ne $ProcessReceiveJobAction -and
                         $null -ne $result) {
                         $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -73,5 +97,7 @@ function Wait-JobQueue {
             Start-Sleep 1
             $continue = $null -ne ($getJobQueue.Values | Where-Object { $_.JobEndTime -eq [DateTime]::MinValue })
         } while ($continue)
+        Write-Progress @jobQueueProgressParams -Completed
+        Write-Verbose "End $($MyInvocation.MyCommand) and took $($stopwatchMain.Elapsed.TotalSeconds) seconds"
     }
 }


### PR DESCRIPTION
**Reason:**
Adding the `Write-Progress` information back into Health Checker for multi-threading operation change. 

**Validation:**
Lab tested

Resolved #2342 