### PR TITLE
Define array type for a list variable

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerHybridInformation.ps1
@@ -283,7 +283,7 @@ function Invoke-AnalyzerHybridInformation {
             }
 
             # Filter any evoSTS auth servers which have the application identifier set to a guid as this indicates the dedicated hybrid app is configured
-            $dedicatedHybridAppAuthServer = $evoStsAuthServer | Where-Object { $_.ApplicationIdentifier -match $guidRegEx }
+            [array]$dedicatedHybridAppAuthServer = $evoStsAuthServer | Where-Object { $_.ApplicationIdentifier -match $guidRegEx }
 
             if ($dedicatedHybridAppAuthServer.Count -ge 1) {
                 foreach ($authServer in $dedicatedHybridAppAuthServer) {


### PR DESCRIPTION
**Issue:**
When running in a job, we need to define a type in PowerShell. Otherwise, the object doesn't work as expected in code when doing it in the main session vs the job session. 

**Fix:**
Set `array` type for the variable. 

**Validation:**
Lab verified

