### PR TITLE
Address Edge Problems with multi-threading logic

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
@@ -102,7 +102,7 @@ function Get-HealthCheckerDataCollection {
                 Write-Verbose "Took $(([DateTime]::Now) - $startTime) to execute the Invoke-Command test for server name"
 
                 foreach ($passed in $invokeCommandResults) {
-                    $key = $getExchangeServerListToTestFQDN.Values | Where-Object { $_.Name -eq $passed }
+                    $key = $getExchangeServerListToTestFQDN.Values | Where-Object { $_.Name -eq $passed.PSComputerName }
                     $getExchangeServerList.Add($passed.PSComputerName, $getExchangeServerListToTestFQDN[$key.FQDN])
                     $getExchangeServerListToTestFQDN.Remove($key.FQDN)
                 }

--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataObject.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataObject.ps1
@@ -51,31 +51,36 @@ function Get-HealthCheckerDataObject {
             $exchangeCustomConnector = Get-ExchangeConnectorCustomObject @customConnectorParams
         }
 
-        # Adjust the IIS information.
-        $iisSettings = $ExchangeLocalResult.IISSettings
-        $webSites = New-Object System.Collections.Generic.List[object]
-        $nonExchangeWebSites = New-Object System.Collections.Generic.List[object]
+        if (-not $ExchangeCmdletResult.GetExchangeServer.IsEdgeServer) {
+            # Adjust the IIS information.
+            $iisSettings = $ExchangeLocalResult.IISSettings
+            $webSites = New-Object System.Collections.Generic.List[object]
+            $nonExchangeWebSites = New-Object System.Collections.Generic.List[object]
 
-        $iisSettings.IISWebSite |
-            ForEach-Object {
-                $site = $_
-                $currentCount = $webSites.Count
-                foreach ($name in $ExchangeCmdletResult.ExchangeWebSiteNames) {
-                    if ($name -eq $site.Name) {
-                        $webSites.Add($site)
+            $iisSettings.IISWebSite |
+                ForEach-Object {
+                    $site = $_
+                    $currentCount = $webSites.Count
+                    foreach ($name in $ExchangeCmdletResult.ExchangeWebSiteNames) {
+                        if ($name -eq $site.Name) {
+                            $webSites.Add($site)
+                        }
+                    }
+
+                    if ($currentCount -eq $webSites.Count) {
+                        $nonExchangeWebSites.Add($site)
                     }
                 }
-
-                if ($currentCount -eq $webSites.Count) {
-                    $nonExchangeWebSites.Add($site)
-                }
+            if ($webSites.Count -gt 0) {
+                $iisSettings.IISWebSite = $webSites
+                $iisSettings | Add-Member -Name "NonExchangeWebSites" -MemberType NoteProperty -Value $nonExchangeWebSites
+            } else {
+                Write-Verbose "No IIS Web Sites were found that matched the ExchangeWebSiteNames so we are placing all the sites in the main container."
+                $iisSettings.IISWebSite = $nonExchangeWebSites
             }
-        if ($webSites.Count -gt 0) {
-            $iisSettings.IISWebSite = $webSites
-            $iisSettings | Add-Member -Name "NonExchangeWebSites" -MemberType NoteProperty -Value $nonExchangeWebSites
         } else {
-            Write-Verbose "No IIS Web Sites were found that matched the ExchangeWebSiteNames so we are placing all the sites in the main container."
-            $iisSettings.IISWebSite = $nonExchangeWebSites
+            Write-Verbose "Processing an Edge Server, so not processing IIS Settings"
+            $iisSettings = $null
         }
 
         $hcObject = [PSCustomObject]@{


### PR DESCRIPTION
**Issue:**
Ran into a few issues while testing on Edge Server.

**Fix:**

Can't process IIS information on an Edge Server, so we need to account for that within the new multi-threading logic for building out the Health Checker Data Object. 

Found bug within trying to find key from Invoke-Command results. 

fix #2358 
fix #2357 

**Validation:**
Lab tested

