### PR TITLE
Temp change of Apr25HU to Apr25SU

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -135,6 +135,7 @@ function Invoke-AnalyzerSecurityCveCheck {
         "Oct23SU" = (NewCveEntry @("CVE-2023-36778") @($ex2016, $ex2019))
         "Nov23SU" = (NewCveEntry @("CVE-2023-36050", "CVE-2023-36039", "CVE-2023-36035", "CVE-2023-36439") @($ex2016, $ex2019))
         "Mar24SU" = (NewCveEntry @("CVE-2024-26198") @($ex2016, $ex2019))
+        "Apr25SU" = (NewCveEntry @("CVE-2025-53786") @($ex2016, $ex2019))
     }
 
     # Need to organize the list so oldest CVEs come out first.

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -144,11 +144,11 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             $cveTests.Contains("CVE-2020-1147") | Should -Be $true
             $cveTests.Contains("CVE-2023-36039") | Should -Be $true
             $cveTests.Contains("ADV24199947") | Should -Be $true
-            $cveTests.Count | Should -Be 52
+            $cveTests.Count | Should -Be 53
             $downloadDomains = GetObject "CVE-2021-1730"
             $downloadDomains.DownloadDomainsEnabled | Should -Be "false"
 
-            $Script:ActiveGrouping.Count | Should -Be 59
+            $Script:ActiveGrouping.Count | Should -Be 60
         }
     }
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -159,7 +159,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             $cveTests.Contains("CVE-2023-36434") | Should -Be $true
             $cveTests.Contains("CVE-2023-36039") | Should -Be $true
             $cveTests.Contains("ADV24199947") | Should -Be $true
-            $cveTests.Count | Should -Be 52
+            $cveTests.Count | Should -Be 53
             $downloadDomains = GetObject "CVE-2021-1730"
             $downloadDomains.DownloadDomainsEnabled | Should -Be "False"
             TestObjectMatch "Extended Protection Vulnerable" "True" -WriteType "Red"

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -145,10 +145,9 @@ function Get-ExchangeBuildVersionInformation {
                     $cuLevel = "CU15"
                     $cuReleaseDate = "02/10/2025"
                     $supportedBuildNumber = $true
-                    $latestSUBuild = $true
                 }
                 (GetBuildVersion $ex19 "CU15" -SU "May25HU") { $latestSUBuild = $true }
-                (GetBuildVersion $ex19 "CU15" -SU "Apr25HU") { $latestSUBuild = $true }
+                (GetBuildVersion $ex19 "CU15" -SU "Apr25SU") { $latestSUBuild = $true }
                 { $_ -lt (GetBuildVersion $ex19 "CU15") } {
                     $cuLevel = "CU14"
                     $cuReleaseDate = "02/13/2024"
@@ -156,17 +155,13 @@ function Get-ExchangeBuildVersionInformation {
                     $orgValue = 16762
                 }
                 (GetBuildVersion $ex19 "CU14" -SU "May25HU") { $latestSUBuild = $true }
-                (GetBuildVersion $ex19 "CU14" -SU "Apr25HU") { $latestSUBuild = $true }
-                (GetBuildVersion $ex19 "CU14" -SU "Nov24SUv2") { $latestSUBuild = $true }
+                (GetBuildVersion $ex19 "CU14" -SU "Apr25SU") { $latestSUBuild = $true }
                 { $_ -lt (GetBuildVersion $ex19 "CU14") } {
                     $cuLevel = "CU13"
                     $cuReleaseDate = "05/03/2023"
                     $supportedBuildNumber = $false
                     $orgValue = 16761
                 }
-                # Technically the SU is still secure. Might need to change pester testing on this to make it okay. But it is complaining about the second SU both being on the latest.
-                # for now just going to leave as is as this might change with upcoming releases.
-                (GetBuildVersion $ex19 "CU13" -SU "Nov24SUv2") { $latestSUBuild = $true }
                 { $_ -lt (GetBuildVersion $ex19 "CU13") } {
                     $cuLevel = "CU12"
                     $cuReleaseDate = "04/20/2022"
@@ -258,8 +253,7 @@ function Get-ExchangeBuildVersionInformation {
                     $supportedBuildNumber = $true
                 }
                 (GetBuildVersion $ex16 "CU23" -SU "May25HU") { $latestSUBuild = $true }
-                (GetBuildVersion $ex16 "CU23" -SU "Apr25HU") { $latestSUBuild = $true }
-                (GetBuildVersion $ex16 "CU23" -SU "Nov24SUv2") { $latestSUBuild = $true }
+                (GetBuildVersion $ex16 "CU23" -SU "Apr25SU") { $latestSUBuild = $true }
                 { $_ -lt (GetBuildVersion $ex16 "CU23") } {
                     $cuLevel = "CU22"
                     $cuReleaseDate = "09/28/2021"
@@ -747,7 +741,7 @@ function GetExchangeBuildDictionary {
                     "Apr24HU"   = "15.1.2507.39"
                     "Nov24SU"   = "15.1.2507.43"
                     "Nov24SUv2" = "15.1.2507.44"
-                    "Apr25HU"   = "15.1.2507.55"
+                    "Apr25SU"   = "15.1.2507.55"
                     "May25HU"   = "15.1.2507.57"
                 })
         }
@@ -856,11 +850,11 @@ function GetExchangeBuildDictionary {
                     "Apr24HU"   = "15.2.1544.11"
                     "Nov24SU"   = "15.2.1544.13"
                     "Nov24SUv2" = "15.2.1544.14"
-                    "Apr25HU"   = "15.2.1544.25"
+                    "Apr25SU"   = "15.2.1544.25"
                     "May25HU"   = "15.2.1544.27"
                 })
             "CU15" = (NewCUAndSUObject "15.2.1748.10" @{
-                    "Apr25HU" = "15.2.1748.24"
+                    "Apr25SU" = "15.2.1748.24"
                     "May25HU" = "15.2.1748.26"
                 })
         }

--- a/Shared/Get-ExchangeBuildVersionInformation.ps1
+++ b/Shared/Get-ExchangeBuildVersionInformation.ps1
@@ -114,7 +114,7 @@ function Get-ExchangeBuildVersionInformation {
         if ($exchangeVersion.Major -eq 15 -and $exchangeVersion.Minor -eq 2 -and $exchangeVersion.Build -ge 2562) {
             Write-Verbose "Exchange Server SE is detected"
             $exchangeMajorVersion = "ExchangeSE"
-            $extendedSupportDate = "10/14/9999"
+            $extendedSupportDate = "12/31/2035"
             $friendlyName = "Exchange SE"
             #Latest Version AD Settings
             $schemaValue = 17003


### PR DESCRIPTION
**Issue:**
We want to be able to call out to our customers who are not on at least this build about the latest CVE. 

**Reason:**
Call out the latest CVE issue for Hybrid environments. This is the best that we can do without being able to connect to the tenant and properly checking everything. 

**Fix:**
Switch Apr25HU to SU till the next SU is released. 

**Validation:**
Pester tested

