### PR TITLE
Address bug for non-environment variable

### DIFF
--- a/Setup/FixInstallerCache/FixInstallerCache.ps1
+++ b/Setup/FixInstallerCache/FixInstallerCache.ps1
@@ -35,7 +35,7 @@ try {
     if ($RemoteDebug) {
         Write-Verbose "Remote Debug detected, saving out the installer cache location."
         try {
-            $installerCacheFiles = Get-ChildItem "$env:SystemPath\Windows\Installer" -ErrorAction Stop |
+            $installerCacheFiles = Get-ChildItem "$env:WinDir\Installer" -ErrorAction Stop |
                 Where-Object { $_.Name.ToLower().EndsWith(".msi") } |
                 ForEach-Object {
                     return Get-FileInformation -File $_.FullName


### PR DESCRIPTION
**Issue:**
`$env:SystemPath` doesn't exist as an environment variable. 

**Fix:**
Use `$env:Windir` instead. 

**Validation:**
NA

