### PR TITLE
Handle Unlimited value for MaxPerDomainOutboundConnections

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerFrequentConfigurationIssues.ps1
@@ -425,7 +425,8 @@ function Invoke-AnalyzerFrequentConfigurationIssues {
     }
 
     if ($null -ne $exchangeInformation.GetTransportService) {
-        if ([int]($exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections) -lt 40) {
+        if ("Unlimited" -ne $exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections -and
+            [int]($exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections) -lt 40) {
             $params = $baseParams + @{
                 Name             = "MaxPerDomainOutboundConnections"
                 Details          = "Value set to $($exchangeInformation.GetTransportService.MaxPerDomainOutboundConnections), which is less than the recommended value of 40. `r`n`t`tMore details: https://aka.ms/HC-TransportRetryConfigCheck"


### PR DESCRIPTION
**Issue:**
After a recent change, we are trying to always convert the `MaxPerDomainOutboundConnections` which doesn't work when the value is `Unlimited` and fails out the script. 

**Fix:**
Need to make sure that we handle `Unlimited` value types as well on this property as it is `Unlimited<Int32>`. 
Resolved #2506 


**Validation:**
Lab tested

