### PR TITLE
Add Extended Protection Configuration to main data object creation

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExtendedProtectionConfigState.ps1
@@ -1,7 +1,5 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
-. $PSScriptRoot\..\..\..\..\Shared\IISFunctions\ExtendedProtection\Get-ExtendedProtectionConfigurationResult.ps1
 . $PSScriptRoot\..\..\..\..\Shared\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 
 function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
@@ -21,6 +19,7 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
     # Adding CVE-2024-21410 for the updated CVE for release with CU14
     $cveList = "CVE-2022-24516, CVE-2022-21979, CVE-2022-21980, CVE-2022-24477, CVE-2022-30134, CVE-2024-21410"
+    $extendedProtection = $SecurityObject.ExchangeInformation.ExtendedProtectionConfig
 
     $baseParams = @{
         AnalyzedInformation = $AnalyzeResults
@@ -29,20 +28,6 @@ function Invoke-AnalyzerSecurityExtendedProtectionConfigState {
 
     # Supported server roles are: Mailbox and ClientAccess
     if ($SecurityObject.IsEdgeServer -eq $false) {
-
-        # Get the Extended Protection Results
-        try {
-            $extendedProtectionParams = @{
-                ExSetupVersion        = $SecurityObject.ExchangeInformation.BuildInformation.VersionInformation.BuildVersion
-                CatchActionFunction   = ${Function:Invoke-CatchActions}
-                ApplicationHostConfig = [xml]$SecurityObject.ExchangeInformation.IISSettings.ApplicationHostConfig
-            }
-            $extendedProtection = $null
-            Get-ExtendedProtectionConfigurationResult @extendedProtectionParams | Invoke-RemotePipelineHandler -Result ([ref]$extendedProtection)
-        } catch {
-            Write-Verbose "Failed to get the ExtendedProtectionConfig"
-            Invoke-CatchActions
-        }
 
         if ($null -ne $extendedProtection) {
             Write-Verbose "Exchange extended protection information found - performing vulnerability testing"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
@@ -190,7 +190,6 @@ function Invoke-JobExchangeInformationLocal {
         Write-Verbose "Completed: $($MyInvocation.MyCommand) and took $($jobStopWatch.Elapsed.TotalSeconds) seconds"
         [PSCustomObject]@{
             BuildInformation                         = $buildInformation
-            ExtendedProtectionConfig                 = $extendedProtectionConfig
             ApplicationPools                         = $applicationPools
             RegistryValues                           = $registryValues
             ExchangeEmergencyMitigationServiceResult = $eemsEndpointResults


### PR DESCRIPTION
**Issue:**
Missing Extended Protection Configuration within the main Health Checker data object, causing some things to be missed. 

**Fix:**
Add in Extended Protection Configuration logic into the main Health Checker data object creation. 

**Validation:**
Lab tested

