### PR TITLE
Fix JWT validation regex pattern

### DIFF
--- a/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
+++ b/Security/src/CVE-2023-23397/CVE-2023-23397.ps1
@@ -472,7 +472,7 @@ begin {
             }
 
             # Check if we use an app secret or certificate by using regex to match Json Web Token (JWT)
-            if ($ApplicationInfo.AppSecret -match "^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)") {
+            if ($ApplicationInfo.AppSecret -match "^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$") {
                 $jwtParams = @{
                     CertificateThumbprint = $ApplicationInfo.CertificateThumbprint
                     CertificateStore      = "CurrentUser"

--- a/Shared/AzureFunctions/Convert-JsonWebTokenToObject.ps1
+++ b/Shared/AzureFunctions/Convert-JsonWebTokenToObject.ps1
@@ -4,7 +4,7 @@
 function Convert-JsonWebTokenToObject {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidatePattern("^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)")]
+        [ValidatePattern("^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")]
         [string]$Token
     )
 

--- a/Shared/AzureFunctions/Invoke-GraphApiRequest.ps1
+++ b/Shared/AzureFunctions/Invoke-GraphApiRequest.ps1
@@ -23,7 +23,7 @@ function Invoke-GraphApiRequest {
         $Body,
 
         [Parameter(Mandatory = $true)]
-        [ValidatePattern("^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)")]
+        [ValidatePattern("^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")]
         [string]$AccessToken,
 
         [Parameter(Mandatory = $false)]


### PR DESCRIPTION
**Issue:**
JWT validation pattern lead to script failures in some cases. It turned out that the regex had an issue.

Resolve #2405 

**Reason:**
Issue in regex pattern.

**Fix:**
Update regex pattern to match JWT (JWS, compact 3 parts) token:

JWS Compact Serialization is `BASE64URL(ProtectedHeader)`.`BASE64URL(Payload)`.`BASE64URL(Signature)`. 
Each part uses Base64URL chars only `(A–Z a–z 0–9 - _)` and no padding `=`.

**Validation:**
Lab

