### PR TITLE
Properly log out unhandled continue errors

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerEngineHandler.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 . $PSScriptRoot\Add-JobAnalyzerEngine.ps1
+. $PSScriptRoot\..\Helpers\HiddenJobUnhandledErrorFunctions.ps1
 . $PSScriptRoot\..\..\..\Shared\JobManagementFunctions\GetJobManagementFunctions.ps1
 . $PSScriptRoot\..\..\..\Shared\JobManagementFunctions\Wait-JobQueue.ps1
 . $PSScriptRoot\..\..\..\Shared\ScriptBlockFunctions\RemoteSBLoggingFunctions.ps1
@@ -64,6 +65,7 @@ function Invoke-AnalyzerEngineHandler {
             Write-Verbose "Saving out the JobQueue"
             Add-DebugObject -ObjectKeyName "GetJobQueue-AfterDataCollection" -ObjectValueEntry ((Get-JobQueue).Clone())
             $noResults = $getJobQueueResult.Keys | Where-Object { $null -eq $getJobQueueResult[$_] }
+            $getJobQueueResult.Values | Where-Object { $null -ne $_ } | Invoke-HiddenJobUnhandledErrors
 
             if ($null -ne $noResults) {
                 Write-Verbose "Analyzer failed for the following servers: $([string]::Join(", ", [array]$noResults))"

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-JobAnalyzerEngine.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-JobAnalyzerEngine.ps1
@@ -35,6 +35,7 @@ function Invoke-JobAnalyzerEngine {
             HCAnalyzedResults = $healthCheckerAnalyzedResult
             RemoteJob         = $true -eq $PSSenderInfo
             JobHandledErrors  = $jobHandledErrors
+            AllErrors         = $Error
         }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
@@ -89,10 +89,18 @@ function Invoke-JobExchangeInformationCmdlet {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $jobStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
         Invoke-DefaultConnectExchangeShell
+        $resetErrors = $false
     }
     process {
 
         foreach ($Server in $ServerName) {
+            if ($resetErrors) {
+                # If we have a lot of errors, we don't want to have a lot of duplicates returned since we are in a loop.
+                if ($PSSenderInfo) {
+                    $Script:ErrorsExcluded = @()
+                }
+                $Error.Clear()
+            }
             $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
             Write-Verbose "Working on collecting information for $Server"
             $exchangeCertificateInformation = $null
@@ -202,7 +210,9 @@ function Invoke-JobExchangeInformationCmdlet {
                 ADObject                        = $getExchangeServerADInformation
                 RemoteJob                       = $true -eq $PSSenderInfo
                 JobHandledErrors                = $jobHandledErrors
+                AllErrors                       = $Error
             }
+            $resetErrors = $true
         }
     }
     end {

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
@@ -209,6 +209,7 @@ function Invoke-JobExchangeInformationLocal {
             LocalGroupMember                         = $localGroupMember
             RemoteJob                                = $true -eq $PSSenderInfo
             JobHandledErrors                         = $jobHandledErrors
+            AllErrors                                = $Error
         }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Invoke-JobOrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Invoke-JobOrganizationInformation.ps1
@@ -217,6 +217,7 @@ function Invoke-JobOrganizationInformation {
             GetSendConnector                  = $getSendConnector
             RemoteJob                         = $true -eq $PSSenderInfo
             JobHandledErrors                  = $jobHandledErrors
+            AllErrors                         = $Error
         }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Invoke-JobHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Invoke-JobHardwareInformation.ps1
@@ -60,6 +60,7 @@ function Invoke-JobHardwareInformation {
             MemoryInformation = [array]$physicalMemory
             RemoteJob         = $true -eq $PSSenderInfo
             JobHandledErrors  = $jobHandledErrors
+            AllErrors         = $Error
         }
     }
 }

--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Invoke-JobOperatingSystemInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Invoke-JobOperatingSystemInformation.ps1
@@ -137,6 +137,7 @@ function Invoke-JobOperatingSystemInformation {
             PerformanceCounters        = $counters
             RemoteJob                  = $true -eq $PSSenderInfo
             JobHandledErrors           = $jobHandledErrors
+            AllErrors                  = $Error
         }
     }
 }

