### PR TITLE
Fallback for analyzer job failure

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
@@ -39,9 +39,27 @@ function Invoke-AnalyzerEngineHandler {
             }
             Wait-JobQueue -ProcessReceiveJobAction ${Function:Invoke-RemotePipelineLoggingLocal}
             $getJobQueueResult = Get-JobQueueResult
+            $noResults = $getJobQueueResult.Keys | Where-Object { $null -eq $getJobQueueResult[$_] }
+
+            if ($null -ne $noResults) {
+                Write-Verbose "Analyzer failed for the following servers: $([string]::Join(", ", $noResults))"
+                $getJobQueue = Get-JobQueue
+                foreach ($failedJobKey in $noResults) {
+                    $serverName = $getJobQueue[$failedJobKey].JobParameter.ArgumentList.ServerName
+                    Write-Verbose "Working on Server $serverName"
+                    $singleServerStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+                    $analyzedResults = Invoke-JobAnalyzerEngine -HealthServerObject $getJobQueue[$failedJobKey].JobParameter.ArgumentList
+                    Write-Verbose "$serverName Analyzer Engine took $($singleServerStopWatch.Elapsed.TotalSeconds) seconds"
+                    $finalResultsProcessed.Add($serverName, $analyzedResults.HCAnalyzedResults)
+                }
+            }
             Write-Verbose "All servers to complete analyzed results $($stopWatch.Elapsed.TotalSeconds) seconds"
 
             foreach ($key in $getJobQueueResult.Keys) {
+                if ( $null -eq $getJobQueueResult[$key]) {
+                    # Skip over jobs that are null out.
+                    continue
+                }
                 $analyzedResults = $getJobQueueResult[$key].HCAnalyzedResults
                 $serverName = $analyzedResults.HealthCheckerExchangeServer.ServerName
                 $finalResultsProcessed.Add($serverName, $analyzedResults)


### PR DESCRIPTION
**Reason:**
Needed to add in some logic for having the analyzer to fallback when it fails.

**Fix:**
When a job fails, we will attempt to execute the job again locally.

**Validation:**
Lab tested

Resolved #2341 

