### PR TITLE
Add null check for GetAuthServer type

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -32,11 +32,13 @@ function Invoke-AnalyzerHybridInformation {
     $getPartnerApplication = $HealthServerObject.OrganizationInformation.GetPartnerApplication
 
     [array]$evoStsAuthServer = $HealthServerObject.OrganizationInformation.GetAuthServer | Where-Object {
+        $null -ne $_.Type -and
         $_.Type.ToString() -eq "AzureAD" -and
         $_.Enabled -eq $true
     }
 
     [array]$acsAuthServer = $HealthServerObject.OrganizationInformation.GetAuthServer | Where-Object {
+        $null -ne $_.Type -and
         $_.Type.ToString() -eq "MicrosoftACS" -and
         $_.Enabled -eq $true
     }


### PR DESCRIPTION
**Issue:**
There were a few customers who reported the following error: 

```
----------------Error Information----------------
 : You cannot call a method on a null-valued expression.
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Object[] args)
   at System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   at System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   at System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   at System.Management.Automation.ScriptBlock.DoInvokeReturnAsIs(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Object[] args)
   at Microsoft.PowerShell.Commands.WhereObjectCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
Position Message: At C:\HealthChecker.ps1:12624 char:9
+         $_.Type.ToString() -eq "AzureAD" -and
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at <ScriptBlock>, C:\HealthChecker.ps1: line 12624
at Invoke-AnalyzerHybridInformation, C:\HealthChecker.ps1: line 12623
at Invoke-AnalyzerEngine, C:\HealthChecker.ps1: line 19569
at Invoke-JobAnalyzerEngine<Process>, C:\HealthChecker.ps1: line 19587
at Invoke-AnalyzerEngineHandler<Process>, C:\HealthChecker.ps1: line 19709
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 19835
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 20721
at <ScriptBlock>, <No file>: line 1
-------------------------------------------------


----------------Error Information----------------
 : You cannot call a method on a null-valued expression.
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Object[] args)
   at System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   at System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   at System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   at System.Management.Automation.ScriptBlock.DoInvokeReturnAsIs(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Object[] args)
   at Microsoft.PowerShell.Commands.WhereObjectCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
Position Message: At C:\HealthChecker.ps1:12624 char:9
+         $_.Type.ToString() -eq "AzureAD" -and
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at <ScriptBlock>, C:\HealthChecker.ps1: line 12624
at Invoke-AnalyzerHybridInformation, C:\HealthChecker.ps1: line 12623
at Invoke-AnalyzerEngine, C:\HealthChecker.ps1: line 19569
at Invoke-JobAnalyzerEngine<Process>, C:\HealthChecker.ps1: line 19587
at Invoke-AnalyzerEngineHandler<Process>, C:\HealthChecker.ps1: line 19709
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 19835
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 20721
at <ScriptBlock>, <No file>: line 1
-------------------------------------------------
```

This issue was caused by the `Type` being `null` prior to doing a `ToString()`. This wasn't an issue before because we did have other comparisons in the statement prior to the Oct25SU release. 

This causes the script to fail out. 


**Fix:**
Add in a `null` check prior to making the property a string with the method `ToString()`

**Validation:**
Customer validated that it worked. 

