### PR TITLE
Use Invoke-JobAnalyzerEngine with AnalyzeDataOnly

### DIFF
--- a/Diagnostics/HealthChecker/HealthChecker.ps1
+++ b/Diagnostics/HealthChecker/HealthChecker.ps1
@@ -258,9 +258,9 @@ begin {
 
             $analyzedResults = @()
             foreach ($serverData in $importData) {
-                $analyzedServerResults = Invoke-AnalyzerEngine -HealthServerObject $serverData.HealthCheckerExchangeServer
-                Write-ResultsToScreen -ResultsToWrite $analyzedServerResults.DisplayResults
-                $analyzedResults += $analyzedServerResults
+                $analyzedServerResults = Invoke-JobAnalyzerEngine -HealthServerObject $serverData.HealthCheckerExchangeServer
+                Write-ResultsToScreen -ResultsToWrite $analyzedServerResults.HCAnalyzedResults.DisplayResults
+                $analyzedResults += $analyzedServerResults.HCAnalyzedResults
             }
 
             Get-HtmlServerReport -AnalyzedHtmlServerValues $analyzedResults.HtmlServerValues -HtmlOutFilePath $htmlOutFilePath


### PR DESCRIPTION
**Issue:**
Running into an issue with `AnalyzeDataOnly` due to missing `Invoke-AnalyzerEngine` because it is within `Invoke-JobAnalyzerEngine` function to make it easier to build out the script block for jobs on down the road. 


**Fix:**
Call `Invoke-JobAnalyzerEngine` instead of `Invoke-AnalyzerEngine` and handle the correct data type coming back. 

**Validation:**
Lab tested

