### PR TITLE
Include GUID when sending emails to us

### DIFF
--- a/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
+++ b/Diagnostics/HealthChecker/Helpers/Get-ErrorsThatOccurred.ps1
@@ -49,6 +49,7 @@ function Get-ErrorsThatOccurred {
 
         if ((Test-UnhandledErrorsOccurred)) {
             Write-Red("There appears to have been some errors in the script. To assist with debugging of the script, please send the HealthChecker-Debug_*.txt, HealthChecker-ScriptDebugObject.xml, and .xml file to ExToolsFeedback@microsoft.com.")
+            Write-Red "`tPlease include in the subject of the email with 'HealthChecker-$([System.Guid]::NewGuid())' to avoid duplicate email subjects being sent to us."
             $Script:Logger.PreventLogCleanup = $true
             Write-ScriptDebugObject
             Write-Errors


### PR DESCRIPTION
**Issue:**
When customers send emails to us, they tend to have a similar subject which make it harder to try to find the email chain. 

**Reason:**
This is to help with trying to find the conversation of an email

**Fix:**
Try to provide a suggested subject. 

**Validation:**
Lab tested

