### PR TITLE
Add w3wp to Defender exclusions, remove code to avoid duplication w3w…

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -354,9 +354,6 @@ while ($currentDiff -gt 0) {
         # Test Exchange Processes for unexpected modules
         $ExchangeProcessList = Get-ExchAVExclusionsProcess -ExchangePath $ExchangePath -MsiProductMinor ([byte]$serverExchangeInstallDirectory.MsiProductMinor)
 
-        # Include w3wp process in the analysis
-        $ExchangeProcessList += (Join-Path $env:SystemRoot '\System32\inetSrv\W3wp.exe')
-
         # Gather all processes on the computer and filter by the Exchange Process List
         $ServerProcess = Get-Process | Where-Object { $ExchangeProcessList -contains $_.path } | Sort-Object -Property ProcessName
 

--- a/Shared/Get-ExchAVExclusions.ps1
+++ b/Shared/Get-ExchAVExclusions.ps1
@@ -286,6 +286,7 @@ function Get-ExchAVExclusionsProcess {
         if ((Get-ExchangeServer $env:COMPUTERNAME).IsClientAccessServer -or (Get-ExchangeServer $env:COMPUTERNAME).IsMailboxServer) {
             $ProcessList.Add((Join-Path $ExchangePath 'Bin\Search\Ceres\HostController\hostcontrollerservice.exe'))
             $ProcessList.Add((Join-Path $env:SystemRoot '\System32\inetSrv\inetInfo.exe'))
+            $ProcessList.Add((Join-Path $env:SystemRoot '\System32\inetSrv\w3wp.exe'))
             $ProcessList.Add((Join-Path $ExchangePath 'Bin\Microsoft.Exchange.Directory.TopologyService.exe'))
         }
 


### PR DESCRIPTION
Add w3wp to Defender exclusions, remove code to avoid duplication w3wp in Test script

**Issue:**
Defender injects his modules to w3wp. This is not supported per https://learn.microsoft.com/en-us/troubleshoot/exchange/administration/avoid-unsupported-integration-methods This will nor prevent AMSI module(s) to be

**Reason:**
Load Defender's AMSI module in supported way.

**Fix:**
Add w3wp to processes exclusions list

**Validation:**
manual add to script in lab

