### PR TITLE
Don't attempt to analyze if no data was able to be collected

### DIFF
--- a/Diagnostics/HealthChecker/Features/Invoke-HealthCheckerMainReport.ps1
+++ b/Diagnostics/HealthChecker/Features/Invoke-HealthCheckerMainReport.ps1
@@ -29,14 +29,16 @@ function Invoke-HealthCheckerMainReport {
     Invoke-ErrorCatchActionLoopFromIndex $currentErrors
     [array]$hcDataCollection = Get-HealthCheckerDataCollection $ServerNames
     # ForceLegacy is only supported running locally on the problem server which will execute in the current session.
-    if ($hcDataCollection.Count -eq 1) {
+    if ($null -eq $hcDataCollection) {
+        Write-Verbose "Get-HealthCheckerDataCollection returned null. Exit now."
+        return
+    } elseif ($hcDataCollection.Count -eq 1) {
         $runType = "CurrentSession"
     } else {
         $runType = "StartNow"
     }
     $analyzedEngineResults = Invoke-AnalyzerEngineHandler -ServerDataCollection $hcDataCollection -RunType $runType
 
-    # TODO: Handle this better.
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
     $stopWatchWrite = New-Object System.Diagnostics.Stopwatch
     $stopWatchToScreen = New-Object System.Diagnostics.Stopwatch


### PR DESCRIPTION
**Issue:**
When there was a major error and no data is collected, don't attempt to analyze the results.

**Reason:**
Don't want to provide an error to the screen that isn't the main concern. 

**Fix:**
Return out of the function right away when no data was collected.

**Validation:**
Lab tested

