### PR TITLE
Handle empty string for Test-Path

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeAppPoolsInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/IISInformation/Get-ExchangeAppPoolsInformation.ps1
@@ -19,17 +19,14 @@ function Get-ExchangeAppPoolsInformation {
         Where-Object { $_.add.name -like "MSExchange*" } |
         ForEach-Object {
             Write-Verbose "Working on App Pool: $($_.add.name)"
-            $scriptBlock = {
-                param(
-                    $FilePath
-                )
-                if (Test-Path $FilePath) {
-                    return (Get-Content $FilePath -Raw -Encoding UTF8).Trim()
-                }
-                return [string]::Empty
+            $clrConfigFilePath = $_.add.CLRConfigFile
+
+            if ((-not ([string]::IsNullOrEmpty($clrConfigFilePath))) -and (Test-Path $clrConfigFilePath)) {
+                $configContent = (Get-Content $clrConfigFilePath -Raw -Encoding UTF8).Trim()
+            } else {
+                $configContent = [string]::Empty
             }
 
-            $configContent = & $scriptBlock $_.add.CLRConfigFile
             $gcUnknown = $true
             $gcServerEnabled = $false
 


### PR DESCRIPTION
**Issue:**
Customer reported this issue

```
----------------Error Information----------------
Error Origin Info: ex2k19.contoso.com
Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
Inner Exception: System.Management.Automation.RemoteException: Cannot bind argument to parameter 'Path' because it is an empty string.
Position Message: At C:\HealthChecker.ps1:10843 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:2290 char:31
+                 if (Test-Path $FilePath) {
+                               ~~~~~~~~~
Script Stack: at <ScriptBlock>, <No file>: line 2290
at <ScriptBlock>, <No file>: line 2296
at Get-ExchangeAppPoolsInformation, <No file>: line 2282
at Invoke-JobExchangeInformationLocal<Process>, <No file>: line 3054
at <ScriptBlock>, <No file>: line 3161
-------------------------------------------------
```

**Reason:**
We need to have the job complete as best as possible. 

**Fix:**
Properly handle this issue. Need to do a `IsNullOrEmpty` check prior to `Test-Path`

**Validation:**
Lab and customer tested

