### PR TITLE
Improve logic in ResetFirstPartyServicePrincipalKeyCredentials mode

### DIFF
--- a/Shared/GraphApiFunctions/Remove-CertificateFromAzureServicePrincipal.ps1
+++ b/Shared/GraphApiFunctions/Remove-CertificateFromAzureServicePrincipal.ps1
@@ -73,7 +73,7 @@ function Remove-CertificateFromAzureServicePrincipal {
     }
 
     # Check for existing key credentials, retain existing ones which don't match the thumbprint that was passed
-    if ($null -ne $getAzureServicePrincipalResponse.KeyCredentials) {
+    if (($getAzureServicePrincipalResponse.KeyCredentials).Count -ge 1) {
         Write-Verbose "Existing key credentials for this Service Principal have been located"
 
         if ($RemoveAllCertificates) {
@@ -108,7 +108,7 @@ function Remove-CertificateFromAzureServicePrincipal {
         }
     } else {
         Write-Verbose "No existing key credentials found for this Service Principal"
-        return $false
+        return $true
     }
 
     # If there are keyCredentials that should be retained, provide them, otherwise, pass an empty array to clean up all keyCredentials


### PR DESCRIPTION
**Issue:**
In `ResetFirstPartyServicePrincipalKeyCredentials` the script queries organization information which are not required in this mode and as a result, limits the script to be executed on computers which are part of the AD domain in which Exchange Server resides.

**Reason:**
No need to query the information because we don't use them in this mode. 

**Fix:**
Don't call `Get-ExchangeOrganizationGuid` and don't query `azureApplicationInformation` information when running script in `ResetFirstPartyServicePrincipalKeyCredentials` mode.

**Validation:**
Lab

