### PR TITLE
Include simple check for root public folder mailbox

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -488,5 +488,24 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
             Add-AnalyzedResultInformation @params
         }
     }
+
+    if ($null -ne $organizationInformation.RootPublicFolderMailbox) {
+        $rootPfMailbox = $organizationInformation.RootPublicFolderMailbox
+        $displayWriteType = "Grey"
+        $details = $true
+
+        if ($rootPfMailbox.IsExcludedFromServingHierarchy -ne $true) {
+            $displayWriteType = "Red"
+            $details = "false - Error"
+        }
+
+        $params = $baseParams + @{
+            Name             = "Root Public Folder Mailbox Serving Hierarchy"
+            Details          = $details
+            DisplayWriteType = $displayWriteType
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
     Write-Verbose "Completed: $($MyInvocation.MyCommand) and took $($stopWatch.Elapsed.TotalSeconds) seconds"
 }

--- a/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Invoke-JobOrganizationInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/OrganizationInformation/Invoke-JobOrganizationInformation.ps1
@@ -167,6 +167,24 @@ function Invoke-JobOrganizationInformation {
                 Invoke-CatchActions
             }
 
+            try {
+                if ($null -ne $getOrganizationConfig -and $null -ne $getOrganizationConfig.RootPublicFolderMailbox) {
+                    [string]$guid = $getOrganizationConfig.RootPublicFolderMailbox
+                    Write-Verbose "Trying to collect root public folder mailbox information - $guid"
+                    $getMailboxRootPF = Get-Mailbox -PublicFolder $guid -ErrorAction Stop
+                    $rootPublicFolderMailbox = [PSCustomObject]@{
+                        Name                           = $getMailboxRootPF.Name
+                        ExchangeGuid                   = $getMailboxRootPF.ExchangeGuid
+                        IsExcludedFromServingHierarchy = $getMailboxRootPF.IsExcludedFromServingHierarchy
+                        IsHierarchyReady               = $getMailboxRootPF.IsHierarchyReady
+                        IsHierarchySyncEnabled         = $getMailboxRootPF.IsHierarchySyncEnabled
+                    }
+                }
+            } catch {
+                Write-Verbose "Failed to get the public folder mailbox. Inner Exception: $_"
+                Invoke-CatchActions
+            }
+
             [array]$globalMonitoringOverride = Get-MonitoringOverride -CatchActionFunction ${Function:Invoke-CatchActions}
 
             # AD Queries
@@ -283,6 +301,7 @@ function Invoke-JobOrganizationInformation {
             GetAuthServer                     = $getAuthServer
             GetSendConnector                  = $getSendConnector
             TrustedDomain                     = $trustedDomainResults
+            RootPublicFolderMailbox           = $rootPublicFolderMailbox
             RemoteJob                         = $true -eq $PSSenderInfo
             JobHandledErrors                  = $jobHandledErrors
             AllErrors                         = $allErrors


### PR DESCRIPTION
**Issue:**
Requested by customer to add in this check.

**Reason:**
Add check to make sure that `IsExcludedFromServingHierarchy` is set to true on the root public folder mailbox

**Fix:**
Add data collection for the Root Public Folder Mailbox
Resolved #1892

**Validation:**
Lab tested

