### PR TITLE
Remove Invoke-ScriptBlockHandler from Shared to avoid Health Checker from using it

### DIFF
--- a/Admin/Remove-DuplicateEntriesFromIanaMappings.ps1
+++ b/Admin/Remove-DuplicateEntriesFromIanaMappings.ps1
@@ -47,6 +47,7 @@ begin {
     . $PSScriptRoot\..\Shared\Confirm-Administrator.ps1
     . $PSScriptRoot\..\Shared\Get-ExSetupFileVersionInfo.ps1
     . $PSScriptRoot\..\Shared\Invoke-ScriptBlockHandler.ps1
+    . $PSScriptRoot\..\Shared\ScriptBlockFunctions\Add-ScriptBlockInjection.ps1
     . $PSScriptRoot\..\Shared\ScriptUpdateFunctions\GenericScriptUpdate.ps1
 
     Write-Verbose "PowerShell version: $($PSVersionTable.PSVersion)"
@@ -189,9 +190,16 @@ begin {
         exit
     }
 
+    $params = @{
+        PrimaryScriptBlock = ${Function:Get-ExSetupFileVersionInfo}
+        IncludeScriptBlock = ${Function:Invoke-CatchActionError}
+    }
+
+    $scriptBlock = Add-ScriptBlockInjection @params
+
     foreach ($srv in $Server) {
         # Check if the target server is online / reachable to us, we use the Get-ExSetupFileVersionInfo custom function to do this
-        $exchangeFileVersionInfo = Get-ExSetupFileVersionInfo -Server $srv
+        $exchangeFileVersionInfo = Invoke-ScriptBlockHandler -ComputerName $srv -ScriptBlock $scriptBlock
 
         if (-not([System.String]::IsNullOrEmpty($exchangeFileVersionInfo))) {
             Invoke-ScriptBlockHandler -ComputerName $srv -ScriptBlock $scriptBlock -ArgumentList $RestartServices, $env:COMPUTERNAME

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeServerIISSettings.ps1
@@ -80,7 +80,6 @@ function Get-ExchangeServerIISSettings {
                 return
             }
             $iisModulesParams = @{
-                ComputerName             = $ComputerName
                 ApplicationHostConfig    = $xmlApplicationHostConfig
                 SkipLegacyOSModulesCheck = $IsLegacyOS
                 CatchActionFunction      = $CatchActionFunction

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationLocal.ps1
@@ -107,7 +107,6 @@ function Invoke-JobExchangeInformationLocal {
         }
 
         $configParams = @{
-            ComputerName = $env:COMPUTERNAME
             FileLocation = @("$([System.IO.Path]::Combine($serverExchangeBinDirectory, "EdgeTransport.exe.config"))",
                 "$([System.IO.Path]::Combine($serverExchangeBinDirectory, "Search\Ceres\Runtime\1.0\noderunner.exe.config"))",
                 "$([System.IO.Path]::Combine($serverExchangeBinDirectory, "Monitoring\Config\AntiMalware.xml"))",

--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
@@ -1,9 +1,6 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Needs to be on top to avoid the function to be encapsulated
-. $PSScriptRoot\..\..\..\Shared\Invoke-ScriptBlockHandler.ps1
-
 . $PSScriptRoot\Get-HealthCheckerDataObject.ps1
 . $PSScriptRoot\..\DataCollection\OrganizationInformation\Add-JobOrganizationInformation.ps1
 . $PSScriptRoot\..\DataCollection\OrganizationInformation\Invoke-JobOrganizationInformation.ps1

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -15,7 +15,6 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
     Context "Basic Exchange 2016 CU22 Testing" {
         BeforeAll {
             Mock Get-InvokeWebRequestResult -ParameterFilter { $Uri -eq "https://officeclient.microsoft.com/GetExchangeMitigations" } -MockWith { return $null }
-            Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Test EEMS pattern service connectivity" } -MockWith { return $null }
             SetDefaultRunOfHealthChecker "Debug_E16_Results.xml"
         }
 
@@ -155,7 +154,6 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
 
     Context "Testing Scenario 1 - Exchange 2016" {
         BeforeAll {
-            Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Test EEMS pattern service connectivity" } -MockWith { return $null }
             Mock Get-WmiObjectHandler -ParameterFilter { $Class -eq "Win32_Processor" } `
                 -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Hardware\HyperV_Win32_Processor1.xml" }
 

--- a/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthCheckerTest.CommonMocks.NotPublished.ps1
@@ -28,8 +28,6 @@ Mock Get-WmiObjectHandler {
     }
 }
 
-Mock Invoke-ScriptBlockHandler -ParameterFilter { $ScriptBlockDescription -eq "Test EEMS pattern service connectivity" } -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\WebRequest_GetExchangeMitigations.xml" }
-
 Mock GetCurrentTimeZone -MockWith { return "Pacific Standard Time" }
 Mock GetProcessorCount -MockWith { return 4 }
 Mock GetCachtoknVersionInfo -MockWith { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\IIS\GetVersionInformationCachTokn.xml" }

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExtendedProtectionPrerequisitesCheck.ps1
@@ -1,9 +1,13 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Remote Registry needs to be loaded before others to make sure we can access it within this function.
+. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
+
 . $PSScriptRoot\..\..\..\..\Shared\TLS\Get-AllTlsSettings.ps1
 . $PSScriptRoot\..\..\..\..\Shared\IISFunctions\ExtendedProtection\Get-ExtendedProtectionConfiguration.ps1
-. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ScriptBlockFunctions\Add-ScriptBlockInjection.ps1
+. $PSScriptRoot\..\..\..\..\Shared\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 
 # This function is used to collect the required information needed to determine if a server is ready for Extended Protection
 function Get-ExtendedProtectionPrerequisitesCheck {
@@ -64,7 +68,13 @@ function Get-ExtendedProtectionPrerequisitesCheck {
                 $progressParams.Status = "$baseStatus TLS Settings"
                 Write-Progress @progressParams
                 Write-Verbose "$($progressParams.Status)"
-                $tlsSettings = Get-AllTlsSettings -MachineName $server.FQDN
+                $includeScriptBlockList = @(
+                    ${Function:Invoke-RemotePipelineHandler},
+                    ${Function:Get-RemoteRegistryValue},
+                    ${Function:Get-RemoteRegistrySubKey}
+                )
+                $scriptBlock = Add-ScriptBlockInjection -PrimaryScriptBlock ${Function:Get-AllTlsSettings} -IncludeScriptBlock $includeScriptBlockList
+                $tlsSettings = Invoke-ScriptBlockHandler -ComputerName $server.FQDN -ScriptBlock $scriptBlock
                 $params = @{
                     MachineName = $server.FQDN
                     SubKey      = "SYSTEM\CurrentControlSet\Control\Lsa"

--- a/Shared/Get-ExSetupFileVersionInfo.ps1
+++ b/Shared/Get-ExSetupFileVersionInfo.ps1
@@ -1,44 +1,42 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\Invoke-ScriptBlockHandler.ps1
+<#
+.DESCRIPTION
+    Get the ExSetup.exe file version information on the local server. If the ExSetup.exe isn't in the environment path, we will manually try to find it.
+.NOTES
+    You MUST execute this code on the server you want to collect information for. This can be done remotely via Invoke-Command/Invoke-ScriptBlockHandler.
+#>
 function Get-ExSetupFileVersionInfo {
     param(
-        [string]$Server = $env:COMPUTERNAME,
-
         [Parameter(Mandatory = $false)]
         [ScriptBlock]$CatchActionFunction
     )
 
+    # You must have Invoke-CatchActionError within Get-ExSetupFileVersionInfo if running this inside of Invoke-Command
+    . $PSScriptRoot\Invoke-CatchActionError.ps1
+
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-    $exSetupDetails = [string]::Empty
-    function Get-ExSetupDetailsScriptBlock {
+    $exSetupDetails = $null
+    try {
+        $exSetupDetails = Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+        $getItem = Get-Item -ErrorAction SilentlyContinue $exSetupDetails[0].FileName
+        $exSetupDetails | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
+    } catch {
         try {
-            $getCommand = Get-Command ExSetup -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
-            $getItem = Get-Item -ErrorAction SilentlyContinue $getCommand[0].FileName
-            $getCommand | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
-            $getCommand
-        } catch {
-            try {
-                Write-Verbose "Failed to find ExSetup by environment path locations. Attempting manual lookup."
-                $installDirectory = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction Stop).MsiInstallPath
+            Write-Verbose "Failed to find ExSetup by environment path locations. Attempting manual lookup. Inner Exception: $_"
+            Invoke-CatchActionError $CatchActionFunction
+            $installDirectory = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup -ErrorAction Stop).MsiInstallPath
 
-                if ($null -ne $installDirectory) {
-                    $getCommand = Get-Command ([System.IO.Path]::Combine($installDirectory, "bin\ExSetup.exe")) -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
-                    $getItem = Get-Item -ErrorAction SilentlyContinue $getCommand[0].FileName
-                    $getCommand | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
-                    $getCommand
-                }
-            } catch {
-                Write-Verbose "Failed to find ExSetup, need to fallback."
+            if ($null -ne $installDirectory) {
+                $exSetupDetails = Get-Command ([System.IO.Path]::Combine($installDirectory, "bin\ExSetup.exe")) -ErrorAction Stop | ForEach-Object { $_.FileVersionInfo }
+                $getItem = Get-Item -ErrorAction SilentlyContinue $exSetupDetails[0].FileName
+                $exSetupDetails | Add-Member -MemberType NoteProperty -Name InstallTime -Value ($getItem.LastAccessTime)
             }
+        } catch {
+            Write-Verbose "Failed to find ExSetup, need to fallback. Inner Exception $_"
+            Invoke-CatchActionError $CatchActionFunction
         }
-    }
-
-    if ($PSSenderInfo) {
-        $exSetupDetails = Get-ExSetupDetailsScriptBlock
-    } else {
-        $exSetupDetails = Invoke-ScriptBlockHandler -ComputerName $Server -ScriptBlock ${Function:Get-ExSetupDetailsScriptBlock} -ScriptBlockDescription "Getting ExSetup remotely" -CatchActionFunction $CatchActionFunction
     }
 
     Write-Verbose "Exiting: $($MyInvocation.MyCommand)"

--- a/Shared/Get-FileContentInformation.ps1
+++ b/Shared/Get-FileContentInformation.ps1
@@ -1,59 +1,44 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\Invoke-ScriptBlockHandler.ps1
+<#
+.DESCRIPTION
+    Gets the file information related to the passed list of files to the function.
+    It will determine if the file exists and the raw content information for the file.
+.NOTES
+    You MUST execute this code on the server you want to collect information for. This can be done remotely via Invoke-Command/Invoke-ScriptBlockHandler.
+#>
 function Get-FileContentInformation {
     [CmdletBinding()]
+    [OutputType([HashTable])]
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$ComputerName,
-
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string[]]$FileLocation
     )
     begin {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-        $allFiles = New-Object System.Collections.Generic.List[string]
-        $scriptBlock = {
-            param($FileLocations)
-            $results = @{}
-            foreach ($fileLocation in $FileLocations) {
-                $present = (Test-Path $fileLocation)
-
-                if ($present) {
-                    $content = Get-Content $fileLocation -Raw -Encoding UTF8
-                } else {
-                    $content = $null
-                }
-
-                $obj = [PSCustomObject]@{
-                    Present  = $present
-                    FileName = ([IO.Path]::GetFileName($fileLocation))
-                    FilePath = $fileLocation
-                    Content  = $content
-                }
-
-                $results.Add($fileLocation, $obj)
-            }
-            return $results
-        }
+        $results = @{}
     }
     process {
         foreach ($file in $FileLocation) {
-            $allFiles.Add($file)
+            $present = (Test-Path $file)
+
+            if ($present) {
+                $content = Get-Content $file -Raw -Encoding UTF8
+            } else {
+                $content = $null
+            }
+
+            $obj = [PSCustomObject]@{
+                Present  = $present
+                FileName = ([IO.Path]::GetFileName($file))
+                FilePath = $file
+                Content  = $content
+            }
+            $results.Add($file, $obj)
         }
     }
     end {
-        if ($PSSenderInfo) {
-            return & $scriptBlock $allFiles
-        } else {
-            $params = @{
-                ComputerName           = $ComputerName
-                ScriptBlockDescription = "Getting File Content Information"
-                ArgumentList           = @(, $allFiles)
-                ScriptBlock            = $scriptBlock
-            }
-            return (Invoke-ScriptBlockHandler @params)
-        }
+        return $results
     }
 }

--- a/Shared/Get-ProcessedServerList.ps1
+++ b/Shared/Get-ProcessedServerList.ps1
@@ -1,6 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\ScriptBlockFunctions\Add-ScriptBlockInjection.ps1
 . $PSScriptRoot\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 . $PSScriptRoot\CompareExchangeBuildLevel.ps1
 . $PSScriptRoot\Get-ExchangeBuildVersionInformation.ps1
@@ -111,7 +112,13 @@ function Get-ProcessedServerList {
                 $paramWriteProgress.PercentComplete = (($serverCount / $possibleValidExchangeServer.Count) * 100)
                 Write-Progress @paramWriteProgress
 
-                $exSetupDetails = Get-ExSetupFileVersionInfo -Server $server.FQDN
+                $params = @{
+                    PrimaryScriptBlock = ${Function:Get-ExSetupFileVersionInfo}
+                    IncludeScriptBlock = ${Function:Invoke-CatchActionError}
+                }
+
+                $scriptBlock = Add-ScriptBlockInjection @params
+                $exSetupDetails = Invoke-ScriptBlockHandler -ComputerName $server.FQDN -ScriptBlock $scriptBlock
 
                 if ($null -ne $exSetupDetails -and
                     (-not ([string]::IsNullOrEmpty($exSetupDetails)))) {

--- a/Shared/IISFunctions/ExtendedProtection/Get-ExtendedProtectionConfiguration.ps1
+++ b/Shared/IISFunctions/ExtendedProtection/Get-ExtendedProtectionConfiguration.ps1
@@ -4,6 +4,7 @@
 . $PSScriptRoot\..\..\Invoke-CatchActionError.ps1
 . $PSScriptRoot\..\..\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\..\..\Write-ErrorInformation.ps1
+. $PSScriptRoot\Get-ExtendedProtectionConfigurationResult.ps1
 
 function Get-ExtendedProtectionConfiguration {
     [CmdletBinding()]
@@ -38,8 +39,6 @@ function Get-ExtendedProtectionConfiguration {
     )
 
     begin {
-
-        . $PSScriptRoot\Get-ExtendedProtectionConfigurationResult.ps1
 
         # Intended for inside of Invoke-Command.
         function GetApplicationHostConfig {

--- a/Shared/TLS/Get-AllTlsSettings.ps1
+++ b/Shared/TLS/Get-AllTlsSettings.ps1
@@ -1,36 +1,37 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\..\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\..\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
-. $PSScriptRoot\Get-AllTlsSettingsFromRegistry.ps1
-. $PSScriptRoot\Get-TlsCipherSuiteInformation.ps1
 
-# Gets all related TLS Settings, from registry or other factors
+<#
+.DESCRIPTION
+    This function gets all TLS related information from the local server.
+    This includes the registry information for TLS, CipherSuites, and SecurityProtocol currently active.
+.NOTES
+    You MUST execute this code on the server you want to collect information for. This can be done remotely via Invoke-Command/Invoke-ScriptBlockHandler.
+#>
 function Get-AllTlsSettings {
     [CmdletBinding()]
     param(
-        [string]$MachineName = $env:COMPUTERNAME,
         [ScriptBlock]$CatchActionFunction
     )
     begin {
+
+        # Place into the function so the build process can handle this.
+        . $PSScriptRoot\Get-AllTlsSettingsFromRegistry.ps1
+        . $PSScriptRoot\Get-TlsCipherSuiteInformation.ps1
+
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $registry = $null
-        $securityProtocol = $null
+        $securityProtocol = ([System.Net.ServicePointManager]::SecurityProtocol).ToString()
         $tlsCipherSuite = $null
     }
     process {
 
-        Get-AllTlsSettingsFromRegistry -MachineName $MachineName -CatchActionFunction $CatchActionFunction |
+        Get-AllTlsSettingsFromRegistry -CatchActionFunction $CatchActionFunction |
             Invoke-RemotePipelineHandler -Result ([ref]$registry)
-        Get-TlsCipherSuiteInformation -MachineName $MachineName -CatchActionFunction $CatchActionFunction |
+        Get-TlsCipherSuiteInformation -CatchActionFunction $CatchActionFunction |
             Invoke-RemotePipelineHandler -Result ([ref]$tlsCipherSuite)
-
-        if ($PSSenderInfo) {
-            $securityProtocol = ([System.Net.ServicePointManager]::SecurityProtocol).ToString()
-        } else {
-            $securityProtocol = (Invoke-ScriptBlockHandler -ComputerName $MachineName -ScriptBlock { ([System.Net.ServicePointManager]::SecurityProtocol).ToString() } -CatchActionFunction $CatchActionFunction)
-        }
 
         return [PSCustomObject]@{
             Registry         = $registry

--- a/Shared/TLS/Get-AllTlsSettingsFromRegistry.ps1
+++ b/Shared/TLS/Get-AllTlsSettingsFromRegistry.ps1
@@ -7,7 +7,6 @@
 function Get-AllTlsSettingsFromRegistry {
     [CmdletBinding()]
     param(
-        [string]$MachineName = $env:COMPUTERNAME,
         [ScriptBlock]$CatchActionFunction
     )
     begin {
@@ -56,7 +55,7 @@ function Get-AllTlsSettingsFromRegistry {
         }
 
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-        Write-Verbose "Passed - MachineName: '$MachineName'"
+        Write-Verbose "Passed - MachineName: '$env:COMPUTERNAME'"
         $registryBase = "SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS {0}\{1}"
         $enabledKey = "Enabled"
         $disabledKey = "DisabledByDefault"
@@ -71,7 +70,7 @@ function Get-AllTlsSettingsFromRegistry {
             $registryServer = $registryBase -f $tlsVersion, "Server"
             $registryClient = $registryBase -f $tlsVersion, "Client"
             $baseParams = @{
-                MachineName         = $MachineName
+                MachineName         = $env:COMPUTERNAME
                 CatchActionFunction = $CatchActionFunction
             }
 
@@ -161,12 +160,12 @@ function Get-AllTlsSettingsFromRegistry {
             $wowSchUseStrongCrypto = $null
 
             $msRegistryKeyParams = @{
-                MachineName         = $MachineName
+                MachineName         = $env:COMPUTERNAME
                 SubKey              = $msRegistryKey
                 CatchActionFunction = $CatchActionFunction
             }
             $wowMsRegistryKeyParams = @{
-                MachineName         = $MachineName
+                MachineName         = $env:COMPUTERNAME
                 SubKey              = $wowMsRegistryKey
                 CatchActionFunction = $CatchActionFunction
             }

--- a/Shared/TLS/Get-TlsCipherSuiteInformation.ps1
+++ b/Shared/TLS/Get-TlsCipherSuiteInformation.ps1
@@ -1,14 +1,13 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\..\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\..\Get-RemoteRegistryValue.ps1
+. $PSScriptRoot\..\Invoke-CatchActionError.ps1
 . $PSScriptRoot\..\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 
 function Get-TlsCipherSuiteInformation {
     [OutputType("System.Object")]
     param(
-        [string]$MachineName = $env:COMPUTERNAME,
         [ScriptBlock]$CatchActionFunction
     )
 
@@ -50,20 +49,11 @@ function Get-TlsCipherSuiteInformation {
         # 'Get-TlsCipherSuite' takes account of the cipher suites which are configured by the help of GPO.
         # No need to query the ciphers defined via GPO if this call is successful.
         Write-Verbose "Trying to query TlsCipherSuites via 'Get-TlsCipherSuite'"
-        if ($PSSenderInfo) {
-            try {
-                $tlsCipherSuites = Get-TlsCipherSuite
-            } catch {
-                Write-Verbose "Failed to get the TlsCipherSuite. Inner Exception: $_"
-                Invoke-CatchActionError $CatchActionFunction
-            }
-        } else {
-            $getTlsCipherSuiteParams = @{
-                ComputerName        = $MachineName
-                ScriptBlock         = { Get-TlsCipherSuite }
-                CatchActionFunction = $CatchActionFunction
-            }
-            $tlsCipherSuites = Invoke-ScriptBlockHandler @getTlsCipherSuiteParams
+        try {
+            $tlsCipherSuites = Get-TlsCipherSuite
+        } catch {
+            Write-Verbose "Failed to get the TlsCipherSuite. Inner Exception: $_"
+            Invoke-CatchActionError $CatchActionFunction
         }
 
         if ($null -eq $tlsCipherSuites) {
@@ -73,7 +63,7 @@ function Get-TlsCipherSuiteInformation {
             Write-Verbose "Failed to query TlsCipherSuites via 'Get-TlsCipherSuite' fallback to registry"
 
             $policyTlsRegistryParams = @{
-                MachineName         = $MachineName
+                MachineName         = $env:COMPUTERNAME
                 SubKey              = "SOFTWARE\Policies\Microsoft\Cryptography\Configuration\SSL\00010002"
                 GetValue            = "Functions"
                 ValueType           = "String"
@@ -90,7 +80,7 @@ function Get-TlsCipherSuiteInformation {
             } else {
                 Write-Verbose "No cipher suites configured via GPO found - going to query the local TLS cipher suites"
                 $tlsRegistryParams = @{
-                    MachineName         = $MachineName
+                    MachineName         = $env:COMPUTERNAME
                     SubKey              = "SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL\00010002"
                     GetValue            = "Functions"
                     ValueType           = "MultiString"

--- a/Shared/Tests/Get-IISModules.Tests.ps1
+++ b/Shared/Tests/Get-IISModules.Tests.ps1
@@ -7,7 +7,6 @@ param()
 BeforeAll {
     $Script:parentPath = (Split-Path -Parent $PSScriptRoot)
     . $Script:parentPath\IISFunctions\Get-IISModules.ps1
-    . $Script:parentPath\Invoke-ScriptBlockHandler.ps1
 
     function LoadApplicationHostConfig {
         [CmdletBinding()]

--- a/Shared/VisualCRedistributableVersionFunctions.ps1
+++ b/Shared/VisualCRedistributableVersionFunctions.ps1
@@ -1,13 +1,20 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\Invoke-ScriptBlockHandler.ps1
 . $PSScriptRoot\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 
+<#
+.DESCRIPTION
+    These set of functions are what we use to collect and determine what Visual C++ Redistributable version is installed on the server.
+    It is responsible for collecting the information and determine the version from the local server.
+.NOTES
+    You MUST execute the Get-VisualCRedistributableInstalledVersion code on the server you want to collect information for.
+    This can be done remotely via Invoke-Command/Invoke-ScriptBlockHandler.
+    The other functions may be executed on the primary script server.
+#>
 function Get-VisualCRedistributableInstalledVersion {
     [CmdletBinding()]
     param(
-        [string]$ComputerName = $env:COMPUTERNAME,
         [ScriptBlock]$CatchActionFunction
     )
     begin {
@@ -16,17 +23,7 @@ function Get-VisualCRedistributableInstalledVersion {
     }
     process {
 
-        if ($PSSenderInfo) {
-            $installedSoftware = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
-        } else {
-            $params = @{
-                ComputerName           = $ComputerName
-                ScriptBlock            = { Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\* }
-                ScriptBlockDescription = "Querying for software"
-                CatchActionFunction    = $CatchActionFunction
-            }
-            $installedSoftware = Invoke-ScriptBlockHandler @params
-        }
+        $installedSoftware = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
 
         foreach ($software in $installedSoftware) {
 


### PR DESCRIPTION
**Reason:**
With Health Checker being multiple threaded, we no longer want to use `Invoke-ScriptBlockHandler` so we need to remove it from all the Shared functions. 

**TODO**
- [x] Squash the commits properly
- [x] Update function descriptions for the ones that we changed
- [x] Verify that all the scripts modified that they are working properly


**Validation:**
Lab tested

