### PR TITLE
Get-SmbServerConfiguration add to try catch block

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-Smb1ServerSettings.ps1
@@ -14,7 +14,13 @@ function Get-Smb1ServerSettings {
         $windowsFeature = $null
     }
     process {
-        $smbServerConfiguration = Get-SmbServerConfiguration
+
+        try {
+            $smbServerConfiguration = Get-SmbServerConfiguration -ErrorAction Stop
+        } catch {
+            Write-Verbose "Failed to run Get-SmbServerConfiguration. Inner Exception: $_"
+            Invoke-CatchActionError
+        }
 
         if ($null -ne $GetWindowsFeature -and
             $GetWindowsFeature.Count -gt 0) {


### PR DESCRIPTION
**Issue:**
Issue was reported of the following: 

```
----Errors that occurred that wasn't handled----
[09/18/2025 22:03:49] : Error Index: 0
[09/18/2025 22:03:49] : 

----------------Error Information----------------
Error Origin Info: exch01.contoso.com
Get-SmbServerConfiguration : Data of this type is not supported. 
Inner Exception: System.Management.Automation.RemoteException: Data of this type is not supported. 
Position Message: At C:\HealthChecker.ps1:10840 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:2508 char:35
+         $smbServerConfiguration = Get-SmbServerConfiguration
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Wait-JobQueue<Process>, C:\HealthChecker.ps1: line 10840
at Get-HealthCheckerDataCollection<Process>, C:\HealthChecker.ps1: line 11135
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 19813
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 20709
at <ScriptBlock>, <No file>: line 1
-------------------------------------------------
```

**Reason:**
Need to have the script complete.

**Fix:**
Place the `Get-SmbServerConfiguration` within a `try` `catch` block and call `Invoke-CatchActionError` to handle the error.

**Validation:**
Lab tested

