### PR TITLE
Ensure $startTime is always set

### DIFF
--- a/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
+++ b/PublicFolders/SourceSideValidations/SourceSideValidations.ps1
@@ -52,6 +52,8 @@ Add-Type -AssemblyName System.Core -ErrorAction Stop
 $BuildVersion = ""
 
 try {
+    $startTime = Get-Date
+
     if (-not $SkipVersionCheck) {
         if (Test-ScriptVersion -AutoUpdate) {
             # Update was downloaded, so stop here.
@@ -112,8 +114,6 @@ try {
 
         return
     }
-
-    $startTime = Get-Date
 
     if ($null -eq (Get-Command Set-ADServerSettings -ErrorAction:SilentlyContinue)) {
         Write-Warning "Exchange Server cmdlets are not present in this shell."


### PR DESCRIPTION
Fixes #2479. The $startTime variable was not being set when -RemoveInvalidPermissions was used. Even if the operation ran successfully, we would fail at the end when we tried to calculate the elapsed time.
