### PR TITLE
Fix error handling in -SlowTraversal path

### DIFF
--- a/PublicFolders/SourceSideValidations/Get-FolderData.ps1
+++ b/PublicFolders/SourceSideValidations/Get-FolderData.ps1
@@ -119,7 +119,7 @@ function Get-FolderData {
                 $folderData.Statistics | Export-Csv $PSScriptRoot\Statistics.csv
                 foreach ($errorParam in $statisticsResult.Errors) {
                     $errorResult = New-TestResult @errorParam
-                    $folderData.Errors.Add($errorResult)
+                    $null = $folderData.Errors.Add($errorResult)
                 }
             }
         }

--- a/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
+++ b/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
@@ -49,6 +49,8 @@ param (
 # For HashSet support
 Add-Type -AssemblyName System.Core -ErrorAction Stop
 
+$BuildVersion = ""
+
 try {
     if (-not $SkipVersionCheck) {
         if (Test-ScriptVersion -AutoUpdate) {
@@ -234,12 +236,10 @@ try {
     Write-Host
     Write-Host "Validation results were written to file:"
     Write-Host $ResultsFile -ForegroundColor Green
-
-    $private:endTime = Get-Date
-
     Write-Host
-    Write-Host "SourceSideValidations complete. Total duration" ($endTime - $startTime)
 } finally {
+    $private:endTime = Get-Date
+    Write-Host "SourceSideValidations $BuildVersion complete. Total duration" ($endTime - $startTime)
     Write-Host
     Write-Host "Liked the script or had a problem? Let us know at ExToolsFeedback@microsoft.com"
 }


### PR DESCRIPTION
When we hit an error getting statistics during slow traversal, we would dump an int to the pipeline which broke the script.

This fixes that issue and some related error handling.
