### PR TITLE
Fixed bug with AMSI detection due to missing ()

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityAMSIConfigState.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityAMSIConfigState.ps1
@@ -110,8 +110,8 @@ function Invoke-AnalyzerSecurityAMSIConfigState {
         [array]$enabledAllValues = $amsiRequestBodyScanning | Where-Object { $_.ParameterName -eq "EnabledAll" }
         $defaultEnabledAll = $isAug25SuOrGreater -and ($null -eq ($enabledAllValues | Where-Object { $_.ParameterValue -eq "False" }))
         Write-Verbose "Enabled All Default Value Set to '$defaultEnabledAll'"
-        $amsiRequestBodyScanningEnabled = $defaultEnabledAll -or $amsiRequestBodyScanning.Count -gt 0 -and
-        ($null -ne ($amsiRequestBodyScanning | Where-Object { $_.ParameterValue -eq "True" }))
+        $amsiRequestBodyScanningEnabled = $defaultEnabledAll -or ($amsiRequestBodyScanning.Count -gt 0 -and
+            ($null -ne ($amsiRequestBodyScanning | Where-Object { $_.ParameterValue -eq "True" })))
         $amsiBlockRequestBodyEnabled = $amsiBlockRequestBodyGreater.Count -gt 0 -and
         ($null -ne ($amsiBlockRequestBodyGreater | Where-Object { $_.ParameterValue -eq "True" }))
         $requestBodyDisplayValue = $amsiStateEnabled -and $amsiRequestBodyScanningEnabled


### PR DESCRIPTION
**Issue:**
AMSI BodyScanning not properly being detected.

**Fix:**
Add in the missing () to have `$requestBodyDisplayValue` properly detect the true value that it should be. 
Resolved #2407 

**Validation:**
Lab tested 

