### PR TITLE
Improve performance for old CVE checks

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecurityCveCheck.ps1
@@ -167,7 +167,7 @@ function Invoke-AnalyzerSecurityCveCheck {
         $year = [int]$value.Substring(3, 2)
 
         # Only add values that are greater than or equal to our current CU year build.
-        $cuReleaseYear = [int]([string]$exchangeInformation.BuildInformation.VersionInformation.ReleaseDate.Year).Substring(2)
+        $cuReleaseYear = $exchangeInformation.BuildInformation.VersionInformation.ReleaseDate.Year % 100
 
         if ($year -lt $cuReleaseYear) {
             continue


### PR DESCRIPTION
**Reason:**
Improving the performance of a large loop that we don't need to be processing because we are on a newer build of Exchange than the SU. 

**Fix:**
Skip over old SU years based off the CU Release Date that we have. 

We will still process some things, but we will also skip over a lot as well. 

Resolved #2331 

**Validation:**
Lab tested