### PR TITLE
Handle null result from failing to connect to server with Invoke-Command

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
@@ -128,12 +128,15 @@ function Get-HealthCheckerDataCollection {
                     }
                 Write-Verbose "Took $(([DateTime]::Now) - $startTime) to execute the Invoke-Command test for server name"
 
-                foreach ($passed in $invokeCommandResults) {
-                    $key = $getExchangeServerListToTestFQDN.Values | Where-Object { $_.Name -eq $passed.PSComputerName }
-                    $getExchangeServerList.Add($passed.PSComputerName, $getExchangeServerListToTestFQDN[$key.FQDN])
-                    $getExchangeServerListToTestFQDN.Remove($key.FQDN)
+                if ($invokeCommandResults.Count -gt 0) {
+                    foreach ($passed in $invokeCommandResults) {
+                        $key = $getExchangeServerListToTestFQDN.Values | Where-Object { $_.Name -eq $passed.PSComputerName }
+                        $getExchangeServerList.Add($passed.PSComputerName, $getExchangeServerListToTestFQDN[$key.FQDN])
+                        $getExchangeServerListToTestFQDN.Remove($key.FQDN)
+                    }
+                    Write-Verbose "Successfully was able to get the following servers for server name: $([string]::Join(", ", [array]$invokeCommandResults.PSComputerName))"
                 }
-                Write-Verbose "Successfully was able to get the following servers for server name: $([string]::Join(", ", [array]$invokeCommandResults.PSComputerName))"
+
                 Write-Verbose "Failed to get from the following servers for server name: $([string]::Join(", ", [array]$getExchangeServerListToTestFQDN.Keys))"
 
                 if ($getExchangeServerListToTestFQDN.Count -gt 0) {


### PR DESCRIPTION
If we can't connect to an Exchange Server remotely with both FQDN and BIOSName with Invoke-Command, we need to properly handle this

**Issue:**
Customer reported and issue facing this problem: 

```
 : Exception calling "Join" with "2" argument(s): "Value cannot be null.
Parameter name: values"
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.PSScriptCmdlet.DoProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
Position Message: At C:\HealthCheckerBETA.ps1:10968 char:102
+ ... ver name: $([string]::Join(", ", [array]$invokeCommandResults.PSCompu ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Get-HealthCheckerDataCollection<Process>, C:\HealthCheckerBETA.ps1: line 10968
at Invoke-HealthCheckerMainReport, C:\HealthCheckerBETA.ps1: line 19797
at <ScriptBlock><End>, C:\HealthCheckerBETA.ps1: line 20678
at <ScriptBlock>, <No file>: line 1
```

Determined that we are failing here: https://github.com/microsoft/CSS-Exchange/blob/0014a2913bf0591bb12a3c2aca97ed204db900d0/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1#L136

**Reason:**
We need to be able to handle this, since this array can be `null`, we need to handle this. 

**Fix:**
Do a count check on `$invokeCommandResults` to make sure it is greater than 0. 

**Validation:**
Customer tested that reported the issue
