### PR TITLE
Add null check for trying to find BinSearchFolders

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -565,7 +565,11 @@ function Invoke-AnalyzerIISInformation {
             $binSearchFolders = (([xml]($_.Content)).configuration.appSettings.add | Where-Object {
                     $_.key -eq "BinSearchFolders"
                 }).value
-            $paths = $binSearchFolders.Split(";").Trim()
+            $paths = $null
+
+            if ($null -ne $binSearchFolders) {
+                $paths = $binSearchFolders.Split(";").Trim()
+            }
             $installPath = $exchangeInformation.RegistryValues.MsiInstallPath
             foreach ($binTestPath in  @("bin", "bin\CmdletExtensionAgents", "ClientAccess\Owa\bin")) {
                 $testPath = [System.IO.Path]::Combine($installPath, $binTestPath)


### PR DESCRIPTION
**Issue:**
Got a report of Health Checker failing with the following error.

```
----------------Error Information----------------
 : You cannot call a method on a null-valued expression.
Inner Exception:    at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Object[] args)
   at System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   at System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   at System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   at System.Management.Automation.ScriptBlock.DoInvokeReturnAsIs(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Object[] args)
   at Microsoft.PowerShell.Commands.WhereObjectCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
Position Message: At C:\HealthChecker.ps1:15072 char:13
+             $paths = $binSearchFolders.Split(";").Trim()
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at <ScriptBlock>, C:\HealthChecker.ps1: line 15072
at Invoke-AnalyzerIISInformation, C:\HealthChecker.ps1: line 15066
at Invoke-AnalyzerEngine, C:\HealthChecker.ps1: line 19578
at Invoke-JobAnalyzerEngine<Process>, C:\HealthChecker.ps1: line 19589
at Invoke-AnalyzerEngineHandler<Process>, C:\HealthChecker.ps1: line 19711
at Invoke-HealthCheckerMainReport, C:\HealthChecker.ps1: line 19837
at <ScriptBlock><End>, C:\HealthChecker.ps1: line 20723
at <ScriptBlock>, <No file>: line 1
-------------------------------------------------
```

The cause was due to `BinSearchFolders` not existing within the `web.config` file that we are checking. Therefore, we need to add in a null check before we do a method on a null result.

**Fix:**
Do a `$null` check prior to doing a `Split(";")` 

**Validation:**
Was able to reproduce the issue in a lab and confirmed the fix.

