### PR TITLE
Properly set array types

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -30,7 +30,7 @@ function Invoke-AnalyzerHybridInformation {
     $exchangeInformation = $HealthServerObject.ExchangeInformation
     $getHybridConfiguration = $HealthServerObject.OrganizationInformation.GetHybridConfiguration
 
-    $evoStsAuthServer = $HealthServerObject.OrganizationInformation.GetAuthServer | Where-Object {
+    [array]$evoStsAuthServer = $HealthServerObject.OrganizationInformation.GetAuthServer | Where-Object {
         (($_.Name -match "^EvoSts - $guidRegEx") -or
         ($_.Name -match "EvoSTS")) -and
         $_.Type -eq "AzureAD" -and
@@ -38,7 +38,7 @@ function Invoke-AnalyzerHybridInformation {
         $_.Enabled -eq $true
     }
 
-    $dedicatedHybridAppOverride = $HealthServerObject.OrganizationInformation.GetSettingOverride | Where-Object {
+    [array]$dedicatedHybridAppOverride = $HealthServerObject.OrganizationInformation.GetSettingOverride | Where-Object {
         $_.ComponentName -eq "Global" -and
         $_.SectionName -eq "ExchangeOnpremAsThirdPartyAppId"
     }
@@ -242,7 +242,7 @@ function Invoke-AnalyzerHybridInformation {
                 foreach ($authServer in $evoStsAuthServer) {
                     $dedicatedHybridAppAuthServerObjects++
 
-                    $authServerDetails = "AuthServer: $($authServer.Id)`r`n`t`tTenantId: $($authServer.Realm)`r`n`t`tAppId: $($authServer.ApplicationIdentifier)`r`n`t`tDomain(s): $([System.String]::Join(", ", $authServer.DomainName))"
+                    $authServerDetails = "AuthServer: $($authServer.Id)`r`n`t`tTenantId: $($authServer.Realm)`r`n`t`tAppId: $($authServer.ApplicationIdentifier)`r`n`t`tDomain(s): $([System.String]::Join(", ", @($authServer.DomainName)))"
 
                     if ($dedicatedHybridAppAuthServerObjects -lt $evoStsAuthServer.Count) {
                         $authServerDetails = $authServerDetails + "`r`n`r`n"

--- a/Diagnostics/HealthChecker/Analyzer/Security/Get-SerializedDataSigningState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Get-SerializedDataSigningState.ps1
@@ -73,9 +73,10 @@ function Get-SerializedDataSigningState {
                 }
 
                 $serializedDataSigningSettingOverride = $null
-                Get-FilteredSettingOverrideInformation @params | Invoke-RemotePipelineHandler -Result ([ref]$serializedDataSigningSettingOverride)
+                Get-FilteredSettingOverrideInformation @params | Invoke-RemotePipelineHandlerList -Result ([ref]$serializedDataSigningSettingOverride)
 
-                if ($null -eq $serializedDataSigningSettingOverride) {
+                if ($null -eq $serializedDataSigningSettingOverride -or
+                    $serializedDataSigningSettingOverride.Count -eq 0) {
                     Write-Verbose "No Setting Override Found"
                     $serializedDataSigningEnabled = $enabledByDefaultVersion
                 } elseif ($serializedDataSigningSettingOverride.Count -eq 1) {

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2024-49040.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2024-49040.ps1
@@ -38,7 +38,7 @@ function Invoke-AnalyzerSecurityCve-2024-49040 {
             FilterParameterName     = $filterParameterName
         }
         $nonCompliantSenderSettings = $null
-        Get-FilteredSettingOverrideInformation @params | Invoke-RemotePipelineHandler -Result ([ref]$nonCompliantSenderSettings)
+        Get-FilteredSettingOverrideInformation @params | Invoke-RemotePipelineHandlerList -Result ([ref]$nonCompliantSenderSettings)
 
         $overrideDisabled = $nonCompliantSenderSettings.Count -gt 0 -and
         (($nonCompliantSenderSettings | Where-Object { $_.ParameterValue -eq "false" }).Count -eq 2)

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveAddressedBySerializedDataSigning.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveAddressedBySerializedDataSigning.ps1
@@ -110,7 +110,7 @@ function Invoke-AnalyzerSecurityCveAddressedBySerializedDataSigning {
 
         $getSerializedDataSigningState = Get-SerializedDataSigningState -SecurityObject $SecurityObject
         $cveFixedBySerializedDataSigning = $null
-        NewCveFixedBySDSObject | Invoke-RemotePipelineHandler -Result ([ref]$cveFixedBySerializedDataSigning)
+        NewCveFixedBySDSObject | Invoke-RemotePipelineHandlerList -Result ([ref]$cveFixedBySerializedDataSigning)
     }
     process {
         if ($getSerializedDataSigningState.SupportedRole -ne $false) {


### PR DESCRIPTION
**Issue:**
Issues that were found during BETA testing about the array types. 

**Reason:**
When the object is passed off to a job, we don't treat the objects as we would expect them to be, so we must properly declare the types. 

**Fix:**
Declare the types of the arrays

**Validation:**
Lab tested

