### PR TITLE
Use [DateTime]::Now vs Script variable

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -73,7 +73,7 @@ function Invoke-AnalyzerExchangeInformation {
     }
 
     if ($exchangeInformation.BuildInformation.VersionInformation.Supported -eq $false) {
-        $daysOld = ($date - $exchangeInformation.BuildInformation.VersionInformation.ReleaseDate).Days
+        $daysOld = (([DateTime]::Now) - $exchangeInformation.BuildInformation.VersionInformation.ReleaseDate).Days
 
         $params = $baseParams + @{
             Name                   = "Error"

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerNicSettings.ps1
@@ -18,6 +18,7 @@ function Invoke-AnalyzerNicSettings {
 
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
     Write-Verbose "Calling: $($MyInvocation.MyCommand)"
+    $currentTime = [DateTime]::Now
     $baseParams = @{
         AnalyzedInformation = $AnalyzeResults
         DisplayGroupingKey  = (Get-DisplayResultsGroupingKey -Name "NIC Settings Per Active Adapter"  -DisplayOrder $Order -DefaultTabNumber 2)
@@ -52,7 +53,7 @@ function Invoke-AnalyzerNicSettings {
                 if ($null -eq $driverDate -or
                     $driverDate -eq [DateTime]::MaxValue) {
                     $detailsValue = "Unknown"
-                } elseif ((New-TimeSpan -Start $date -End $driverDate).Days -lt [int]-365) {
+                } elseif ((New-TimeSpan -Start $currentTime -End $driverDate).Days -lt [int]-365) {
                     $params = $baseParams + @{
                         Details          = "Warning: NIC driver is over 1 year old. Verify you are at the latest version."
                         DisplayWriteType = "Yellow"


### PR DESCRIPTION
**Issue:**
Customer reported an issue trying to run the analyzer against a server. 

```
----------------Error Information----------------
Error Origin Info: EX02.contoso.com
New-TimeSpan : Cannot bind parameter 'Start' to the target. Exception setting "Start": "Cannot convert null to type "System.DateTime"."
Inner Exception: System.Management.Automation.RemoteException: Cannot bind parameter 'Start' to the target. Exception setting "Start": "Cannot convert null to type "System.DateTime"."
Position Message: At c:\HealthChecker.ps1:10846 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:5917 char:48
+                 } elseif ((New-TimeSpan -Start $date -End $driverDate ...
+                                                ~~~~~
Script Stack: at Invoke-AnalyzerNicSettings, <No file>: line 5917
at Invoke-AnalyzerEngine, <No file>: line 10175
at Invoke-JobAnalyzerEngine<Process>, <No file>: line 10190
at <ScriptBlock>, <No file>: line 10208
-------------------------------------------------
```

**Reason:**
Want the script to be able to work properly remotely and not report that there was a problem. 

**Fix:**
Need to use a method due to the variable not being set in jobs

**Validation:**
Pester tested

