### PR TITLE
Handle server begin offline in Extended Protection

### DIFF
--- a/Shared/IISFunctions/ExtendedProtection/Get-ExtendedProtectionConfiguration.ps1
+++ b/Shared/IISFunctions/ExtendedProtection/Get-ExtendedProtectionConfiguration.ps1
@@ -69,7 +69,8 @@ function Get-ExtendedProtectionConfiguration {
         }
 
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
-
+    }
+    process {
         $computerResult = Invoke-ScriptBlockHandler -ComputerName $ComputerName -ScriptBlock { return $env:COMPUTERNAME }
         $serverConnected = $null -ne $computerResult
 
@@ -110,8 +111,7 @@ function Get-ExtendedProtectionConfiguration {
             # Hopefully the caller knows what they are doing, best be from the correct server!!
             Write-Verbose "Caller passed the application host config."
         }
-    }
-    process {
+
         $params = @{
             ApplicationHostConfig = $ApplicationHostConfig
             ExSetupVersion        = $ExSetupVersion


### PR DESCRIPTION
**Issue:**
When a server is offline, we fail to execute the script as before the change with making the script multi-threaded for HC. This is because we do a `return` inside the `begin` section the `process` still executes. The previous change now always executes the next call due to us not being inside of a `foreach` loop like before. 

**Reason:**
Avoid having the script fail due to the remote server being down. 

**Fix:**
Move the logic into the `process` section of the method. 

**Validation:**
Lab tested

