### PR TITLE
Add ScriptBlock Injection to handle Invoke-RemotePipelineHandler

### DIFF
--- a/Security/src/ConfigureFipFsTextExtractionOverrides/ConfigurationAction/Invoke-TextExtractionOverride.ps1
+++ b/Security/src/ConfigureFipFsTextExtractionOverrides/ConfigurationAction/Invoke-TextExtractionOverride.ps1
@@ -1,6 +1,9 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+. $PSScriptRoot\..\..\..\..\Shared\ScriptBlockFunctions\Add-ScriptBlockInjection.ps1
+. $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
+
 function Invoke-TextExtractionOverride {
     [CmdletBinding()]
     param(
@@ -17,7 +20,6 @@ function Invoke-TextExtractionOverride {
     begin {
         $remoteScriptBlockExecute = {
             param($ArgumentList)
-            . $PSScriptRoot\..\..\..\..\Shared\Get-RemoteRegistryValue.ps1
             . $PSScriptRoot\..\..\Shared\Invoke-StartStopService.ps1
             . $PSScriptRoot\..\..\Shared\Invoke-XmlConfigurationRemoteAction.ps1
 
@@ -296,6 +298,13 @@ function Invoke-TextExtractionOverride {
         }
     }
     process {
+        $params = @{
+            PrimaryScriptBlock = $remoteScriptBlockExecute
+            IncludeScriptBlock = @(${Function:Get-RemoteRegistryValue},
+                ${Function:Get-RemoteRegistrySubKey},
+                ${Function:Invoke-RemotePipelineHandler})
+        }
+        $remoteScriptBlockExecute = Add-ScriptBlockInjection @params
         $results = Invoke-Command -ComputerName $ComputerName -ScriptBlock $remoteScriptBlockExecute -ArgumentList ([PSCustomObject]@{
                 ConfigureOverride = $ConfigureOverride
                 Action            = $Action


### PR DESCRIPTION
**Issue:**
Missing `Invoke-RemotePipelineHandler` because it is inside a script block that is needed to be run remotely. 

**Reason:**
`Invoke-RemotePipelineHandler` needs to be both inside a remote `ScriptBlock` to get executed on the server as well as in the main script

**Fix:**
Use `Add-ScriptBlockInjection` to combined the required functions and make sure `Invoke-RemotePipelineHandler` is loaded outside of the script block

Resolved #2390 

**Validation:**
Lab tested 

