### PR TITLE
Place Get-WinEvent within a try catch block

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-EventLogInformation.ps1
@@ -12,16 +12,21 @@ function Get-EventLogInformation {
 
         $results = @{}
         foreach ($log in @("Application", "System")) {
-            $lastLogEntry = Get-WinEvent -LogName $log -Oldest -MaxEvents 1
-            $listLog = Get-WinEvent -ListLog $log
-            $results.Add($log, ([PSCustomObject]@{
-                        LastLogEntry = $lastLogEntry.TimeCreated
-                        MaxSize      = $listLog.MaximumSizeInBytes
-                        FileSize     = $listLog.FileSize
-                        LogMode      = $listLog.LogMode.ToString()
-                        IsEnabled    = $listLog.IsEnabled
-                        LogFilePath  = $listLog.LogFilePath
-                    }))
+            try {
+                $lastLogEntry = Get-WinEvent -LogName $log -Oldest -MaxEvents 1
+                $listLog = Get-WinEvent -ListLog $log
+                $results.Add($log, ([PSCustomObject]@{
+                            LastLogEntry = $lastLogEntry.TimeCreated
+                            MaxSize      = $listLog.MaximumSizeInBytes
+                            FileSize     = $listLog.FileSize
+                            LogMode      = $listLog.LogMode.ToString()
+                            IsEnabled    = $listLog.IsEnabled
+                            LogFilePath  = $listLog.LogFilePath
+                        }))
+            } catch {
+                Write-Verbose "Failed to get Event Log '$log'. Inner Exception: $_"
+                Invoke-CatchActionError $CatchActionFunction
+            }
         }
 
         return $results


### PR DESCRIPTION
**Issue:**
Customer reported the following error being reported with running the script: 

```
----------------Error Information----------------
Error Origin Info: FQDN.contoso.com
 : The 'Get-WinEvent' command was found in the module 'Microsoft.PowerShell.Diagnostics', but the module could not be loaded. For more information, run 'Import-Module Microsoft.PowerShell.Diagnostics'.
Inner Exception: System.Management.Automation.RemoteException: The 'Get-WinEvent' command was found in the module 'Microsoft.PowerShell.Diagnostics', but the module could not be loaded. For more information, run 'Import-Module Microsoft.PowerShell.Diagnostics'.
Position Message: At C:\HealthChecker.ps1:10861 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:2006 char:29
+             $lastLogEntry = Get-WinEvent -LogName $log -Oldest -MaxEv ...
+                             ~~~~~~~~~~~~
Script Stack: at Get-EventLogInformation<Process>, <No file>: line 2006
at Invoke-JobOperatingSystemInformation<Process>, <No file>: line 2701
at <ScriptBlock>, <No file>: line 2738
-------------------------------------------------
```

This caused the script to fail.

**Reason:**
Properly handle any errors that we get trying to get the win event logs

**Fix:**
Places the `Get-WinEvent` cmdlet within a `try` `catch` block to handle the error and allow the script to continue. 

**Validation:**
Lab tested

