### PR TITLE
Edge Server to be at least 64GB of RAM

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHardwareInformation.ps1
@@ -261,11 +261,12 @@ function Invoke-AnalyzerHardwareInformation {
 
         if ($totalPhysicalMemory -gt 256) {
             $displayDetails = "{0} GB `r`n`t`tWarning: We recommend for the best performance to be scaled at or below 256 GB of Memory" -f $totalPhysicalMemory
+        } elseif ($totalPhysicalMemory -lt 128 -and
+            $exchangeInformation.GetExchangeServer.IsEdgeServer -eq $false) {
+            $displayDetails = "{0} GB `r`n`t`tWarning: We recommend for the best performance to have a minimum of 128GB of RAM installed on the machine." -f $totalPhysicalMemory
         } elseif ($totalPhysicalMemory -lt 64 -and
             $exchangeInformation.GetExchangeServer.IsEdgeServer -eq $true) {
             $displayDetails = "{0} GB `r`n`t`tWarning: We recommend for the best performance to have a minimum of 64GB of RAM installed on the machine." -f $totalPhysicalMemory
-        } elseif ($totalPhysicalMemory -lt 128) {
-            $displayDetails = "{0} GB `r`n`t`tWarning: We recommend for the best performance to have a minimum of 128GB of RAM installed on the machine." -f $totalPhysicalMemory
         } else {
             $displayDetails = "{0} GB" -f $totalPhysicalMemory
             $displayWriteType = "Grey"


### PR DESCRIPTION
**Issue:**
Edge Server still recommends 128GB of RAM. Where we do support 64GB for a min. 

**Reason:**
Be in line with support docs. 

**Fix:**
Properly check Edge Server to be at least 64GB of Memory. 

Resolved #2286 

**Validation:**
Lab tested

