### PR TITLE
Use Get-TransportService InternalTransportCertificateThumbprint instead of LDAP query

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Get-ExchangeCertificateCustomObject.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Get-ExchangeCertificateCustomObject.ps1
@@ -7,7 +7,7 @@ function Get-ExchangeCertificateCustomObject {
         [Parameter(ValueFromPipeline)]
         [object[]]$Certificate,
 
-        [object]$InternalTransportCertificate,
+        [string]$InternalTransportCertificateThumbprint,
 
         [object]$AuthConfig
     )
@@ -104,7 +104,7 @@ function Get-ExchangeCertificateCustomObject {
                     IsSanCertificate               = $null -ne $cert.DnsNameList -and ($cert.DnsNameList).Count -gt 1
                     Namespaces                     = $certDnsNameList
                     Services                       = $cert.Services
-                    IsInternalTransportCertificate = $null -ne $InternalTransportCertificate -and $cert.Thumbprint -eq $InternalTransportCertificate.Thumbprint
+                    IsInternalTransportCertificate = $null -ne $InternalTransportCertificateThumbprint -and $cert.Thumbprint -eq $InternalTransportCertificateThumbprint
                     IsCurrentAuthConfigCertificate = $isAuthConfigInfo
                     IsNextAuthConfigCertificate    = $isNextAuthCertificate
                     SetAsActiveAuthCertificateOn   = if ($isNextAuthCertificate) { $authConfig.NextCertificateEffectiveDate } else { $null }

--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityExchangeCertificates.ps1
@@ -266,19 +266,6 @@ function Invoke-AnalyzerSecurityExchangeCertificates {
             }
             Add-AnalyzedResultInformation @params
         }
