### PR TITLE
TlsAuthLevel set to string type by default

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Get-ExchangeConnectorCustomObject.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-ExchangeConnectorCustomObject.ps1
@@ -32,6 +32,7 @@ function Get-ExchangeConnectorCustomObject {
             $goodTlsCertificateSyntax = $false
             $tlsCertificateNameStatus = "TlsCertificateNameEmpty"
             $certificateLifetimeInformation = @{}
+            $tlsAuthLevel = $null
 
             if ($null -ne $currentConnector.TlsCertificateName) {
 
@@ -85,6 +86,10 @@ function Get-ExchangeConnectorCustomObject {
                 }
             }
 
+            if ($null -ne $currentConnector.TlsAuthLevel) {
+                $tlsAuthLevel = $currentConnector.TlsAuthLevel.ToString()
+            }
+
             [PSCustomObject]@{
                 Identity           = $currentConnector.Identity
                 Name               = $currentConnector.Name
@@ -96,7 +101,7 @@ function Get-ExchangeConnectorCustomObject {
                 SmartHosts         = $currentConnector.SmartHosts
                 AddressSpaces      = $currentConnector.AddressSpaces
                 RequireTls         = $currentConnector.RequireTls
-                TlsAuthLevel       = $currentConnector.TlsAuthLevel
+                TlsAuthLevel       = $tlsAuthLevel
                 TlsDomain          = $currentConnector.TlsDomain
                 CertificateDetails = [PSCustomObject]@{
                     CertificateMatchDetected = $certificateMatchDetected

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectorCustomObject.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeConnectorCustomObject.Tests.ps1
@@ -253,7 +253,8 @@ Describe "Testing Get-ExchangeConnectorCustomObject" {
                     $_.Name | Should -Be "My company to Office 365"
                     $_.RequireTLS | Should -Be $true
                     # 1 = EncryptionOnly; 2 = CertificateValidation; 3 = DomainValidation
-                    $_.TlsAuthLevel | Should -Be 2
+                    # Now forcing the use of property to be a string, this is the correct way to do this.
+                    $_.TlsAuthLevel | Should -Be "CertificateValidation"
                 }
                 { ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($_.AddressSpaces)) } {
                     $addressSpacesContainsWildcard = $true


### PR DESCRIPTION
**Issue:**
`TLSAuthLevel` not being properly detected, this is due to the job returning an object that needs to be converted manually to a string. This results in incorrectly detecting the Hybrid Connector for the internet setting. 

**Reason:**
We should report this correctly. 

**Fix:**
When we build out the object for the connector, convert the `TLSAuthLevel` to a string object, as that is what we use to compare. 

Resolved #2433 

**Validation:**
Lab tested