--- a/Diagnostics/HealthChecker/Helpers/HiddenJobUnhandledErrorFunctions.ps1
+++ b/Diagnostics/HealthChecker/Helpers/HiddenJobUnhandledErrorFunctions.ps1
@@ -1,0 +1,111 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    These functions are related for how a remote job will pass back any unhandled errors.
+#>
+function Test-HiddenJobUnhandledErrors {
+    $null -ne $Script:HiddenJobUnhandedErrors -and $Script:HiddenJobUnhandedErrors.Count -gt 0
+}
+
+function Invoke-WriteHiddenJobUnhandledErrors {
+    if (-not (Test-HiddenJobUnhandledErrors)) {
+        return
+    }
+
+    $Script:HiddenJobUnhandedErrors | ForEach-Object { WriteRemoteErrorInformation $_ }
+}
+
+<#
+    Write out the Remote Error Information that we have collected.
+#>
+function WriteRemoteErrorInformation {
+    [CmdletBinding()]
+    param(
+        [object]$CurrentError
+    )
+
+    [string]$errorInformation = [System.Environment]::NewLine + [System.Environment]::NewLine +
+    "----------------Remote Error Information----------------" + [System.Environment]::NewLine
+
+    if ($null -ne $CurrentError.Exception) {
+        $errorInformation += "Exception Message: $($CurrentError.Exception.Message)$([System.Environment]::NewLine)"
+
+        if ($null -ne $CurrentError.Exception.InnerException) {
+            $errorInformation += "Exception Inner Exception: $($CurrentError.Exception.InnerException)$([System.Environment]::NewLine)"
+        }
+    }
+
+    if ($null -ne $CurrentError.InvocationInfo.PositionMessage) {
+        $errorInformation += "Position Message: $($CurrentError.InvocationInfo.PositionMessage)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorCategory_Activity))) {
+        $errorInformation += "Error Category Activity: $($CurrentError.ErrorCategory_Activity)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorCategory_Reason))) {
+        $errorInformation += "Error Category Reason: $($CurrentError.ErrorCategory_Reason)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorCategory_TargetName))) {
+        $errorInformation += "Error Category TargetName: $($CurrentError.ErrorCategory_TargetName)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorCategory_TargetType))) {
+        $errorInformation += "Error Category TargetType: $($CurrentError.ErrorCategory_TargetType)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorCategory_Message))) {
+        $errorInformation += "Error Category Message: $($CurrentError.ErrorCategory_Message)$([System.Environment]::NewLine)"
+    }
+
+    if (-not ([string]::IsNullOrEmpty($CurrentError.ErrorDetails_ScriptStackTrace))) {
+        $errorInformation += "Error Details Script Stack Trace: $($CurrentError.ErrorDetails_ScriptStackTrace)$([System.Environment]::NewLine)"
+    }
+
+    $errorInformation += "--------------------------------------------------------$([System.Environment]::NewLine)$([System.Environment]::NewLine)"
+
+    Write-Verbose $errorInformation
+}
+
+<#
+    Determines if the remote job had any unhandled errors that we want to have bubbled up.
+    It adds the errors to the $Script:HiddenJobUnhandedErrors variable to be stored until we want to write out the information.
+#>
+function Invoke-HiddenJobUnhandledErrors {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [object[]]$RemoteJob
+    )
+    begin {
+        if ($null -eq $Script:HiddenJobUnhandedErrors) {
+            $Script:HiddenJobUnhandedErrors = @()
+        }
+    }
+    process {
+        foreach ($job in $RemoteJob) {
+            if (-not $job.RemoteJob -and $null -ne $job.RemoteJob) {
+                Write-Verbose "Not running a Remote Job, skipping"
+            } elseif ($null -eq $job.AllErrors -and $null -ne $job.JobHandledErrors) {
+                Write-Error "All Errors were not saved on this job. $($job.RunspaceId)" -ErrorAction SilentlyContinue
+            } elseif ($null -ne $job.AllErrors -and $null -eq $job.JobHandledErrors) {
+                $job.AllErrors |
+                    ForEach-Object {
+                        $Script:HiddenJobUnhandedErrors += $_
+                    }
+            } elseif ($null -ne $job.AllErrors -and $job.AllErrors.Count -ne $job.JobHandledErrors.Count) {
+                $job.AllErrors |
+                    ForEach-Object {
+                        $currentError = $_
+                        $handledError = $job.JobHandledErrors | Where-Object { $_.Equals($currentError) }
+
+                        if ($null -eq $handledError) {
+                            $Script:HiddenJobUnhandedErrors += $currentError
+                        }
+                    }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue:**
A lot of errors pop up from Receive-Job if we aren't able to send the entire object to be analyzed to the remote location. 

**Reason:**
When we hit an error that doesn't stop the job, we need to be aware of this and log it When we do Receive-Job, we need to hide those errors from occurring, but we still need to take action on them.

**Fix:**
Update the error handling of the job work being done

**Validation:**
Lab tested

