### PR TITLE
Update Spell Check to not run on Internal

### DIFF
--- a/.build/SpellCheck.ps1
+++ b/.build/SpellCheck.ps1
@@ -30,6 +30,13 @@ function DoSpellCheck {
     $cspellModule = npm -g ls cspell | Select-String "cspell@"
 
     if ([string]::IsNullOrEmpty($cspellModule)) {
+
+        if ($env:RepositoryName -ne "microsoft/CSS-Exchange") {
+            Write-Host "Not running on public pipeline. You must manually run SpellCheck to verify this step will pass. Skipping over."
+            # Need to exit to allow the pipeline to continue
+            exit 0
+        }
+
         Write-Host "Could not install cspell. Please install cspell and try again."
         exit 1
     }

--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -26,6 +26,8 @@ extends:
           displayName: "Docs Check"
         - pwsh: .\.build\SpellCheck.ps1
           displayName: "Spell Check"
+          env:
+            RepositoryName: $(Build.Repository.Name)
         - pwsh: |
             cd .\.build
             .\CodeFormatter.ps1 -Branch $env:TargetBranchName


### PR DESCRIPTION
**Issue:**
internal repro isn't able to execute for spellcheck, so going to prevent this from running there. 

**Fix:**
Attempt to run spell check, but don't allow it to block pipeline. 

**Validation:**
Build pipeline testing

