### PR TITLE
Corrected wording of Root PF Serving Hierarchy

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -492,11 +492,11 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
     if ($null -ne $organizationInformation.RootPublicFolderMailbox) {
         $rootPfMailbox = $organizationInformation.RootPublicFolderMailbox
         $displayWriteType = "Grey"
-        $details = $true
+        $details = $false
 
         if ($rootPfMailbox.IsExcludedFromServingHierarchy -ne $true) {
             $displayWriteType = "Red"
-            $details = "false - Error"
+            $details = "true - Error"
         }
 
         $params = $baseParams + @{


### PR DESCRIPTION
**Issue:**
The section is called 'Root Public Folder Mailbox Serving Hierarchy' and we had the values backwards due to the property being `IsExcludedFromServingHierarchy`. 

**Reason:**
When we have the issue, we need to provide `true` instead of `false` because the Root Public Folder Mailbox is serving the hierarchy, when it shouldn't be. The setting needs to be set to true, which is `IsExcludedFromServingHierarchy`. 

**Fix:**
Corrected the wording. 

**Validation:**
N/A

