### PR TITLE
Add NIC Teaming detection

### DIFF
--- a/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-NetworkingInformation.ps1
+++ b/Diagnostics/HealthChecker/DataCollection/ServerInformation/Get-NetworkingInformation.ps1
@@ -21,9 +21,9 @@ function Get-NetworkingInformation {
         Get-HttpProxySetting | Invoke-RemotePipelineHandler -Result ([ref]$httpProxy)
         Get-LocalizedCounterSamples -MachineName $Server -Counter "\Network Interface(*)\Packets Received Discarded" |
             Invoke-RemotePipelineHandler -Result ([ref]$packetsReceivedDiscarded)
-        Get-AllNicInformation -CatchActionFunction ${Function:Invoke-CatchActions} | Invoke-RemotePipelineHandlerList -Result ([ref]$networkAdapters)
+        Get-AllNicInformation -CatchActionFunction ${Function:Invoke-CatchActions} | Invoke-RemotePipelineHandler -Result ([ref]$networkAdapters)
 
-        foreach ($adapter in $networkAdapters) {
+        foreach ($adapter in $networkAdapters.Adapters) {
             if (-not ($adapter.IPv6Enabled)) {
                 $ipv6DisabledOnNICs = $true
                 break
@@ -33,7 +33,7 @@ function Get-NetworkingInformation {
         return [PSCustomObject]@{
             HttpProxy                = $httpProxy
             PacketsReceivedDiscarded = $packetsReceivedDiscarded
-            NetworkAdapters          = [array]$networkAdapters
+            NetworkAdapters          = $networkAdapters
             IPv6DisabledOnNICs       = $ipv6DisabledOnNICs
         }
     }

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E16.Main.Tests.ps1
@@ -106,7 +106,7 @@ Describe "Testing Health Checker by Mock Data Imports - Exchange 2016" {
             TestObjectMatch "Registered In DNS" "True"
             TestObjectMatch "Packets Received Discarded" 0 -WriteType "Green"
 
-            $Script:ActiveGrouping.Count | Should -Be 16
+            $Script:ActiveGrouping.Count | Should -Be 17
         }
 
         It "Display Results - Frequent Configuration Issues" {

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -112,7 +112,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
             TestObjectMatch "Registered In DNS" "True"
             TestObjectMatch "Packets Received Discarded" 0 -WriteType "Green"
 
-            $Script:ActiveGrouping.Count | Should -Be 16
+            $Script:ActiveGrouping.Count | Should -Be 17
         }
 
         It "Display Results - Frequent Configuration Issues" {
@@ -234,7 +234,7 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
             TestObjectMatch "Sleepy NIC Disabled" "True"
 
-            $Script:ActiveGrouping.Count | Should -Be 18
+            $Script:ActiveGrouping.Count | Should -Be 19
         }
 
         It "Display Results - Security Settings" {

--- a/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExchangeServerIPs.ps1
+++ b/Security/src/ExchangeExtendedProtectionManagement/DataCollection/Get-ExchangeServerIPs.ps1
@@ -38,7 +38,7 @@ function Get-ExchangeServerIPs {
 
             $IpsFound = $false
             # TODO: Refactor Get-AllNicInformation function to get rid of the duplicate ComputerName / FQDN logic
-            $HostNetworkInfo = Get-AllNicInformation -ComputerName $Server.FQDN
+            $HostNetworkInfo = (Get-AllNicInformation -ComputerName $Server.FQDN).Adapters
             if ($null -ne $HostNetworkInfo) {
                 if ($null -ne $HostNetworkInfo.IPv4Addresses) {
                     foreach ($address in $HostNetworkInfo.IPv4Addresses) {


### PR DESCRIPTION
**Issue:**
Don't have good logic for NIC teaming detection on servers. We aren't able to get the dropped packets count because of the teaming and so we need to include some logic to detect this. 

The teaming logic that we added will likely only work for Windows Teaming vs 3rd party teaming. I don't think there is going to be a good way to add 3rd party teaming to Health Checker. 

**Reason:**
Improve NIC output. 

**Fix:**
Resolved #533 

**Validation:**
Lab tested

