### PR TITLE
Require PowerShell 5 and update docs

### DIFF
--- a/Hybrid/ConfigureExchangeHybridApplication/ConfigureExchangeHybridApplication.ps1
+++ b/Hybrid/ConfigureExchangeHybridApplication/ConfigureExchangeHybridApplication.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-#Requires -Version 3.0
+#Requires -Version 5.0
 
 <#
 .SYNOPSIS

--- a/docs/Hybrid/ConfigureExchangeHybridApplication.md
+++ b/docs/Hybrid/ConfigureExchangeHybridApplication.md
@@ -6,6 +6,8 @@ This documentation focuses on different scenarios and how they can be configured
 
 ## How to use the script
 
+The script must be run from PowerShell version 5 or greater. Running the script from PowerShell Core is not supported.
+
 This section contains examples of some of the most common scenarios in which the script can be used. These examples aim to provide clear guidance on how to configure various settings and features using the script, ensuring that administrators can effectively apply it to their specific needs.
 
 ### Examples


### PR DESCRIPTION
**Reason:**
Customers have reported issues trying to run the script from Windows Server 2012 R2 and from PowerShell Core. These were not tested scenarios. 

**Fix:**
Require a supported version of PowerShell. 
Temp block the use of PowerShell core to prevent issues. 
Update the docs regarding this change. 


