### PR TITLE
Add Invoke-CatchActions that were missing

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -235,6 +235,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                     }
                 }
             } catch {
+                Invoke-CatchActions
                 $params = $baseParams + @{
                     Name                = "$fileName Invalid Config Format"
                     Details             = "True --- Error: Not able to convert to xml which means it is in an incorrect format that will cause problems with the process."
@@ -476,6 +477,7 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
                 Add-AnalyzedResultInformation @params
             }
         } catch {
+            Invoke-CatchActions
             if ($edgeKeySuccessful) {
                 $params.Details = "AntiMalware.xml Invalid Config Format"
             } else {


### PR DESCRIPTION
**Issue:**
Customer reported an issue that handled, but falsely reported it wasn't. This was due to the missing `Invoke-CatchActions` inside of a `catch` block in the analyzer. 

**Reason:**
We handled the error, therefore, we shouldn't have the customer report the problem. 

**Fix:**
Include `Invoke-CatchActions` within the `catch` block. 

**Validation:**
pester tested

