### PR TITLE
Add w3wp.exe to process exclusion list

### DIFF
--- a/Shared/Get-ExchAVExclusions.ps1
+++ b/Shared/Get-ExchAVExclusions.ps1
@@ -286,6 +286,7 @@ function Get-ExchAVExclusionsProcess {
         if ((Get-ExchangeServer $env:COMPUTERNAME).IsClientAccessServer -or (Get-ExchangeServer $env:COMPUTERNAME).IsMailboxServer) {
             $ProcessList.Add((Join-Path $ExchangePath 'Bin\Search\Ceres\HostController\hostcontrollerservice.exe'))
             $ProcessList.Add((Join-Path $env:SystemRoot '\System32\inetSrv\inetInfo.exe'))
+            $ProcessList.Add((Join-Path $env:SystemRoot '\System32\inetSrv\w3wp.exe'))
             $ProcessList.Add((Join-Path $ExchangePath 'Bin\Microsoft.Exchange.Directory.TopologyService.exe'))
         }
 


### PR DESCRIPTION
Defender injects his modules to w3wp. This is not supported per https://learn.microsoft.com/en-us/troubleshoot/exchange/administration/avoid-unsupported-integration-methods This will nor prevent AMSI module(s) to be loaded.

**Reason:**
Load Defender's AMSI module in supported way.

**Fix:**
Add w3wp to processes exclusions list 

**Validation:**
manual add to script in lab

