### PR TITLE
Throw error about multiple setting overrides being created for the same setting

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -728,6 +728,46 @@ function Invoke-AnalyzerExchangeInformation {
             }
             Add-AnalyzedResultInformation @params
         }
+
+        $groupedResults = $exchangeInformation.SettingOverrides.SimpleSettingOverrides |
+            Group-Object ComponentName, SectionName |
+            Where-Object { $_.Count -gt 1 }
+
+        if ($null -ne $groupedResults) {
+            $breakAndDisplay = $false
+            foreach ($groupedResult in $groupedResults) {
+                $parameterNameList = New-Object System.Collections.Generic.HashSet[string]
+                foreach ($group in $groupedResult.Group) {
+                    foreach ($parameterLine in @($group.Parameters)) {
+                        $parameterName = ([string]$parameterLine).Split("=")[0].Trim()
+
+                        # If it is already added to the list, it will be a false value returned. Therefore, we have multiple parameters set on the same thing.
+                        if (-not ($parameterNameList.Add($parameterName))) {
+                            $breakAndDisplay = $true
+                            break
+                        }
+                    }
+
+                    if ($breakAndDisplay) {
+                        break
+                    }
+                }
+
+                if ($breakAndDisplay) {
+                    break
+                }
+            }
+
+            if ($breakAndDisplay) {
+                $params = $baseParams + @{
+                    Name                   = "Duplicate Overrides"
+                    Details                = "Error! Duplicate Overrides have been detected for the same parameter causing possible misconfigurations. Please address as soon as possible."
+                    DisplayWriteType       = "Red"
+                    DisplayCustomTabNumber = 2
+                }
+                Add-AnalyzedResultInformation @params
+            }
+        }
     }
 
     $monitoringOverrides = New-Object System.Collections.Generic.List[object]


### PR DESCRIPTION
**Reason:**
There is no valid reason to have multiple settings with the same or different values, therefore it should be addressed

**Fix:**
Call out multiple setting overrides for the same thing. 
Resolved #2320 

**Validation:**
Lab tested

