### PR TITLE
Handle Warning that is being displayed with Get-ClusterNode

### DIFF
--- a/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
@@ -88,7 +88,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Assert-MockCalled Get-WebServicesVirtualDirectory -Exactly 1
             Assert-MockCalled Get-OrganizationConfig -Exactly 1
             Assert-MockCalled Get-HybridConfiguration -Exactly 1
-            Assert-MockCalled Get-Service -Exactly 1
+            Assert-MockCalled Get-Service -Exactly 2
             Assert-MockCalled Get-SettingOverride -Exactly 1
             Assert-MockCalled Get-ServerComponentState -Exactly 1
             Assert-MockCalled Test-ServiceHealth -Exactly 1


### PR DESCRIPTION
**Issue:**
We were seeing a warning being displayed within the main PowerShell session when running multi-threaded caused by `Get-ClusterNode` on a computer that didn't have the Cluster Service or when it wasn't running. 

**Reason:**
Don't want to see this warning being displayed on the screen. 

**Fix:**
Execute the cmdlet remotely to try to run on the server that should have the service running. 
Resolved #2343 

**Validation:**
Lab tested

