### PR TITLE
Revert "Temp remove of CSpell check in pipeline"

### DIFF
--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -24,7 +24,7 @@ extends:
             cd .\.build
             .\docs.ps1
           displayName: "Docs Check"
-        - pwsh: Write-Host "Temp Skip of Spell Check, Manually Check!" # .\.build\SpellCheck.ps1
+        - pwsh: .\.build\SpellCheck.ps1
           displayName: "Spell Check"
         - pwsh: |
             cd .\.build


### PR DESCRIPTION
This reverts commit 9f3efb8a53f3311460c5d51301d77d1c64418f7c.

**Issue:**
Previously, we weren't able use CSpell within the pipeline and needed to make some changes, but we are now able to use it again. 

**Reason:**
Since we were able to use it the same as before, we are going to revert the change and keep it within the pipeline. 

**Validation:**
Pipeline tested

