### PR TITLE
Fix #2289: Handle deserialization issue in Get-ExchangeVersion

### DIFF
--- a/Databases/VSSTester/ExchangeInformation/Get-ExchangeVersion.ps1
+++ b/Databases/VSSTester/ExchangeInformation/Get-ExchangeVersion.ps1
@@ -11,8 +11,17 @@ function Get-ExchangeVersion {
 
     Write-Host "$(Get-Date) Verifying Exchange version..."
     $exchVer = (Get-ExchangeServer $ServerName).AdminDisplayVersion
-    $exchVerMajor = $exchVer.major
-    $exchVerMinor = $exchVer.minor
+    if ($exchVer -is [string]) {
+    # Agar string hai (deserialize ho gaya), split karke major/minor nikal lo
+    $parts = $exchVer.Split('.')
+    $exchVerMajor = [int]$parts[0]
+    $exchVerMinor = if ($parts.Count -gt 1) { [int]$parts[1] } else { 0 }
+} else {
+    # Agar object hai, normal property access
+    $exchVerMajor = $exchVer.Major
+    $exchVerMinor = $exchVer.Minor
+}
+
 
     switch ($exchVerMajor) {
         "14" {


### PR DESCRIPTION
## Problem
`VSSTester.ps1` was failing on Exchange 2016 because `(Get-ExchangeServer $ServerName).AdminDisplayVersion` sometimes returns a string instead of a `System.Version` object.  
This caused `$exchVer.Major` and `$exchVer.Minor` to throw errors.

## Fix
Added a type check in `Get-ExchangeVersion.ps1`:
- If `$exchVer` is a string, parse it with `.Split('.')` to extract **Major** and **Minor** versions.  
- If `$exchVer` is a `System.Version` object, continue using `.Major` and `.Minor`.

## Test
- Verified that the function now handles both object and string return types without failing.  
- Code tested to ensure Exchange version detection works correctly for **Exchange 2013, 2016, and 2019**.

## Related Issue
Fixes #2289
