### PR TITLE
Handle missing module or problem with running Get-AuthenticodeSignature

### DIFF
--- a/.build/cspell-words.txt
+++ b/.build/cspell-words.txt
@@ -4,6 +4,7 @@ amsi
 Antispam
 anob
 asmx
+Authenticode
 authsspi
 autodiscover
 bincirc
@@ -45,7 +46,6 @@ fltmc
 freb
 FYDIBOHF
 GCDO
-Get-AuthenticodeSignature
 globalsequence
 Hashtable
 HHMM

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityIISModules.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityIISModules.ps1
@@ -37,10 +37,11 @@ function Invoke-AnalyzerSecurityIISModules {
                     $modulesWriteType = "Red"
 
                     $iisModulesOutputList.Add([PSCustomObject]@{
-                            Module = $m.Name
-                            Path   = $m.Path
-                            Signer = "N/A"
-                            Status = "Not signed"
+                            Module       = $m.Name
+                            Path         = $m.Path
+                            Signer       = "N/A"
+                            Status       = "Not signed"
+                            PathNotFound = $m.PathNotFound
                         })
                 } elseif (($m.SignatureDetails.IsMicrosoftSigned -eq $false) -or
                     ($m.SignatureDetails.SignatureStatus -ne 0) -and
@@ -97,6 +98,10 @@ function Invoke-AnalyzerSecurityIISModules {
                             "Red"
                         } elseif ($o.$p -ne 0) {
                             "Yellow"
+                        }
+                    } elseif ($p -eq "PathNotFound") {
+                        if ($o.$p -eq $true) {
+                            "Red"
                         }
                     }
                 }


### PR DESCRIPTION
**Issue:**
Customer has reported the following issue: 

```
----------------Error Information----------------
Error Origin Info: FQDN.contoso.com
Get-AuthenticodeSignature : File C:\Windows\Microsoft.NET\Framework\v2.0.50727\webengine.dll was not found.
Inner Exception: System.Management.Automation.RemoteException: File C:\Windows\Microsoft.NET\Framework\v2.0.50727\webengine.dll was not found.
Position Message: At c:\HealthChecker.ps1:10861 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:2679 char:42
+ ...   $allSignatures = Get-AuthenticodeSignature -FilePath $Modules.image
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at GetIISModulesSignatureStatus<Process>, <No file>: line 2679
at Get-IISModules<Process>, <No file>: line 2763
at Get-ExchangeServerIISSettings<Process>, <No file>: line 2866
at Invoke-JobExchangeInformationLocal<Process>, <No file>: line 3058
at <ScriptBlock>, <No file>: line 3158
-------------------------------------------------
```

This issue is caused by not handling a failure trying to grab all Authenticode Signature. The current failure is due to a missing module that was added.

Based off lab testing, this should have resolved in the EMS from not even working on the server based off of testing the next day, but initially I was able to reproduce and have the script function. However, later it didn't work. But we still need to address due to the fact that we could run the script remotely against the server if `Invoke-Command` does work. 

**Fix:**
Place `Get-AuthenticodeSignature` within a `try` `catch` block to handle the error of the missing module. Then if we fail, run `Get-AuthenticodeSignature` against each module when we need to set the `$signature` variable for modules that exist. 


**Validation:**
Lab tested

