### PR TITLE
Prevent trying to use the Exchange Snap-in against multiple servers

### DIFF
--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataCollection.ps1
@@ -179,6 +179,15 @@ function Get-HealthCheckerDataCollection {
 
         # Set the script variable for the name of the computer that we want to connect to for EMS
         $Script:PrimaryRemoteShellConnectionPoint = (Get-PSSession | Where-Object { $_.Availability -eq "Available" -and $_.State -eq "Opened" } | Select-Object -First 1).ComputerName
+
+        if ($null -eq $Script:PrimaryRemoteShellConnectionPoint) {
+            if ($orgRunType -eq "QueueJob") {
+                Write-Warning "Unsupported to use the snap-in to run Health Checker against multiple servers. You must use Remote Shell or EMS."
+                throw "Using Exchange Snap-In to run Health Checker with Jobs"
+            } else {
+                Write-Verbose "Using the Exchange Snap-in and we are using the current session, so this might work."
+            }
+        }
         $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
         $orgKey = "Invoke-JobOrganizationInformation"
         $hardwareKey = "Invoke-JobHardwareInformation"


### PR DESCRIPTION
**Issue:**
Customer reported the previous workflow with Health Checker is no longer working. 

Previous workflow: 
- Log in with Normal User account
- Run As PowerShell of Exchange Admin
- `Start-Process PowerShell -Verb RunAs` within PowerShell
- Add in the snap-in with the Admin version of PowerShell as the Exchange Admin
- Run the Health Checker with `Get-ExchangeServer | .\HealthChecker.ps1`

This is now breaking due to the jobs trying to connect to Remote Shell, that uses the parent session to get information from, but since we are using the snap-in, we don't have a session to reference. When trying to connect, we get errors like this: 

```
----------------Error Information----------------
Error Origin Info: localhost
New-PSSession : Cannot bind parameter 'ConnectionUri'. Cannot convert value "http:///powershell" to type "System.Uri". Error: "Invalid URI: The hostname could not be parsed."
Inner Exception: System.Management.Automation.RemoteException: Cannot bind parameter 'ConnectionUri'. Cannot convert value "http:///powershell" to type "System.Uri". Error: "Invalid URI: The hostname could not be parsed."
Position Message: At c:\HealthChecker.ps1:10861 char:25
+ ...             $result = Receive-Job $jobInfo.Job -ErrorVariable "JobErr ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Remote Position Message: At line:738 char:98
+ ... change -ConnectionUri "http://$ExchangeServerName/powershell" -Authen ...
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Script Stack: at Invoke-DefaultConnectExchangeShell<Process>, <No file>: line 738
at Invoke-JobExchangeInformationCmdlet<Begin>, <No file>: line 1369
at <ScriptBlock>, <No file>: line 1504
-------------------------------------------------
```


**Fix:**
Block the script from running when we detect the snap-in and trying to use `QueueJob` for the Exchange Cmdlets. 

**Validation:**
Lab tested