-    } elseif ($exchangeInformation.GetExchangeServer.IsEdgeServer -eq $true) {
-        $params = $baseParams + @{
-            Name                   = "Valid Internal Transport Certificate Found On Server"
-            Details                = $false
-            DisplayCustomTabNumber = 1
-        }
-        Add-AnalyzedResultInformation @params
-
-        $params = $baseParams + @{
-            Details                = "We can't check for Internal Transport Certificate on Edge Transport Servers"
-            DisplayCustomTabNumber = 2
-        }
-        Add-AnalyzedResultInformation @params
     } else {
         $params = $baseParams + @{
             Name                   = "Valid Internal Transport Certificate Found On Server"

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
@@ -161,6 +161,12 @@ function Invoke-JobExchangeInformationCmdlet {
 
                 try {
                     $getTransportService = Get-TransportService -Identity $Server -ErrorAction Stop
+                    try {
+                        $exchangeCertificateInformation.InternalCertificateThumbprint = $getTransportService.InternalTransportCertificateThumbprint
+                    } catch {
+                        Write-Verbose "Failed to create the certificate object."
+                        Invoke-CatchActions
+                    }
                 } catch {
                     Write-Verbose "Failed to run Get-TransportService"
                     Invoke-CatchActions

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeCertificateCustomObject.Tests.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Tests/Get-ExchangeCertificateCustomObject.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
     Context "Valid Exchange Server Certificates Detected" {
         BeforeAll {
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "Valid Auth Certificate (using weak SHA1 Hash Algorithm) Detected" {
@@ -82,7 +82,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-ExchangeCertificate -MockWith { return Import-Clixml $Script:parentPath\Tests\DataCollection\GetExchangeCertificateWithoutAuth.xml }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "Get Auth Config But No Matching Certificate" {
@@ -99,7 +99,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-AuthConfig -MockWith { throw "Bad thing happened - Get-AuthConfig" }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig $null
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig $null
         }
 
         It "Unable To Find Valid Auth Certificate" {
@@ -116,7 +116,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-ExchangeCertificate -MockWith { return $null }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "No Custom certificate Object Returned" {
@@ -128,7 +128,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-ExchangeCertificate { Import-Clixml $Script:parentPath\Tests\DataCollection\GetExchangeCertificateBroken.xml }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "Should Successfully Import Certificates From RawData" {
@@ -146,7 +146,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-ExchangeCertificate -MockWith { throw "Bad thing happened - Get-ExchangeCertificate" }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "No Custom Certificate Object Returned And Exception Logged" {
@@ -159,7 +159,7 @@ Describe "Testing Get-ExchangeServerCertificateInformation & Get-ExchangeCertifi
         BeforeAll {
             Mock Get-ExchangeCertificate -MockWith { return Import-Clixml $Script:parentPath\Tests\DataCollection\GetExchangeCertificateOnAzure.xml }
             $info = Get-ExchangeServerCertificateInformation -Server $Script:Server
-            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -InternalTransportCertificate $info.InternalCertificate -AuthConfig (Get-AuthConfig)
+            $script:results = $info.Certificates | Get-ExchangeCertificateCustomObject -AuthConfig (Get-AuthConfig)
         }
 
         It "Should Not Return The 'Windows Azure CRP Certificate Generator' Certificate" {

--- a/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataObject.ps1
+++ b/Diagnostics/HealthChecker/Features/Get-HealthCheckerDataObject.ps1
@@ -38,14 +38,14 @@ function Get-HealthCheckerDataObject {
         if ($null -ne $ExchangeCmdletResult.ExchangeCertificateInformation) {
             $certs = ($ExchangeCmdletResult.ExchangeCertificateInformation.Certificates | ConvertTo-ExchangeCertificate -CatchActionFunction ${Function:Invoke-CatchActions})
             $certCustomParams = @{
-                InternalTransportCertificate = $ExchangeCmdletResult.ExchangeCertificateInformation.InternalCertificate
-                AuthConfig                   = $OrganizationInformationResult.GetAuthConfig
+                InternalTransportCertificateThumbprint = $ExchangeCmdletResult.ExchangeCertificateInformation.InternalCertificateThumbprint
+                AuthConfig                             = $OrganizationInformationResult.GetAuthConfig
             }
 
             $exchangeCertificateInformation = [PSCustomObject]@{
-                Certificates        = $certs
-                InternalCertificate = $ExchangeCmdletResult.ExchangeCertificateInformation.InternalCertificate
-                CustomCertificates  = ($certs | Get-ExchangeCertificateCustomObject @certCustomParams)
+                Certificates                  = $certs
+                InternalCertificateThumbprint = $ExchangeCmdletResult.ExchangeCertificateInformation.InternalCertificateThumbprint
+                CustomCertificates            = ($certs | Get-ExchangeCertificateCustomObject @certCustomParams)
             }
 
             [array]$connector = $OrganizationInformationResult.GetSendConnector

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.MockedCalls.Tests.ps1
@@ -30,7 +30,6 @@ Describe "Testing Health Checker by Mock Data Imports" {
             Mock Get-OwaVirtualDirectory { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOwaVirtualDirectory.xml" }
             Mock Get-WebServicesVirtualDirectory { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetWebServicesVirtualDirectory.xml" }
             Mock Get-OrganizationConfig { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetOrganizationConfig.xml" }
-            Mock Get-InternalTransportCertificateFromServer { return Import-Clixml "$Script:MockDataCollectionRoot\Exchange\GetInternalTransportCertificateFromServer.xml" }
             Mock Get-HybridConfiguration { return $null }
             Mock Get-PartnerApplication { return $null }
             Mock Get-ExchangeDiagnosticInfo -ParameterFilter { $Process -eq "Microsoft.Exchange.Directory.TopologyService" -and $Component -eq "VariantConfiguration" -and $Argument -eq "Overrides" } `

--- a/Shared/CertificateFunctions/Get-ExchangeServerCertificateInformation.ps1
+++ b/Shared/CertificateFunctions/Get-ExchangeServerCertificateInformation.ps1
@@ -1,7 +1,6 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-. $PSScriptRoot\..\ActiveDirectoryFunctions\Get-InternalTransportCertificateFromServer.ps1
 . $PSScriptRoot\..\ScriptBlockFunctions\RemotePipelineHandlerFunctions.ps1
 . $PSScriptRoot\..\Invoke-CatchActionError.ps1
 . $PSScriptRoot\ConvertTo-ExchangeCertificate.ps1
@@ -85,11 +84,6 @@ function Get-ExchangeServerCertificateInformation {
             $exchangeServerCertificates = $null
             Get-ExchangeCertificate -Server $Server -ErrorAction Stop | ConvertTo-ExchangeCertificate -CatchActionFunction $CatchActionFunction |
                 Invoke-RemotePipelineHandler -Result ([ref]$exchangeServerCertificates)
-
-            Write-Verbose "Trying to query internal transport certificate from AD for this server"
-            $internalTransportCertificate = $null
-            Get-InternalTransportCertificateFromServer -ComputerName $Server -CatchActionFunction $CatchActionFunction |
-                Invoke-RemotePipelineHandler -Result ([ref]$internalTransportCertificate)
         } catch {
             Write-Verbose "Failed to collect the Exchange Server Certificate Information on $server. Inner Exception: $_"
             Invoke-CatchActionError $CatchActionFunction
@@ -105,8 +99,8 @@ function Get-ExchangeServerCertificateInformation {
     }
     end {
         return [PSCustomObject]@{
-            Certificates        = $certObject
-            InternalCertificate = $internalTransportCertificate
+            Certificates                  = $certObject
+            InternalCertificateThumbprint = $null
         }
     }
 }

--- a/docs/Diagnostics/HealthChecker/InternalTransportCertificateCheck.md
+++ b/docs/Diagnostics/HealthChecker/InternalTransportCertificateCheck.md
@@ -6,6 +6,8 @@ The Internal Transport Certificate in Exchange Server is used in Exchange Server
 
 A missing Internal Transport Certificate can lead to a broken MailFlow on or with the affected machine. It's therefore essential to have a valid certificate for this purpose on the machine. We recommend to not replace the self-signed certificate which was created by Exchange itself.
 
+Health Checker gets the Internal Transport Certificate by running `Get-TransportService` if this has failed to run, this would also result in the failed to find the Internal Transport Certificate.
+
 ### What does the check do?
 
 The check queries the certificate which is marked as Internal Transport Certificate on the server against which the script is currently running. The script will throw a warning if the certificate cannot be found on the machine. It must then be recreated by the Exchange Server administrator and set as new Internal Transport Certificate.


### PR DESCRIPTION
**Issue:**
We are unable to use LDAP query to get the `InternalTransportCertificateThumbprint` from the Edge Server, so using `Get-TransportService` is the better option. Plus, this cuts out another scenario that is broken with multi forest. 

**Fix:**
Instead of getting the `InternalTransportCertificateThumbprint` with `Get-InternalTransportCertificateFromServer` where it is doing an LDAP query, we are going to just use `Get-TransportService`, which is already being collected

Resolved #1455
Resolved #2324

**Validation:**
Lab tested

