### PR TITLE
Fix string concatenation for error message

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerExchangeInformation.ps1
@@ -382,7 +382,7 @@ function Invoke-AnalyzerExchangeInformation {
         if ($null -ne $exchangeInformation.ADComputerObject -and
             $null -ne $exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal) {
             $displayWriteType = "Grey"
-            $details = $exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count
+            [string]$details = $exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count
 
             if ($exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count -ge 75) {
                 $displayWriteType = "Yellow"
@@ -390,7 +390,7 @@ function Invoke-AnalyzerExchangeInformation {
 
             if ($exchangeInformation.ADComputerObject.ADObject.TokenGroupsGlobalAndUniversal.Count -ge 100) {
                 $displayWriteType = "Red"
-                [string]$details += " --- Error: Might run into issues with this token being too large"
+                $details += " --- Error: Might run into issues with this token being too large"
             }
 
             $params = $baseParams + @{


### PR DESCRIPTION
Write-Error : Failed to process E1905.contoso.lab for analysis
At E:\HealthChecker (3).ps1:20003 char:21
+ ...             Write-Error "Failed to process $($healthServerObject.Serv ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Write-Error