### PR TITLE
Added check for TokenGroupsGlobalAndUniversal on the computer account

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -378,6 +378,28 @@ function Invoke-AnalyzerExchangeInformation {
             $params.Details = "Unknown - Wasn't able to get the Computer Membership information"
             Add-AnalyzedResultInformation @params
         }
+
+        if ($null -ne $exchangeInformation.ADComputerObject -and
+            $null -ne $exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal) {
+            $displayWriteType = "Grey"
+            $details = $exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count
+
+            if ($exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count -ge 75) {
+                $displayWriteType = "Yellow"
+            }
+
+            if ($exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count -ge 100) {
+                $displayWriteType = "Red"
+                $details += " --- Error: Might run into issues with this token being too large"
+            }
+
+            $params = $baseParams + @{
+                Name             = "Exchange Server Token Groups"
+                Details          = $details
+                DisplayWriteType = $displayWriteType
+            }
+            Add-AnalyzedResultInformation @params
+        }
     }
 
     if ($exchangeInformation.BuildInformation.MajorVersion -eq "Exchange2013" -and

--- a/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ExchangeInformation/Invoke-JobExchangeInformationCmdlet.ps1
@@ -21,6 +21,7 @@ function Invoke-JobExchangeInformationCmdlet {
         . $PSScriptRoot\..\..\..\..\Shared\Get-ExchangeSettingOverride.ps1
         . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-ExchangeWebSitesFromAd.ps1
         . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-GlobalCatalogServer.ps1
+        . $PSScriptRoot\..\..\..\..\Shared\ActiveDirectoryFunctions\Get-TokenGroupsGlobalAndUniversal.ps1
         . $PSScriptRoot\..\..\..\..\Shared\CertificateFunctions\Get-ExchangeServerCertificateInformation.ps1
         . $PSScriptRoot\Get-ExchangeVirtualDirectories.ps1
         . $PSScriptRoot\Get-ExchangeServerMaintenanceState.ps1
@@ -52,14 +53,19 @@ function Invoke-JobExchangeInformationCmdlet {
                 $computerObjectSidBytes = $computerSearchResults.Properties["objectSid"][0]
                 $computerObjectSid = New-Object System.Security.Principal.SecurityIdentifier($computerObjectSidBytes, 0)
                 $computerObject = [PSCustomObject]@{
-                    MemberOf                    = $computerSearchResults.Properties["memberOf"]
-                    MSExchRmsComputerAccountsBl = $computerSearchResults.Properties["MsExchRmsComputerAccountsBl"]
-                    WhenCreated                 = $computerSearchResults.Properties["WhenCreated"]
-                    WhenChanged                 = $computerSearchResults.Properties["WhenChanged"]
-                    DistinguishedName           = $computerSearchResults.Properties["DistinguishedName"]
-                    ObjectGuid                  = ([System.Guid]::New($($computerSearchResults.Properties["objectGuid"])).Guid)
-                    ServicePrincipalName        = $computerSearchResults.Properties["ServicePrincipalName"]
-                    ObjectSid                   = $computerObjectSid
+                    MemberOf                      = $computerSearchResults.Properties["memberOf"]
+                    MSExchRmsComputerAccountsBl   = $computerSearchResults.Properties["MsExchRmsComputerAccountsBl"]
+                    WhenCreated                   = $computerSearchResults.Properties["WhenCreated"]
+                    WhenChanged                   = $computerSearchResults.Properties["WhenChanged"]
+                    DistinguishedName             = $computerSearchResults.Properties["DistinguishedName"]
+                    ObjectGuid                    = ([System.Guid]::New($($computerSearchResults.Properties["objectGuid"])).Guid)
+                    ServicePrincipalName          = $computerSearchResults.Properties["ServicePrincipalName"]
+                    ObjectSid                     = $computerObjectSid
+                    TokenGroupsGlobalAndUniversal = $null
+                }
+
+                if ($null -ne $computerObject.DistinguishedName) {
+                    $computerObject.TokenGroupsGlobalAndUniversal = Get-TokenGroupsGlobalAndUniversal -GCName $globalCatalog -DistinguishedName $computerObject.DistinguishedName -CatchActionFunction ${Function:Invoke-CatchActions}
                 }
 
                 if ($null -ne $computerSearchResults) {


### PR DESCRIPTION
**Issue:**
Include the number of `TokenGroupsGlobalAndUniversal` that the computer account has to call out possible issues. Right now we are calling out a warning for 75 with just a `Yellow` display, then for anything 100 and greater, we will mark as `Red` with an Error message.

**Reason:**
When the Exchange Server's token is too large, transport connections to MSExchangeDelivery service fail with an IllegalMessage from NegotiateSecurityContext.

**Fix:**
Include information about the Server's token size. 

Resolved #662

**Validation:**
Lab tested

