### PR TITLE
Add NULL check for empty DumpsterEntryId

### DIFF
--- a/PublicFolders/SourceSideValidations/Tests/DumpsterMapping/Test-DumpsterMapping.ps1
+++ b/PublicFolders/SourceSideValidations/Tests/DumpsterMapping/Test-DumpsterMapping.ps1
@@ -31,7 +31,11 @@ function Test-DumpsterMapping {
             }
 
             process {
-                $dumpster = $FolderData.NonIpmEntryIdDictionary[$Folder.DumpsterEntryId]
+                $dumpster = $null
+
+                if (-not ([string]::IsNullOrEmpty($Folder.DumpsterEntryId))) {
+                    $dumpster = $FolderData.NonIpmEntryIdDictionary[$Folder.DumpsterEntryId]
+                }
 
                 if ($null -eq $dumpster -or
                     (-not $dumpster.Identity.StartsWith("\NON_IPM_SUBTREE\DUMPSTER_ROOT", "OrdinalIgnoreCase")) -or


### PR DESCRIPTION
**Issue:**
Customer was receiving "Index operation failed" for empty DumpsterEntryID. 

**Reason:**
You can't try to pull a hashtable value from a null key entry. 

**Fix:**
Do a null check before trying to get the value from the hashtable. 

Related to #2491 
Leaving issue open to possibly link article to fix

**Validation:**
N/A

