### PR TITLE
Only show disabled by override when it is enabled

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25005.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25005.ps1
@@ -44,7 +44,7 @@ function Invoke-AnalyzerSecurityCve-2025-25005 {
                 AnalyzedInformation = $AnalyzeResults
                 DisplayGroupingKey  = $DisplayGroupingKey
                 Name                = "Security Vulnerability"
-                Details             = ("{0} - Override Is Set: $overrideDisabled`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25005")
+                Details             = ("{0}$(if($overrideDisabled){" - Disabled By Override"})`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25005")
                 DisplayWriteType    = "Red"
                 DisplayTestingValue = "CVE-2025-25005"
             }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25006.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25006.ps1
@@ -44,7 +44,7 @@ function Invoke-AnalyzerSecurityCve-2025-25006 {
                 AnalyzedInformation = $AnalyzeResults
                 DisplayGroupingKey  = $DisplayGroupingKey
                 Name                = "Security Vulnerability"
-                Details             = ("{0} - Override Is Set: $overrideDisabled`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25006")
+                Details             = ("{0}$(if($overrideDisabled){" - Disabled By Override"})`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25006")
                 DisplayWriteType    = "Red"
                 DisplayTestingValue = "CVE-2025-25006"
             }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25007.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-25007.ps1
@@ -44,7 +44,7 @@ function Invoke-AnalyzerSecurityCve-2025-25007 {
                 AnalyzedInformation = $AnalyzeResults
                 DisplayGroupingKey  = $DisplayGroupingKey
                 Name                = "Security Vulnerability"
-                Details             = ("{0} - Override Is Set: $overrideDisabled`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25007")
+                Details             = ("{0}$(if($overrideDisabled){" - Disabled By Override"})`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-25007")
                 DisplayWriteType    = "Red"
                 DisplayTestingValue = "CVE-2025-25007"
             }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-33051.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCve-2025-33051.ps1
@@ -44,7 +44,7 @@ function Invoke-AnalyzerSecurityCve-2025-33051 {
                 AnalyzedInformation = $AnalyzeResults
                 DisplayGroupingKey  = $DisplayGroupingKey
                 Name                = "Security Vulnerability"
-                Details             = ("{0} - Override Is Set: $overrideDisabled`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-33051")
+                Details             = ("{0}$(if($overrideDisabled){" - Disabled By Override"})`r`n`t`tSee: https://portal.msrc.microsoft.com/security-guidance/advisory/{0} for more information." -f "CVE-2025-33051")
                 DisplayWriteType    = "Red"
                 DisplayTestingValue = "CVE-2025-33051"
             }


### PR DESCRIPTION
**Issue:**
There was some confusion about if an override needs to be applied prior to SU being applied. 

**Reason:**
Remove confusion. 

**Fix:**
Only display override information if it is the cause for the vulnerability. 

**Validation:**
Lab tested

