### PR TITLE
Backlog of bugs

### DIFF
--- a/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
@@ -109,6 +109,7 @@ function CreateExternalMasterIDMap {
         $AllFolderNames = @($script:GCDO | Where-Object { $_.ExternalSharingMasterId -eq $ExternalID } | Select-Object -ExpandProperty OriginalParentDisplayName | Select-Object -Unique)
 
         # Default calendar folder names across the top localized versions of Exchange
+        # cSpell:ignore Kalender Calendario Calendrier Calendário Календарь
         $DefaultCalendarNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
         [void]$DefaultCalendarNames.Add('Calendar')       # English
         [void]$DefaultCalendarNames.Add('Kalender')        # German, Dutch, Swedish, Norwegian, Danish

--- a/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
@@ -108,16 +108,25 @@ function CreateExternalMasterIDMap {
 
         $AllFolderNames = @($script:GCDO | Where-Object { $_.ExternalSharingMasterId -eq $ExternalID } | Select-Object -ExpandProperty OriginalParentDisplayName | Select-Object -Unique)
 
-        # Remove empty/null and 'Calendar' (the default folder name) entries
+        # Default calendar folder names across the top localized versions of Exchange
+        $DefaultCalendarNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        [void]$DefaultCalendarNames.Add('Calendar')       # English
+        [void]$DefaultCalendarNames.Add('Kalender')        # German, Dutch, Swedish, Norwegian, Danish
+        [void]$DefaultCalendarNames.Add('Calendario')      # Spanish, Italian
+        [void]$DefaultCalendarNames.Add('Calendrier')      # French
+        [void]$DefaultCalendarNames.Add('Calendário')     # Portuguese
+        [void]$DefaultCalendarNames.Add('Календарь')      # Russian
+
+        # Remove empty/null entries
         $AllFolderNames = @($AllFolderNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
         if ($AllFolderNames.count -gt 1) {
-            # We have 2+ FolderNames, remove only exact match to 'Calendar' (the default folder name, not folder names containing 'Calendar')
-            $Filtered = $AllFolderNames | Where-Object { $_ -ne 'Calendar' }
+            # We have 2+ FolderNames, remove default calendar folder names (localized) by exact match
+            $Filtered = $AllFolderNames | Where-Object { -not $DefaultCalendarNames.Contains($_) }
             if ($Filtered.Count -gt 0) {
                 $AllFolderNames = @($Filtered)
             }
-            # else keep the original list — all entries were 'Calendar'
+            # else keep the original list — all entries were default calendar names
         }
 
         if ($AllFolderNames.Count -eq 0) {

--- a/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
@@ -51,7 +51,7 @@ function MapSharedFolder {
     if ($ExternalMasterID -eq "NotFound") {
         return "Not Shared"
     } else {
-        $SharedFolders[$ExternalMasterID]
+        $script:SharedFolders[$ExternalMasterID]
     }
 }
 
@@ -98,10 +98,10 @@ function CreateExternalMasterIDMap {
 
         if ($AllFolderNames.Count -eq 0) {
             $unknownCount++
-            $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
+            $script:SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
             Write-Host -ForegroundColor red "Found Zero folder names to map to for ExternalID [$ExternalID]."
         } elseif ($AllFolderNames.Count -eq 1) {
-            $SharedFolders[$ExternalID] = $AllFolderNames[0]
+            $script:SharedFolders[$ExternalID] = $AllFolderNames[0]
             Write-Verbose "Found map: [$($AllFolderNames[0])] is for $ExternalID"
         } else {
             # we still have multiple possible Folder Names, need to chose one or combine
@@ -109,20 +109,20 @@ function CreateExternalMasterIDMap {
             Write-Host -ForegroundColor Red "Found $($AllFolderNames.count) possible folders: $($AllFolderNames -join ', ')"
 
             if ($AllFolderNames.Count -eq 2) {
-                $SharedFolders[$ExternalID] = $AllFolderNames[0] + " + " + $AllFolderNames[1]
+                $script:SharedFolders[$ExternalID] = $AllFolderNames[0] + " + " + $AllFolderNames[1]
             } else {
                 $unknownCount++
-                $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
+                $script:SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
             }
         }
     }
 
     Write-Host -ForegroundColor Green "Created the following Shared Calendar Mapping:"
-    foreach ($Key in $SharedFolders.Keys) {
-        Write-Host -ForegroundColor Green "$Key : $($SharedFolders[$Key])"
+    foreach ($Key in $script:SharedFolders.Keys) {
+        Write-Host -ForegroundColor Green "$Key : $($script:SharedFolders[$Key])"
     }
     Write-Verbose "Created the following Mapping :"
-    Write-Verbose $SharedFolders
+    Write-Verbose $script:SharedFolders
 }
 
 <#
@@ -254,9 +254,9 @@ function ConvertDateTime {
         return $Parsed
     }
 
-    # Priority 5: Return original string rather than losing data
+    # Priority 5: Return MinValue so sorting is not broken by mixed types
     Write-Warning "Unable to parse date: [$DateTime]"
-    return $DateTime
+    return [DateTime]::MinValue
 }
 
 function GetAttendeeCount {

--- a/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
@@ -25,7 +25,6 @@ $script:CalendarItemTypes = @{
     'IPM.OLE.CLASS.{00061055-0000-0000-C000-000000000046}' = "Exception"
     'IPM.Schedule.Meeting.Notification.Forward'            = "Forward.Notification"
     'IPM.Appointment'                                      = "Ipm.Appointment"
-    'IPM.Appointment.MP'                                   = "Ipm.Appointment"
     'IPM.Schedule.Meeting.Request'                         = "Meeting.Request"
     'IPM.CalendarSharing.EventUpdate'                      = "SharingCFM"
     'IPM.CalendarSharing.EventDelete'                      = "SharingDelete"
@@ -34,6 +33,28 @@ $script:CalendarItemTypes = @{
     'IPM.Schedule.Meeting.Resp.Tent'                       = "Resp.Tent"
     'IPM.Schedule.Meeting.Resp.Pos'                        = "Resp.Pos"
     '(Occurrence Deleted)'                                 = "Exception.Deleted"
+}
+
+<#
+.SYNOPSIS
+Resolves the ItemClass to a friendly type name using the CalendarItemTypes table.
+If no exact match is found, progressively strips the last dot-segment and retries.
+e.g. IPM.Schedule.Meeting.Resp.Tent.Follow → IPM.Schedule.Meeting.Resp.Tent → "Resp.Tent"
+#>
+function GetItemType {
+    param([string]$ItemClass)
+    $lookup = $ItemClass
+    while (-not [string]::IsNullOrEmpty($lookup)) {
+        $type = $script:CalendarItemTypes[$lookup]
+        if (-not [string]::IsNullOrEmpty($type)) {
+            return $type
+        }
+        # Strip the last segment and try the parent
+        $lastDot = $lookup.LastIndexOf('.')
+        if ($lastDot -le 0) { break }
+        $lookup = $lookup.Substring(0, $lastDot)
+    }
+    return $null
 }
 
 # ===================================================================================================
@@ -86,6 +107,9 @@ function CreateExternalMasterIDMap {
         }
 
         $AllFolderNames = @($script:GCDO | Where-Object { $_.ExternalSharingMasterId -eq $ExternalID } | Select-Object -ExpandProperty OriginalParentDisplayName | Select-Object -Unique)
+
+        # Remove empty/null and 'Calendar' (the default folder name) entries
+        $AllFolderNames = @($AllFolderNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
         if ($AllFolderNames.count -gt 1) {
             # We have 2+ FolderNames, remove only exact match to 'Calendar' (the default folder name, not folder names containing 'Calendar')
@@ -161,7 +185,7 @@ function BuildCSV {
     $Index = 0
     $GCDOResults = foreach ($CalLog in $script:GCDO) {
         $Index++
-        $ItemType = $CalendarItemTypes.($CalLog.ItemClass)
+        $ItemType = GetItemType $CalLog.ItemClass
 
         # CleanNotFounds
         $PropsToClean = "FreeBusyStatus", "ClientIntent", "AppointmentSequenceNumber", "AppointmentLastSequenceNumber", "RecurrencePattern", "AppointmentAuxiliaryFlags", "EventEmailReminderTimer", "IsSeriesCancelled", "AppointmentCounterProposal", "MeetingRequestType", "SendMeetingMessagesDiagnostics", "AttendeeCollection"

--- a/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogCSVFunctions.ps1
@@ -4,6 +4,20 @@
 # ===================================================================================================
 # Constants to support the script
 # ===================================================================================================
+# Non-US date formats for TryParseExact fallback (constant, created once)
+[string[]]$script:DateFormats = @(
+    "d/M/yyyy h:mm:ss tt",
+    "d/M/yyyy H:mm:ss",
+    "d/M/yyyy H:mm",
+    "d/M/yyyy h:mm tt",
+    "dd/MM/yyyy h:mm:ss tt",
+    "dd/MM/yyyy H:mm:ss",
+    "dd/MM/yyyy HH:mm:ss",
+    "dd/MM/yyyy H:mm",
+    "dd/MM/yyyy h:mm tt",
+    "d/M/yyyy",
+    "dd/MM/yyyy"
+)
 
 $script:CalendarItemTypes = @{
     'IPM.Schedule.Meeting.Request.AttendeeListReplication' = "AttendeeList"
@@ -63,6 +77,7 @@ Creates a Mapping of ExternalMasterID to FolderName
 function CreateExternalMasterIDMap {
     # This function will create a Map of the log folder to ExternalMasterID
     $script:SharedFolders = [System.Collections.SortedList]::new()
+    $unknownCount = 0
     Write-Verbose "Starting CreateExternalMasterIDMap"
 
     foreach ($ExternalID in $script:GCDO.ExternalSharingMasterId | Select-Object -Unique) {
@@ -73,27 +88,31 @@ function CreateExternalMasterIDMap {
         $AllFolderNames = @($script:GCDO | Where-Object { $_.ExternalSharingMasterId -eq $ExternalID } | Select-Object -ExpandProperty OriginalParentDisplayName | Select-Object -Unique)
 
         if ($AllFolderNames.count -gt 1) {
-            # We have 2+ FolderNames, Need to find the best one. Remove 'Calendar' from possible names
-            $AllFolderNames = $AllFolderNames | Where-Object { $_ -notmatch 'Calendar' } # Need a better way to do this for other languages...
+            # We have 2+ FolderNames, remove only exact match to 'Calendar' (the default folder name, not folder names containing 'Calendar')
+            $Filtered = $AllFolderNames | Where-Object { $_ -ne 'Calendar' }
+            if ($Filtered.Count -gt 0) {
+                $AllFolderNames = @($Filtered)
+            }
+            # else keep the original list — all entries were 'Calendar'
         }
 
         if ($AllFolderNames.Count -eq 0) {
-            $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy"
-            Write-Host -ForegroundColor red "Found Zero to map to."
-        }
-
-        if ($AllFolderNames.Count -eq 1) {
-            $SharedFolders[$ExternalID] = $AllFolderNames
-            Write-Verbose "Found map: [$AllFolderNames] is for $ExternalID"
+            $unknownCount++
+            $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
+            Write-Host -ForegroundColor red "Found Zero folder names to map to for ExternalID [$ExternalID]."
+        } elseif ($AllFolderNames.Count -eq 1) {
+            $SharedFolders[$ExternalID] = $AllFolderNames[0]
+            Write-Verbose "Found map: [$($AllFolderNames[0])] is for $ExternalID"
         } else {
             # we still have multiple possible Folder Names, need to chose one or combine
             Write-Host -ForegroundColor Red "Unable to Get Exact Folder for $ExternalID"
-            Write-Host -ForegroundColor Red "Found $($AllFolderNames.count) possible folders"
+            Write-Host -ForegroundColor Red "Found $($AllFolderNames.count) possible folders: $($AllFolderNames -join ', ')"
 
             if ($AllFolderNames.Count -eq 2) {
-                $SharedFolders[$ExternalID] = $AllFolderNames[0] + $AllFolderNames[1]
+                $SharedFolders[$ExternalID] = $AllFolderNames[0] + " + " + $AllFolderNames[1]
             } else {
-                $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy"
+                $unknownCount++
+                $SharedFolders[$ExternalID] = "UnknownSharedCalendarCopy$unknownCount"
             }
         }
     }
@@ -102,7 +121,6 @@ function CreateExternalMasterIDMap {
     foreach ($Key in $SharedFolders.Keys) {
         Write-Host -ForegroundColor Green "$Key : $($SharedFolders[$Key])"
     }
-    # ToDo: Need to check for multiple ExternalSharingMasterId pointing to the same FolderName
     Write-Verbose "Created the following Mapping :"
     Write-Verbose $SharedFolders
 }
@@ -130,8 +148,10 @@ Builds the CSV output from the Calendar Diagnostic Objects
 function BuildCSV {
 
     Write-Host "Starting to Process Calendar Logs..."
-    $GCDOResults = @()
     $script:MailboxList = @{}
+    # Initialize lookup caches to avoid redundant CN resolution across hundreds of log entries
+    $script:SMTPAddressCache = @{}
+    $script:DisplayNameCache = @{}
     Write-Host "Creating Map of Mailboxes to CNs..."
     CreateExternalMasterIDMap
     ConvertCNtoSMTP
@@ -139,7 +159,7 @@ function BuildCSV {
 
     Write-Host "Making Calendar Logs more readable..."
     $Index = 0
-    foreach ($CalLog in $script:GCDO) {
+    $GCDOResults = foreach ($CalLog in $script:GCDO) {
         $Index++
         $ItemType = $CalendarItemTypes.($CalLog.ItemClass)
 
@@ -152,8 +172,8 @@ function BuildCSV {
             }
         }
 
-        # Record one row
-        $GCDOResults += [PSCustomObject]@{
+        # Output one row (collected by the foreach assignment)
+        [PSCustomObject]@{
             #'LogRow'                         = $Index
             'LogTimestamp'                   = ConvertDateTime($CalLog.LogTimestamp)
             'LogRowType'                     = $CalLog.LogRowType.ToString()
@@ -180,7 +200,7 @@ function BuildCSV {
             'CalendarItemType'               = $CalLog.CalendarItemType.ToString()
             'RecurrencePattern'              = $CalLog.RecurrencePattern
             'AppointmentAuxiliaryFlags'      = $CalLog.AppointmentAuxiliaryFlags.ToString()
-            'DisplayAttendeesAll'            = $CalLog.DisplayAttendeesAll
+            'DisplayAttendeesAll'            = $(if ($CalLog.DisplayAttendeesAll -eq "NotFound") { "-" } else { $CalLog.DisplayAttendeesAll })
             'AttendeeCount'                  = GetAttendeeCount($CalLog.DisplayAttendeesAll)
             'AppointmentState'               = $CalLog.AppointmentState.ToString()
             'ResponseType'                   = $CalLog.ResponseType.ToString()
@@ -189,10 +209,12 @@ function BuildCSV {
             'HasAttachment'                  = $CalLog.HasAttachment
             'IsCancelled'                    = $CalLog.IsCancelled
             'IsAllDayEvent'                  = $CalLog.IsAllDayEvent
+            'Sensitivity'                    = $CalLog.Sensitivity
             'IsSeriesCancelled'              = $CalLog.IsSeriesCancelled
             'SendMeetingMessagesDiagnostics' = $CalLog.SendMeetingMessagesDiagnostics
             'AttendeeCollection'             = MultiLineFormat($CalLog.AttendeeCollection)
             'CalendarLogRequestId'           = $CalLog.CalendarLogRequestId.ToString()    # Move to front.../ Format in groups???
+            'CleanGlobalObjectId'            = $CalLog.CleanGlobalObjectId
         }
     }
     $script:EnhancedCalLogs = $GCDOResults
@@ -210,7 +232,31 @@ function ConvertDateTime {
         $DateTime -eq "NotFound") {
         return ""
     }
-    return [DateTime]$DateTime
+
+    $InvariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
+    $DateStyles = [System.Globalization.DateTimeStyles]::None
+    $Parsed = [DateTime]::MinValue
+
+    # Priority 1 & 2: InvariantCulture TryParse
+    # Handles ISO 8601 and M/d/yyyy (the default EXO output format)
+    if ([DateTime]::TryParse($DateTime, $InvariantCulture, $DateStyles, [ref]$Parsed)) {
+        return $Parsed
+    }
+
+    # Priority 3: Explicit non-US formats via TryParseExact
+    # Reached when day > 12 makes InvariantCulture fail (e.g., "22/07/2024")
+    if ([DateTime]::TryParseExact($DateTime, $script:DateFormats, $InvariantCulture, $DateStyles, [ref]$Parsed)) {
+        return $Parsed
+    }
+
+    # Priority 4: Current culture (last resort for unexpected formats)
+    if ([DateTime]::TryParse($DateTime, [ref]$Parsed)) {
+        return $Parsed
+    }
+
+    # Priority 5: Return original string rather than losing data
+    Write-Warning "Unable to parse date: [$DateTime]"
+    return $DateTime
 }
 
 function GetAttendeeCount {

--- a/Calendar/CalLogHelpers/CalLogInfoFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogInfoFunctions.ps1
@@ -39,13 +39,15 @@ function SetIsRoom {
     }
 
     # Simple logic is if RBA is running on the MB, it is a Room MB, otherwise it is not.
-    foreach ($CalLog in $CalLogs) {
-        Write-Verbose "Checking if this is a Room Mailbox. [$($CalLog.ItemClass)] [$($CalLog.ExternalSharingMasterId)] [$($CalLog.LogClientInfoString)]"
-        if ($CalLog.ItemClass -eq "IPM.Appointment" -and
-            $CalLog.ExternalSharingMasterId -eq "NotFound" -and
-            $CalLog.LogClientInfoString -like "*ResourceBookingAssistant*" ) {
-            return $true
-        }
+    $rbaLog = $CalLogs | Where-Object {
+        $_.ItemClass -eq "IPM.Appointment" -and
+        $_.ExternalSharingMasterId -eq "NotFound" -and
+        $_.LogClientInfoString -like "*ResourceBookingAssistant*"
+    } | Select-Object -First 1
+
+    if ($null -ne $rbaLog) {
+        Write-Host -ForegroundColor Green "Found Room Mailbox indicator: [$($rbaLog.LogClientInfoString)]"
+        return $true
     }
     return $false
 }
@@ -62,7 +64,8 @@ function SetIsRecurring {
     [bool] $IsRecurring = $false
     # See if this is a recurring meeting
     foreach ($CalLog in $CalLogs) {
-        if ($CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -and
+        if ($null -ne $CalLog.ItemClass -and
+            $CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -and
             # Commenting this out will get all the updates for shared calendars, which is important with Delegates.
             #      $CalLog.ExternalSharingMasterId -eq "NotFound" -and
             $CalLog.CalendarItemType.ToString() -eq "RecurringMaster") {
@@ -94,8 +97,8 @@ function CheckForBifurcation {
             return $IsBifurcated
         }
     }
-    Write-Host -ForegroundColor Red "Did not find any Ipm.Appointments in the CalLogs. If this is the Organizer of the meeting, this could the the Outlook Bifurcation issue."
-    Write-Host -ForegroundColor Yellow "`t This could be the Outlook Bifurcation issue, where Outlook saves to the Organizers Mailbox on one thread and send to the attendee via transport on another thread.  If the save to Organizers mailbox failed, we get into the Bifurcated State, where the Organizer does not have the meeting but the Attendees do."
+    Write-Host -ForegroundColor Red "Did not find any Ipm.Appointments in the CalLogs. If this is the Organizer of the meeting, this could be the Outlook Bifurcation issue."
+    Write-Host -ForegroundColor Yellow "`t The Outlook Bifurcation issue is where Outlook saves to the Organizer's Mailbox on one thread and sends to the attendees via transport on another thread. If the save to the Organizer's mailbox failed, we get into the Bifurcated State, where the Organizer does not have the meeting but the Attendees do."
     Write-Host -ForegroundColor Yellow "`t See https://support.microsoft.com/en-us/office/meeting-request-is-missing-from-organizers-calendar-c13c47cd-18f9-4ef0-b9d0-d9e174912c4a"
     return $IsBifurcated
 }

--- a/Calendar/CalLogHelpers/CalLogInfoFunctions.ps1
+++ b/Calendar/CalLogHelpers/CalLogInfoFunctions.ps1
@@ -65,7 +65,7 @@ function SetIsRecurring {
     # See if this is a recurring meeting
     foreach ($CalLog in $CalLogs) {
         if ($null -ne $CalLog.ItemClass -and
-            $CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -and
+            (GetItemType $CalLog.ItemClass) -eq "Ipm.Appointment" -and
             # Commenting this out will get all the updates for shared calendars, which is important with Delegates.
             #      $CalLog.ExternalSharingMasterId -eq "NotFound" -and
             $CalLog.CalendarItemType.ToString() -eq "RecurringMaster") {

--- a/Calendar/CalLogHelpers/CreateTimelineRow.ps1
+++ b/Calendar/CalLogHelpers/CreateTimelineRow.ps1
@@ -74,7 +74,7 @@ function CreateTimelineRow {
             }
 
             if ($CalLog.AppointmentCounterProposal -eq "True") {
-                [array] $Output = "[$($CalLog.Organizer)] send a $($MeetingRespType) response message with a New Time Proposal: $($CalLog.StartTime) to $($CalLog.EndTime)"
+                [array] $Output = "[$($CalLog.Organizer)] sent a $($MeetingRespType) response message with a New Time Proposal: $($CalLog.StartTime) to $($CalLog.EndTime)"
             } else {
                 switch -Wildcard ($CalLog.TriggerAction) {
                     "Update" { $Action = "Updated" }

--- a/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
+++ b/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
@@ -6,85 +6,210 @@ function Export-CalLogExcel {
     Write-Host -ForegroundColor Cyan "Exporting Enhanced CalLogs to Excel Tab [$ShortId]..."
     $script:lastRow = 1000 # Default last row, will be updated later
     $script:firstRow = 3 # Row 1 is the Title, Row 2 is the Header
-    $script:lastColumn = "AL" # Column AL is the last column in the Excel sheet
+    $script:lastColumn = "AN" # Column AN is the last column in the Excel sheet
 
     $ExcelParamsArray = GetExcelParams -path $FileName -tabName $ShortId
 
-    $excel = $GCDOResults | Export-Excel @ExcelParamsArray -PassThru
+    # Suppress EPPlus warnings and errors that occur when writing to an existing file
+    # (AutoNameRange validation, named range conflicts, title character warnings)
+    $savedErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+
+    $excel = $GCDOResults | Export-Excel @ExcelParamsArray -PassThru 3>$null
+
+    $ErrorActionPreference = $savedErrorActionPreference
 
     FormatHeader ($excel)
+    SortByLogTimestamp ($excel)
     CheckRows ($excel)
+
+    # Set tab color to match the role (Organizer=Orange, Room=Green, Attendee=Blue)
+    $excel.Workbook.Worksheets[$ShortId].TabColor = $script:TabColor
+
     Export-Excel -ExcelPackage $excel -WorksheetName $ShortId -MoveToStart
+
+    # Log script info (will be positioned in the middle)
+    LogScriptInfo
 
     # Export Raw Logs for Developer Analysis
     Write-Host -ForegroundColor Cyan "Exporting Raw CalLogs to Excel Tab [$($ShortId + "_Raw")]..."
-    $script:GCDO | Export-Excel -Path  $FileName -WorksheetName $($ShortId + "_Raw") -AutoFilter -FreezeTopRow -BoldTopRow -MoveToEnd
-    LogScriptInfo
+    $ErrorActionPreference = 'SilentlyContinue'
+    $rawExcel = $script:GCDO | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_Raw") -AutoFilter -FreezeTopRow -BoldTopRow -MoveToEnd -PassThru 3>$null
+    $ErrorActionPreference = $savedErrorActionPreference
+    $rawExcel.Workbook.Worksheets[$ShortId + "_Raw"].TabColor = $script:TabColor
+    Export-Excel -ExcelPackage $rawExcel -WorksheetName $($ShortId + "_Raw")
 }
 
 function LogScriptInfo {
-    # Only need to run once per script execution.
-    if ($null -eq $script:CollectedCmdLine) {
-        $RunInfo = @()
-        $RunInfo += [PSCustomObject]@{
-            Key   = "Script Name"
-            Value = $($script:command.MyCommand.Name)
+    # Increment run number only once per script invocation (not per identity)
+    if (-not $script:RunNumberSet) {
+        # Read the existing run count from the Excel file so numbering is continuous across sessions
+        if ($script:RunNumber -eq 0 -and (Test-Path $FileName)) {
+            try {
+                $pkg = Open-ExcelPackage -Path $FileName -ErrorAction SilentlyContinue
+                if ($null -ne $pkg -and $null -ne $pkg.Workbook.Worksheets["Script Info"]) {
+                    $existingInfo = Import-Excel -ExcelPackage $pkg -WorksheetName "Script Info" -ErrorAction SilentlyContinue
+                    if ($null -ne $existingInfo) {
+                        $lastRunKey = $existingInfo | Where-Object { $_.Key -like "--- Run #* ---" } | Select-Object -Last 1
+                        if ($null -ne $lastRunKey -and $lastRunKey.Key -match '#(\d+)') {
+                            $script:RunNumber = [int]$Matches[1]
+                        }
+                    }
+                } else {
+                    if ($null -ne $pkg) { $pkg.Dispose() }
+                }
+            } catch {
+                Write-Verbose "Unable to read existing run count from Excel: $_"
+            }
         }
-        $RunInfo += [PSCustomObject]@{
-            Key   ="RunTime"
-            Value = Get-Date
+        $script:RunNumber++
+        $script:RunNumberSet = $true
+        $script:RunHeaderWritten = $false
+    }
+
+    $RunInfo = [System.Collections.Generic.List[object]]::new()
+
+    # Write run header and shared info only once per run (on the first identity)
+    if (-not $script:RunHeaderWritten) {
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "--- Run #$($script:RunNumber) ---"
+                Value = "---"
+            })
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "RunTime"
+                Value = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+            })
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "Script Name"
+                Value = $($script:command.MyCommand.Name)
+            })
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "Command Line"
+                Value = $($script:command.Line)
+            })
+
+        # Combine version and age into one line
+        $versionText = if (-not [string]::IsNullOrEmpty($script:BuildVersion)) { $script:BuildVersion } else { "Unknown" }
+        if (-not [string]::IsNullOrEmpty($script:BuildVersion)) {
+            try {
+                $parts = $script:BuildVersion.Split('.')
+                $buildDate = [DateTime]::new(2000 + [int]$parts[0], [int]$parts[1], [int]$parts[2])
+                $age = (Get-Date) - $buildDate
+                $ageText = if ($age.Days -eq 0) { "today" }
+                elseif ($age.Days -eq 1) { "1 day old" }
+                elseif ($age.Days -lt 30) { "$($age.Days) days old" }
+                elseif ($age.Days -lt 365) { "$([math]::Floor($age.Days / 30)) month(s) old" }
+                else { "$([math]::Floor($age.Days / 365)) year(s), $([math]::Floor(($age.Days % 365) / 30)) month(s) old" }
+                $versionText = "$versionText ($ageText, built $($buildDate.ToString('yyyy-MM-dd')))"
+            } catch {
+                Write-Verbose "Unable to parse BuildVersion '$($script:BuildVersion)' for age calculation: $_"
+            }
         }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "Command Line"
-            Value = $($script:command.Line)
-        }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "Script Version"
-            Value =  $script:BuildVersion
-        }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "User"
-            Value =  whoami.exe
-        }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "PowerShell Version"
-            Value = $PSVersionTable.PSVersion
-        }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "OS Version"
-            Value = $(Get-CimInstance -ClassName Win32_OperatingSystem).Version
-        }
-        $RunInfo += [PSCustomObject]@{
-            Key   = "More Info"
-            Value = "https://learn.microsoft.com/en-us/exchange/troubleshoot/calendars/analyze-calendar-diagnostic-logs"
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "Script Version"
+                Value = $versionText
+            })
+
+        $RunInfo.Add([PSCustomObject]@{
+                Key   = "Identities"
+                Value = ($ValidatedIdentities -join '; ')
+            })
+
+        # Only log environment info on the first run
+        if ($script:RunNumber -eq 1) {
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "User"
+                    Value = whoami.exe
+                })
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "PowerShell Version"
+                    Value = $PSVersionTable.PSVersion
+                })
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "OS Version"
+                    Value = $(Get-CimInstance -ClassName Win32_OperatingSystem).Version
+                })
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "More Info"
+                    Value = "https://learn.microsoft.com/en-us/exchange/troubleshoot/calendars/analyze-calendar-diagnostic-logs"
+                })
         }
 
-        $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -MoveToEnd
-        $script:CollectedCmdLine = $true
+        $script:RunHeaderWritten = $true
     }
-    # If someone runs the script the script again logs will update, but ScriptInfo does not update. Need to add new table for each run.
+
+    # Per-identity line: show which identity was collected and log count
+    $logCount = if ($null -ne $script:GCDO) { $script:GCDO.Count } else { 0 }
+    $RunInfo.Add([PSCustomObject]@{
+            Key   = "  $($script:Identity)"
+            Value = "$logCount logs collected at $(Get-Date -Format 'HH:mm:ss')"
+        })
+
+    # Capture errors that occurred during this identity (new errors since last snapshot)
+    # Filter out EPPlus internal errors (IsValidAddress) and Import-Excel worksheet-not-found errors
+    $newErrors = @()
+    for ($i = 0; $i -lt ($Error.Count - $script:PreRunErrorCount); $i++) {
+        $err = $Error[$i]
+        $msg = if ($err -is [System.Management.Automation.ErrorRecord]) { $err.Exception.Message } else { $err.ToString() }
+        if ($msg -notlike '*IsValidAddress*' -and $msg -notlike '*Worksheet*Script Info*not found*') {
+            $newErrors += $err
+        }
+    }
+    if ($newErrors.Count -gt 0) {
+        for ($i = 0; $i -lt $newErrors.Count; $i++) {
+            $err = $newErrors[$i]
+            $errorMessage = if ($err -is [System.Management.Automation.ErrorRecord]) {
+                "$($err.Exception.Message) [$($err.CategoryInfo.Category): $($err.FullyQualifiedErrorId)]"
+            } else {
+                $err.ToString()
+            }
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "    Error $($i + 1)"
+                    Value = $errorMessage
+                })
+        }
+    }
+    # Update snapshot so next identity only captures new errors
+    $script:PreRunErrorCount = $Error.Count
+
+    # Append to the existing Script Info tab
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -Append -PassThru 3>$null
+    $ErrorActionPreference = $savedEAP
+    $infoExcel.Workbook.Worksheets["Script Info"].TabColor = [System.Drawing.Color]::Gray
+    Export-Excel -ExcelPackage $infoExcel -WorksheetName "Script Info"
 }
 
 function Export-TimelineExcel {
     Write-Host -ForegroundColor Cyan "Exporting Timeline to Excel..."
-    $script:TimeLineOutput | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_TimeLine") -Title "Timeline for $Identity" -AutoSize -FreezeTopRow -BoldTopRow
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    $tlExcel = $script:TimeLineOutput | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_TimeLine") -Title "Timeline for $Identity" -AutoSize -FreezeTopRow -BoldTopRow -PassThru 3>$null
+    $ErrorActionPreference = $savedEAP
+    $tlExcel.Workbook.Worksheets[$ShortId + "_TimeLine"].TabColor = $script:TabColor
+    Export-Excel -ExcelPackage $tlExcel -WorksheetName $($ShortId + "_TimeLine")
 }
 
 function GetExcelParams($path, $tabName) {
     if ($script:IsOrganizer) {
         $TableStyle = "Light10" # Orange for Organizer
         $TitleExtra = ", Organizer"
+        $script:TabColor = [System.Drawing.Color]::FromArgb(237, 125, 49) # Orange
     } elseif ($script:IsRoomMB) {
         Write-Host -ForegroundColor green "Room Mailbox Detected"
         $TableStyle = "Light11" # Green for Room Mailbox
         $TitleExtra = ", Resource"
+        $script:TabColor = [System.Drawing.Color]::FromArgb(112, 173, 71) # Green
     } else {
         $TableStyle = "Light12" # Light Blue for normal
         # Dark Blue for Delegates (once we can determine this)
+        $script:TabColor = [System.Drawing.Color]::FromArgb(91, 155, 213) # Blue
     }
 
     if ($script:CalLogsDisabled) {
         $TitleExtra += ", WARNING: CalLogs are Turned Off for $Identity! This will be a incomplete story"
+        $script:TabColor = [System.Drawing.Color]::FromArgb(255, 0, 0) # Red for Disabled CalLogs
     }
 
     $script:lastRow = $script:GCDO.Count + $firstRow - 1 # Last row is the number of items in the GCDO array + 2 for the header and title rows.
@@ -100,7 +225,6 @@ function GetExcelParams($path, $tabName) {
         TableName               = $tabName
         FreezeTopRowFirstColumn = $true
         AutoFilter              = $true
-        AutoNameRange           = $true
         Append                  = $true
         Title                   = "Enhanced Calendar Logs for $Identity" + $TitleExtra + " for MeetingID [$($script:GCDO[0].CleanGlobalObjectId)]."
         TitleSize               = 14
@@ -143,10 +267,12 @@ $ColumnMap = @{
     HasAttachment                  = "AF"
     IsCancelled                    = "AG"
     IsAllDayEvent                  = "AH"
-    IsSeriesCancelled              = "AI"
-    SendMeetingMessagesDiagnostics = "AJ"
-    AttendeeCollection             = "AK"
-    CalendarLogRequestId           = "AL"
+    Sensitivity                    = "AI"
+    IsSeriesCancelled              = "AJ"
+    SendMeetingMessagesDiagnostics = "AK"
+    AttendeeCollection             = "AL"
+    CalendarLogRequestId           = "AM"
+    CleanGlobalObjectId            = "AN"
 }
 
 function GetExcelColumnNumber {
@@ -215,9 +341,6 @@ $ConditionalFormatting = @(
     New-ConditionalText -Range (Get-ColumnRange -PropertyName 'FreeBusyStatus') -ConditionalType ContainsText -Text "Tentative" -ConditionalTextColor Orange -BackgroundColor $null
     New-ConditionalText -Range (Get-ColumnRange -PropertyName 'FreeBusyStatus') -ConditionalType ContainsText -Text "Busy" -ConditionalTextColor Green -BackgroundColor $null
 
-    New-ConditionalText -Range (Get-ColumnRange -PropertyName 'SharedFolderName') -ConditionalType Equal -Text "Not Shared" -ConditionalTextColor Blue -BackgroundColor $null
-    New-ConditionalText -Range (Get-ColumnRange -PropertyName 'SharedFolderName') -ConditionalType NotContainsText -Text "Not Shared" -ConditionalTextColor Black -BackgroundColor Tan
-
     New-ConditionalText -Range (Get-ColumnRange -PropertyName 'MeetingRequestType') -ConditionalType ContainsText -Text "Outdated" -ConditionalTextColor DarkRed -BackgroundColor LightPink
 
     New-ConditionalText -Range (Get-ColumnRange -PropertyName 'CalendarItemType') -ConditionalType ContainsText -Text "RecurringMaster" -ConditionalTextColor $null -BackgroundColor Plum
@@ -234,6 +357,9 @@ function CheckRows {
     )
     $sheet = $excel.Workbook.Worksheets[$ShortId]
 
+    # Pre-filter LogRowType to hide noisy rows (OtherAssistant, MeetingMessageChange, deleted exceptions)
+    SetLogRowTypeFilter -excel $excel
+
     # Highlight the Resp in LightGoldenRodYellow
     CheckColumnForText -sheet $sheet -columnNumber $(GetExcelColumnNumber($ColumnMap.ItemClass)) -textToFind "Resp" -cellColor "LightGoldenRodYellow" -fontColor "Black"
 
@@ -246,6 +372,244 @@ function CheckRows {
     # Highlight the Create from Transport in light blue
     CheckColumnsForValues -sheet $sheet -columnNumber1  $(GetExcelColumnNumber($ColumnMap.LogClientInfoString)) -value1 "Transport" -columnNumber2  $(GetExcelColumnNumber($ColumnMap.TriggerAction)) -value2 "Create" -cellColor "LightBlue" -fontColor "Black"
 
+    # Highlight SharedFolderName with unique colors per shared folder
+    HighlightSharedFolderNames -sheet $sheet
+
+    # Detect organizer anomalies (only on organizer's tab)
+    if ($script:IsOrganizer) {
+        CheckOrganizerErrors -sheet $sheet
+    }
+
+    $excel.Save()
+}
+
+<#
+.SYNOPSIS
+Pre-filters the LogRowType column in the Excel table to hide noisy row types.
+Hides OtherAssistant, MeetingMessageChange, and DeletedSeriesException rows by default.
+Users can clear the filter in Excel to see all rows.
+#>
+function SetLogRowTypeFilter {
+    param(
+        [object] $excel
+    )
+
+    $sheet = $excel.Workbook.Worksheets[$ShortId]
+    $logRowCol = GetExcelColumnNumber($ColumnMap.LogRowType)
+
+    # Values to hide by default
+    $hideValues = @("OtherAssistant", "MeetingMessageChange", "DeletedSeriesException")
+
+    # Collect all unique values in the LogRowType column
+    $lastDataRow = $sheet.Dimension.End.Row
+    $allValues = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
+        $val = $sheet.Cells[$row, $logRowCol].Text
+        if (-not [string]::IsNullOrEmpty($val)) {
+            [void]$allValues.Add($val)
+        }
+    }
+
+    $showValues = @($allValues | Where-Object { $_ -notin $hideValues })
+    if ($showValues.Count -eq $allValues.Count) {
+        Write-Verbose "No LogRowType values to filter out."
+        return
+    }
+
+    Write-Verbose "Pre-filtering LogRowType: hiding $($hideValues -join ', ')"
+
+    # Get the table and its autoFilter XML node
+    $tbl = $sheet.Tables[0]
+    if ($null -eq $tbl) {
+        Write-Verbose "No table found, skipping LogRowType filter."
+        return
+    }
+
+    $ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    $nsm = [System.Xml.XmlNamespaceManager]::new($tbl.TableXml.NameTable)
+    $nsm.AddNamespace("t", $ns)
+    $autoFilter = $tbl.TableXml.SelectSingleNode("//t:autoFilter", $nsm)
+
+    if ($null -eq $autoFilter) {
+        Write-Verbose "No autoFilter found in table, skipping."
+        return
+    }
+
+    # Build filterColumn with visible values (Excel filters list what to SHOW)
+    # colId is 0-based relative to the table, LogRowType is the 2nd column (B) = colId 1
+    $tableStartCol = $tbl.Address.Start.Column
+    $filterColId = $logRowCol - $tableStartCol
+
+    $filterCol = $tbl.TableXml.CreateElement("filterColumn", $ns)
+    $filterCol.SetAttribute("colId", $filterColId.ToString())
+    $filters = $tbl.TableXml.CreateElement("filters", $ns)
+
+    foreach ($val in $showValues) {
+        $f = $tbl.TableXml.CreateElement("filter", $ns)
+        $f.SetAttribute("val", $val)
+        $null = $filters.AppendChild($f)
+    }
+    $null = $filterCol.AppendChild($filters)
+    $null = $autoFilter.AppendChild($filterCol)
+
+    # Hide the actual rows so they appear filtered on open
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
+        $val = $sheet.Cells[$row, $logRowCol].Text
+        if ($val -in $hideValues) {
+            $sheet.Row($row).Hidden = $true
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Detects organizer anomalies on the Organizer's tab:
+1. ResponseType changes from "Organizer" to something else on IPM.Appointment/Exception rows (not shared).
+2. The From (Organizer SMTP) changes between qualifying rows, indicating multiple organizers.
+Highlights the row text in Red and the problematic cell in Yellow.
+#>
+function CheckOrganizerErrors {
+    param(
+        [object] $sheet
+    )
+
+    $itemClassCol = GetExcelColumnNumber($ColumnMap.ItemClass)
+    $sharedFolderCol = GetExcelColumnNumber($ColumnMap.SharedFolderName)
+    $responseTypeCol = GetExcelColumnNumber($ColumnMap.ResponseType)
+    $fromCol = GetExcelColumnNumber($ColumnMap.From)
+    $lastDataRow = $sheet.Dimension.End.Row
+    $lastDataCol = $sheet.Dimension.End.Column
+
+    $firstOrganizer = $null  # Track the first From value seen on a qualifying row
+
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
+        $itemClass = $sheet.Cells[$row, $itemClassCol].Text
+        $sharedFolder = $sheet.Cells[$row, $sharedFolderCol].Text
+
+        # Only check IPM.Appointment and Exception rows that are not shared
+        if (($itemClass -ne "Ipm.Appointment" -and $itemClass -ne "Exception") -or
+            $sharedFolder -ne "Not Shared") {
+            continue
+        }
+
+        $responseType = $sheet.Cells[$row, $responseTypeCol].Text
+        $fromValue = $sheet.Cells[$row, $fromCol].Text
+
+        # Check 1: ResponseType should be "Organizer" on the organizer's tab
+        if ($responseType -ne "Organizer") {
+            # Red text for the whole row
+            $rowRange = $sheet.Cells[$row, 1, $row, $lastDataCol]
+            $rowRange.Style.Font.Color.SetColor([System.Drawing.Color]::Red)
+            # Yellow highlight on the ResponseType cell
+            $cell = $sheet.Cells[$row, $responseTypeCol]
+            $cell.Style.Fill.PatternType = 'Solid'
+            $cell.Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::Yellow)
+        }
+
+        # Check 2: From (Organizer SMTP) should not change between qualifying rows
+        if ([string]::IsNullOrEmpty($fromValue) -or $fromValue -eq "-") {
+            continue
+        }
+
+        if ($null -eq $firstOrganizer) {
+            $firstOrganizer = $fromValue
+        } elseif ($fromValue -ne $firstOrganizer) {
+            # Red text for the whole row
+            $rowRange = $sheet.Cells[$row, 1, $row, $lastDataCol]
+            $rowRange.Style.Font.Color.SetColor([System.Drawing.Color]::Red)
+            # Yellow highlight on the From cell
+            $cell = $sheet.Cells[$row, $fromCol]
+            $cell.Style.Fill.PatternType = 'Solid'
+            $cell.Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::Yellow)
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Highlights rows in the SharedFolderName column with a unique pale color per shared folder name.
+Cycles through 7 pale colors if there are more than 7 unique shared folder names.
+#>
+function HighlightSharedFolderNames {
+    param(
+        [object] $sheet
+    )
+
+    $sharedFolderCol = GetExcelColumnNumber($ColumnMap.SharedFolderName)
+    $lastDataRow = $sheet.Dimension.End.Row
+    $lastDataCol = $sheet.Dimension.End.Column
+
+    # Debug: verify column alignment
+    $headerValue = $sheet.Cells[2, $sharedFolderCol].Text
+    Write-Verbose "HighlightSharedFolderNames: Column $($ColumnMap.SharedFolderName) = col# $sharedFolderCol, header='$headerValue', rows=$($script:firstRow)..$lastDataRow"
+    if ($headerValue -ne "SharedFolderName") {
+        # Column map is misaligned — find the actual column by scanning the header row
+        for ($c = 1; $c -le $lastDataCol; $c++) {
+            if ($sheet.Cells[2, $c].Text -eq "SharedFolderName") {
+                Write-Host -ForegroundColor Yellow "HighlightSharedFolderNames: SharedFolderName found at column $c (expected $sharedFolderCol)"
+                $sharedFolderCol = $c
+                break
+            }
+        }
+    }
+
+    # Pale colors that are readable with black text
+    # cSpell:ignore FromArgb
+    [System.Drawing.Color[]] $PaleColors = @(
+        [System.Drawing.Color]::FromArgb(220, 245, 220)  # Pale Green
+        [System.Drawing.Color]::FromArgb(180, 215, 255)  # Pale Blue
+        [System.Drawing.Color]::FromArgb(255, 240, 220)  # Pale Peach
+        [System.Drawing.Color]::FromArgb(245, 230, 255)  # Pale Lavender
+        [System.Drawing.Color]::FromArgb(255, 255, 210)  # Pale Yellow
+        [System.Drawing.Color]::FromArgb(255, 225, 230)  # Pale Pink
+        [System.Drawing.Color]::FromArgb(220, 245, 245)  # Pale Cyan
+    )
+
+    # Collect unique SharedFolderName values and apply formatting in a single pass
+    $folderNames = @{}
+    $colorIndex = 0
+
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
+        $cellValue = $sheet.Cells[$row, $sharedFolderCol].Text
+        if ([string]::IsNullOrEmpty($cellValue) -or $cellValue -eq "Not Shared") {
+            continue
+        }
+        if (-not $folderNames.ContainsKey($cellValue)) {
+            $folderNames[$cellValue] = $PaleColors[$colorIndex % $PaleColors.Count]
+            $colorIndex++
+        }
+
+        $color = $folderNames[$cellValue]
+        # Italicize the entire row
+        $rowRange = $sheet.Cells[$row, 1, $row, $lastDataCol]
+        $rowRange.Style.Font.Italic = $true
+        # Highlight only the SharedFolderName cell
+        $cell = $sheet.Cells[$row, $sharedFolderCol]
+        $cell.Style.Fill.PatternType = 'Solid'
+        $cell.Style.Fill.BackgroundColor.SetColor($color)
+    }
+
+    if ($folderNames.Count -eq 0) {
+        Write-Verbose "No shared folder names found to highlight."
+    } else {
+        Write-Verbose "Highlighted $($folderNames.Count) unique shared folder name(s)."
+    }
+}
+
+function SortByLogTimestamp {
+    param(
+        [object] $excel
+    )
+    $sheet = $excel.Workbook.Worksheets[$ShortId]
+    $dataStartRow = $script:firstRow # Row 3 (row 1 = title, row 2 = header)
+    $dataEndRow = $sheet.Dimension.End.Row
+    $dataEndCol = $sheet.Dimension.End.Column
+    $sortCol = GetExcelColumnNumber($ColumnMap.LogTimestamp)
+
+    # Sort the data range by LogTimestamp column ascending
+    # EPPlus Sort() takes a 0-based column offset within the range
+    $sortRange = $sheet.Cells[$dataStartRow, 1, $dataEndRow, $dataEndCol]
+    $sortRange.Sort($sortCol - 1)
     $excel.Save()
 }
 
@@ -262,12 +626,14 @@ function CheckColumnForText {
         [string] $fontColor = "DarkRed"
     )
 
+    $lastDataRow = $sheet.Dimension.End.Row
+    $lastDataCol = $sheet.Dimension.End.Column
     Write-Verbose "Checking column $columnNumber for text '$textToFind'..."
-    for ($row = 3; $row -le $sheet.Dimension.End.Row; $row++) {
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
         $cellValue = $sheet.Cells[$row, $columnNumber].Text
 
         if ($cellValue -like "*$textToFind*") {
-            HighlightRow -sheet $sheet -rowNumber $row -cellColor $cellColor -fontColor $fontColor
+            HighlightRow -sheet $sheet -rowNumber $row -lastCol $lastDataCol -cellColor $cellColor -fontColor $fontColor
         }
     }
 }
@@ -284,13 +650,15 @@ function CheckColumnsForValues {
         [string] $fontColor = "DarkRed"
     )
 
+    $lastDataRow = $sheet.Dimension.End.Row
+    $lastDataCol = $sheet.Dimension.End.Column
     Write-Verbose "Checking for rows where column $columnNumber1 = '$value1' AND column $columnNumber2 = '$value2'..."
-    for ($row = 3; $row -le $sheet.Dimension.End.Row; $row++) {
+    for ($row = $script:firstRow; $row -le $lastDataRow; $row++) {
         $cellValue1 = $sheet.Cells[$row, $columnNumber1].Text
         $cellValue2 = $sheet.Cells[$row, $columnNumber2].Text
 
         if ($cellValue1 -like "*$value1*" -and $cellValue2 -like "*$value2*") {
-            HighlightRow -sheet $sheet -rowNumber $row -cellColor $cellColor -fontColor $fontColor
+            HighlightRow -sheet $sheet -rowNumber $row -lastCol $lastDataCol -cellColor $cellColor -fontColor $fontColor
         }
     }
 }
@@ -298,18 +666,17 @@ function CheckColumnsForValues {
 function HighlightRow {
     param(
         [object] $sheet,
-        [string] $rowNumber,
+        [int] $rowNumber,
+        [int] $lastCol,
         [string] $cellColor = "Thistle",
         [string] $fontColor = "DarkRed"
     )
-    # Highlight the entire row with the specified color
-    # 'A' to our last row, 'AM'.
-    $rowName = "A" + $row + ":" + $lastColumn + $row
 
-    Write-Verbose "Highlighting row $rowName with cell color [$cellColor] and font color [$fontColor]"
-    $sheet.Cells[$rowName].Style.Fill.PatternType = 'Solid'
-    $sheet.Cells[$rowName].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::$cellColor)
-    $sheet.Cells[$rowName].Style.Font.Color.SetColor([System.Drawing.Color]::$fontColor)
+    $rowRange = $sheet.Cells[$rowNumber, 1, $rowNumber, $lastCol]
+    Write-Verbose "Highlighting row $rowNumber with cell color [$cellColor] and font color [$fontColor]"
+    $rowRange.Style.Fill.PatternType = 'Solid'
+    $rowRange.Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::$cellColor)
+    $rowRange.Style.Font.Color.SetColor([System.Drawing.Color]::$fontColor)
 }
 
 function FormatHeader {
@@ -322,7 +689,7 @@ function FormatHeader {
     # Define header metadata: property name, width, alignment, number format, comment
     $headerMeta = @(
         @{ Name = "LogTimestamp"; Width = 20; Align = "Center"; NumberFormat = "m/d/yyyy h:mm:ss"; Comment = "LogTimestamp: Time when the change was recorded in the CalLogs. This and all Times are in UTC." }
-        @{ Name = "LogRowType"; Width = 20; Align = "Left"; Comment = "LogRowType: Interesting logs are what to focus on, filter all the others out to start with." }
+        @{ Name = "LogRowType"; Width = 20; Align = "Left"; Comment = "LogRowType: Filtered by default! Interesting logs are what to focus on. OtherAssistant, MeetingMessageChange, and DeletedSeriesException are hidden. Clear the filter to see all rows." }
         @{ Name = "SubjectProperty"; Width = 20; Align = "Left"; Comment = "SubjectProperty: The Subject of the Meeting." }
         @{ Name = "Client"; Width = 20; Align = "Left"; Comment = "Client (ShortClientInfoString): The 'friendly' Client name of the client that made the change." }
         @{ Name = "LogClientInfoString"; Width = 5; Align = "Left"; Comment = "LogClientInfoString: Full Client Info String of client that made the change." }
@@ -337,7 +704,7 @@ function FormatHeader {
         @{ Name = "LogFolder"; Width = 16; Align = "Left"; Comment = "LogFolder (ParentDisplayName): The Log Folder that the CalLog was in." }
         @{ Name = "OriginalLogFolder"; Width = 16; Align = "Left"; Comment = "OriginalLogFolder (OriginalParentDisplayName): The Original Log Folder that the item was in / delivered to." }
         @{ Name = "SharedFolderName"; Width = 15; Align = "Left"; Comment = "SharedFolderName: Was this from a Modern Sharing, and if so what Folder." }
-        @{ Name = "ReceivedRepresenting"; Width = 10; Align = "Left"; Comment = "ReceivedRepresenting: Who the item was Received for, of then the Delegate." }
+        @{ Name = "ReceivedRepresenting"; Width = 10; Align = "Left"; Comment = "ReceivedRepresenting: Who the item was Received for, often the Delegate." }
         @{ Name = "MeetingRequestType"; Width = 10; Align = "Center"; Comment = "MeetingRequestType: The Meeting Request Type of the Meeting." }
         @{ Name = "StartTime"; Width = 23; Align = "Center"; NumberFormat = "m/d/yyyy h:mm:ss"; Comment = "StartTime: The Start Time of the Meeting. This and all Times are in UTC." }
         @{ Name = "EndTime"; Width = 23; Align = "Center"; NumberFormat = "m/d/yyyy h:mm:ss"; Comment = "EndTime: The End Time of the Meeting. This and all Times are in UTC." }
@@ -355,10 +722,12 @@ function FormatHeader {
         @{ Name = "HasAttachment"; Width = 10; Align = "Center"; Comment = "HasAttachment: Does this Meeting have an Attachment?" }
         @{ Name = "IsCancelled"; Width = 10; Align = "Center"; Comment = "IsCancelled: Is this Meeting Cancelled?" }
         @{ Name = "IsAllDayEvent"; Width = 10; Align = "Center"; Comment = "IsAllDayEvent: Is this an All Day Event?" }
+        @{ Name = "Sensitivity"; Width = 12; Align = "Center"; Comment = "Sensitivity: The Sensitivity of the Meeting (Normal, Personal, Private, Confidential)." }
         @{ Name = "IsSeriesCancelled"; Width = 10; Align = "Center"; Comment = "IsSeriesCancelled: Is this a Series Cancelled Meeting?" }
         @{ Name = "SendMeetingMessagesDiagnostics"; Width = 30; Align = "Left"; Comment = "SendMeetingMessagesDiagnostics: Compound Property to describe why meeting was or was not sent to everyone." }
         @{ Name = "AttendeeCollection"; Width = 50; Align = "Left"; Comment = "AttendeeCollection: The Attendee Collection of the Meeting, use -TrackingLogs to get values." }
         @{ Name = "CalendarLogRequestId"; Width = 40; Align = "Center"; Comment = "CalendarLogRequestId: The Calendar Log Request ID of the Meeting." }
+        @{ Name = "CleanGlobalObjectId"; Width = 40; Align = "Left"; Comment = "CleanGlobalObjectId: The MeetingID / Clean Global Object ID of the Meeting." }
     )
 
     foreach ($meta in $headerMeta) {
@@ -381,7 +750,7 @@ function FormatHeader {
 
     # Title Row
     $sheet.Row(1) | Set-ExcelRange -HorizontalAlignment Left
-    Set-CellComment -Text "For more information see: Https:\\aka.ms\AnalyzeCalLogs"  -Row 1 -ColumnNumber 1  -Worksheet $sheet
+    Set-CellComment -Text "For more information see: https://aka.ms/AnalyzeCalLogs"  -Row 1 -ColumnNumber 1  -Worksheet $sheet
 
     # Set the Header row to be bold and left aligned
     $sheet.Row($HeaderRow) | Set-ExcelRange -Bold -HorizontalAlignment Left

--- a/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
+++ b/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
@@ -55,11 +55,11 @@ function LogScriptInfo {
                             $script:RunNumber = [int]$Matches[1]
                         }
                     }
-                } else {
-                    if ($null -ne $pkg) { $pkg.Dispose() }
                 }
             } catch {
                 Write-Verbose "Unable to read existing run count from Excel: $_"
+            } finally {
+                if ($null -ne $pkg) { $pkg.Dispose() }
             }
         }
         $script:RunNumber++
@@ -172,13 +172,33 @@ function LogScriptInfo {
     # Update snapshot so next identity only captures new errors
     $script:PreRunErrorCount = $Error.Count
 
-    # Append to the existing Script Info tab
+    # Append to the existing Script Info tab (skip -Append on first write when the tab doesn't exist yet)
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'SilentlyContinue'
-    $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -Append -PassThru 3>$null
+    $appendToSheet = $false
+    if (Test-Path $FileName) {
+        try {
+            $testPkg = Open-ExcelPackage -Path $FileName -ErrorAction SilentlyContinue
+            if ($null -ne $testPkg -and $null -ne $testPkg.Workbook.Worksheets["Script Info"]) {
+                $appendToSheet = $true
+            }
+            if ($null -ne $testPkg) { $testPkg.Dispose() }
+        } catch {
+            Write-Verbose "Unable to check for existing Script Info tab: $_"
+        }
+    }
+
+    if ($appendToSheet) {
+        $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -Append -PassThru 3>$null
+    } else {
+        $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -PassThru 3>$null
+    }
     $ErrorActionPreference = $savedEAP
-    $infoExcel.Workbook.Worksheets["Script Info"].TabColor = [System.Drawing.Color]::Gray
-    Export-Excel -ExcelPackage $infoExcel -WorksheetName "Script Info"
+
+    if ($null -ne $infoExcel) {
+        $infoExcel.Workbook.Worksheets["Script Info"].TabColor = [System.Drawing.Color]::Gray
+        Export-Excel -ExcelPackage $infoExcel -WorksheetName "Script Info"
+    }
 }
 
 function Export-TimelineExcel {
@@ -439,6 +459,12 @@ function SetLogRowTypeFilter {
     # colId is 0-based relative to the table, LogRowType is the 2nd column (B) = colId 1
     $tableStartCol = $tbl.Address.Start.Column
     $filterColId = $logRowCol - $tableStartCol
+
+    # Remove any existing filterColumn for this colId to avoid duplicates on reruns
+    $existingFilterCol = $autoFilter.SelectSingleNode("t:filterColumn[@colId='$filterColId']", $nsm)
+    if ($null -ne $existingFilterCol) {
+        $null = $autoFilter.RemoveChild($existingFilterCol)
+    }
 
     $filterCol = $tbl.TableXml.CreateElement("filterColumn", $ns)
     $filterCol.SetAttribute("colId", $filterColId.ToString())

--- a/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
+++ b/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
@@ -115,6 +115,18 @@ function LogScriptInfo {
                 Value = ($ValidatedIdentities -join '; ')
             })
 
+        if ($script:SubjectSearch) {
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "Collection Method"
+                    Value = "Subject search (no Exception or Tracking Log data). Use -MeetingID for full collection."
+                })
+        } else {
+            $RunInfo.Add([PSCustomObject]@{
+                    Key   = "Collection Method"
+                    Value = "MeetingID"
+                })
+        }
+
         # Only log environment info on the first run
         if ($script:RunNumber -eq 1) {
             $RunInfo.Add([PSCustomObject]@{
@@ -172,33 +184,46 @@ function LogScriptInfo {
     # Update snapshot so next identity only captures new errors
     $script:PreRunErrorCount = $Error.Count
 
-    # Append to the existing Script Info tab (skip -Append on first write when the tab doesn't exist yet)
+    # Write Script Info into the existing workbook (Enhanced tab was already saved)
     $savedEAP = $ErrorActionPreference
     $ErrorActionPreference = 'SilentlyContinue'
-    $appendToSheet = $false
-    if (Test-Path $FileName) {
-        try {
-            $testPkg = Open-ExcelPackage -Path $FileName -ErrorAction SilentlyContinue
-            if ($null -ne $testPkg -and $null -ne $testPkg.Workbook.Worksheets["Script Info"]) {
-                $appendToSheet = $true
-            }
-            if ($null -ne $testPkg) { $testPkg.Dispose() }
-        } catch {
-            Write-Verbose "Unable to check for existing Script Info tab: $_"
+
+    # Open existing package and add/append the Script Info sheet
+    try {
+        $pkg = Open-ExcelPackage -Path $FileName -ErrorAction Stop
+        $sheetExists = $null -ne $pkg.Workbook.Worksheets["Script Info"]
+
+        if ($sheetExists) {
+            # Append rows after existing data
+            $ws = $pkg.Workbook.Worksheets["Script Info"]
+            $startRow = $ws.Dimension.End.Row + 1
+        } else {
+            # Create a new sheet
+            $ws = $pkg.Workbook.Worksheets.Add("Script Info")
+            $startRow = 1
+            # Add header row
+            $ws.Cells[$startRow, 1].Value = "Key"
+            $ws.Cells[$startRow, 2].Value = "Value"
+            $startRow = 2
         }
+
+        foreach ($item in $RunInfo) {
+            $ws.Cells[$startRow, 1].Value = $item.Key
+            $ws.Cells[$startRow, 2].Value = [string]$item.Value
+            $startRow++
+        }
+
+        $ws.Column(1).Width = 25
+        $ws.Column(2).Width = 80
+        $ws.TabColor = [System.Drawing.Color]::Gray
+        $pkg.Save()
+        $pkg.Dispose()
+    } catch {
+        Write-Warning "Unable to write Script Info tab: $_"
+        if ($null -ne $pkg) { $pkg.Dispose() }
     }
 
-    if ($appendToSheet) {
-        $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -Append -PassThru 3>$null
-    } else {
-        $infoExcel = $RunInfo | Export-Excel -Path $FileName -WorksheetName "Script Info" -PassThru 3>$null
-    }
     $ErrorActionPreference = $savedEAP
-
-    if ($null -ne $infoExcel) {
-        $infoExcel.Workbook.Worksheets["Script Info"].TabColor = [System.Drawing.Color]::Gray
-        Export-Excel -ExcelPackage $infoExcel -WorksheetName "Script Info"
-    }
 }
 
 function Export-TimelineExcel {
@@ -230,6 +255,10 @@ function GetExcelParams($path, $tabName) {
     if ($script:CalLogsDisabled) {
         $TitleExtra += ", WARNING: CalLogs are Turned Off for $Identity! This will be a incomplete story"
         $script:TabColor = [System.Drawing.Color]::FromArgb(255, 0, 0) # Red for Disabled CalLogs
+    }
+
+    if ($script:SubjectSearch) {
+        $TitleExtra += ", Collected with Subject search (no Exception info)"
     }
 
     $script:lastRow = $script:GCDO.Count + $firstRow - 1 # Last row is the number of items in the GCDO array + 2 for the header and title rows.

--- a/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
+++ b/Calendar/CalLogHelpers/ExportToExcelFunctions.ps1
@@ -13,11 +13,12 @@ function Export-CalLogExcel {
     # Suppress EPPlus warnings and errors that occur when writing to an existing file
     # (AutoNameRange validation, named range conflicts, title character warnings)
     $savedErrorActionPreference = $ErrorActionPreference
-    $ErrorActionPreference = 'SilentlyContinue'
-
-    $excel = $GCDOResults | Export-Excel @ExcelParamsArray -PassThru 3>$null
-
-    $ErrorActionPreference = $savedErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        $excel = $GCDOResults | Export-Excel @ExcelParamsArray -PassThru 3>$null
+    } finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
 
     FormatHeader ($excel)
     SortByLogTimestamp ($excel)
@@ -33,9 +34,12 @@ function Export-CalLogExcel {
 
     # Export Raw Logs for Developer Analysis
     Write-Host -ForegroundColor Cyan "Exporting Raw CalLogs to Excel Tab [$($ShortId + "_Raw")]..."
-    $ErrorActionPreference = 'SilentlyContinue'
-    $rawExcel = $script:GCDO | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_Raw") -AutoFilter -FreezeTopRow -BoldTopRow -MoveToEnd -PassThru 3>$null
-    $ErrorActionPreference = $savedErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        $rawExcel = $script:GCDO | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_Raw") -AutoFilter -FreezeTopRow -BoldTopRow -MoveToEnd -PassThru 3>$null
+    } finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
     $rawExcel.Workbook.Worksheets[$ShortId + "_Raw"].TabColor = $script:TabColor
     Export-Excel -ExcelPackage $rawExcel -WorksheetName $($ShortId + "_Raw")
 }
@@ -186,52 +190,57 @@ function LogScriptInfo {
 
     # Write Script Info into the existing workbook (Enhanced tab was already saved)
     $savedEAP = $ErrorActionPreference
-    $ErrorActionPreference = 'SilentlyContinue'
-
-    # Open existing package and add/append the Script Info sheet
     try {
-        $pkg = Open-ExcelPackage -Path $FileName -ErrorAction Stop
-        $sheetExists = $null -ne $pkg.Workbook.Worksheets["Script Info"]
+        $ErrorActionPreference = 'SilentlyContinue'
 
-        if ($sheetExists) {
-            # Append rows after existing data
-            $ws = $pkg.Workbook.Worksheets["Script Info"]
-            $startRow = $ws.Dimension.End.Row + 1
-        } else {
-            # Create a new sheet
-            $ws = $pkg.Workbook.Worksheets.Add("Script Info")
-            $startRow = 1
-            # Add header row
-            $ws.Cells[$startRow, 1].Value = "Key"
-            $ws.Cells[$startRow, 2].Value = "Value"
-            $startRow = 2
+        # Open existing package and add/append the Script Info sheet
+        try {
+            $pkg = Open-ExcelPackage -Path $FileName -ErrorAction Stop
+            $sheetExists = $null -ne $pkg.Workbook.Worksheets["Script Info"]
+
+            if ($sheetExists) {
+                # Append rows after existing data
+                $ws = $pkg.Workbook.Worksheets["Script Info"]
+                $startRow = $ws.Dimension.End.Row + 1
+            } else {
+                # Create a new sheet
+                $ws = $pkg.Workbook.Worksheets.Add("Script Info")
+                $startRow = 1
+                # Add header row
+                $ws.Cells[$startRow, 1].Value = "Key"
+                $ws.Cells[$startRow, 2].Value = "Value"
+                $startRow = 2
+            }
+
+            foreach ($item in $RunInfo) {
+                $ws.Cells[$startRow, 1].Value = $item.Key
+                $ws.Cells[$startRow, 2].Value = [string]$item.Value
+                $startRow++
+            }
+
+            $ws.Column(1).Width = 25
+            $ws.Column(2).Width = 80
+            $ws.TabColor = [System.Drawing.Color]::Gray
+            $pkg.Save()
+            $pkg.Dispose()
+        } catch {
+            Write-Warning "Unable to write Script Info tab: $_"
+            if ($null -ne $pkg) { $pkg.Dispose() }
         }
-
-        foreach ($item in $RunInfo) {
-            $ws.Cells[$startRow, 1].Value = $item.Key
-            $ws.Cells[$startRow, 2].Value = [string]$item.Value
-            $startRow++
-        }
-
-        $ws.Column(1).Width = 25
-        $ws.Column(2).Width = 80
-        $ws.TabColor = [System.Drawing.Color]::Gray
-        $pkg.Save()
-        $pkg.Dispose()
-    } catch {
-        Write-Warning "Unable to write Script Info tab: $_"
-        if ($null -ne $pkg) { $pkg.Dispose() }
+    } finally {
+        $ErrorActionPreference = $savedEAP
     }
-
-    $ErrorActionPreference = $savedEAP
 }
 
 function Export-TimelineExcel {
     Write-Host -ForegroundColor Cyan "Exporting Timeline to Excel..."
     $savedEAP = $ErrorActionPreference
-    $ErrorActionPreference = 'SilentlyContinue'
-    $tlExcel = $script:TimeLineOutput | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_TimeLine") -Title "Timeline for $Identity" -AutoSize -FreezeTopRow -BoldTopRow -PassThru 3>$null
-    $ErrorActionPreference = $savedEAP
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        $tlExcel = $script:TimeLineOutput | Export-Excel -Path $FileName -WorksheetName $($ShortId + "_TimeLine") -Title "Timeline for $Identity" -AutoSize -FreezeTopRow -BoldTopRow -PassThru 3>$null
+    } finally {
+        $ErrorActionPreference = $savedEAP
+    }
     $tlExcel.Workbook.Worksheets[$ShortId + "_TimeLine"].TabColor = $script:TabColor
     Export-Excel -ExcelPackage $tlExcel -WorksheetName $($ShortId + "_TimeLine")
 }

--- a/Calendar/CalLogHelpers/FindChangedPropFunctions.ps1
+++ b/Calendar/CalLogHelpers/FindChangedPropFunctions.ps1
@@ -3,6 +3,30 @@
 
 <#
 .SYNOPSIS
+    Returns true if the value is effectively "not found" / empty.
+#>
+function IsNotFound {
+    param($Value)
+    return ([string]::IsNullOrEmpty($Value) -or $Value -eq "NotFound" -or $Value -eq "-")
+}
+
+<#
+.SYNOPSIS
+    Checks if a property changed between two CalLog entries, ignoring transitions to/from NotFound.
+    Returns true if there is a meaningful change worth reporting.
+#>
+function HasMeaningfulChange {
+    param(
+        $OldValue,
+        $NewValue
+    )
+    if ($OldValue -eq $NewValue) { return $false }
+    if ((IsNotFound $OldValue) -or (IsNotFound $NewValue)) { return $false }
+    return $true
+}
+
+<#
+.SYNOPSIS
     Determines if key properties of the calendar log have changed.
 .DESCRIPTION
     This function checks if the properties of the calendar log have changed by comparing the current
@@ -11,114 +35,114 @@
     Changed properties will be added to the Timeline.
 #>
 function FindChangedProperties {
-    if ($CalLog.Client -ne "LocationProcessor" -or $CalLog.Client -notlike "*EBA*" -or $CalLog.Client -notlike "*TBA*") {
+    if ($CalLog.Client -ne "LocationProcessor" -and $CalLog.Client -notlike "*EBA*" -and $CalLog.Client -notlike "*TBA*") {
         if ($script:PreviousCalLog -and $script:AddChangedProperties) {
-            if ($CalLog.StartTime.ToString() -ne $script:PreviousCalLog.StartTime.ToString()) {
+            if (HasMeaningfulChange $script:PreviousCalLog.StartTime.ToString() $CalLog.StartTime.ToString()) {
                 [Array]$TimeLineText = "The StartTime changed from [$($script:PreviousCalLog.StartTime)] to: [$($CalLog.StartTime)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.EndTime.ToString() -ne $script:PreviousCalLog.EndTime.ToString()) {
+            if (HasMeaningfulChange $script:PreviousCalLog.EndTime.ToString() $CalLog.EndTime.ToString()) {
                 [Array]$TimeLineText = "The EndTime changed from [$($script:PreviousCalLog.EndTime)] to: [$($CalLog.EndTime)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.SubjectProperty -ne $script:PreviousCalLog.SubjectProperty) {
+            if (HasMeaningfulChange $script:PreviousCalLog.SubjectProperty $CalLog.SubjectProperty) {
                 [Array]$TimeLineText = "The SubjectProperty changed from [$($script:PreviousCalLog.SubjectProperty)] to: [$($CalLog.SubjectProperty)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.NormalizedSubject -ne $script:PreviousCalLog.NormalizedSubject) {
+            if (HasMeaningfulChange $script:PreviousCalLog.NormalizedSubject $CalLog.NormalizedSubject) {
                 [Array]$TimeLineText = "The NormalizedSubject changed from [$($script:PreviousCalLog.NormalizedSubject)] to: [$($CalLog.NormalizedSubject)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.Location -ne $script:PreviousCalLog.Location) {
+            if (HasMeaningfulChange $script:PreviousCalLog.Location $CalLog.Location) {
                 [Array]$TimeLineText = "The Location changed from [$($script:PreviousCalLog.Location)] to: [$($CalLog.Location)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.TimeZone -ne $script:PreviousCalLog.TimeZone) {
+            if (HasMeaningfulChange $script:PreviousCalLog.TimeZone $CalLog.TimeZone) {
                 [Array]$TimeLineText = "The TimeZone changed from [$($script:PreviousCalLog.TimeZone)] to: [$($CalLog.TimeZone)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.DisplayAttendeesAll -ne $script:PreviousCalLog.DisplayAttendeesAll) {
+            if (HasMeaningfulChange $script:PreviousCalLog.DisplayAttendeesAll $CalLog.DisplayAttendeesAll) {
                 [Array]$TimeLineText = "The All Attendees changed from [$($script:PreviousCalLog.DisplayAttendeesAll)] to: [$($CalLog.DisplayAttendeesAll)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.AppointmentRecurring -ne $script:PreviousCalLog.AppointmentRecurring) {
+            if (HasMeaningfulChange $script:PreviousCalLog.AppointmentRecurring $CalLog.AppointmentRecurring) {
                 [Array]$TimeLineText = "The Appointment Recurrence changed from [$($script:PreviousCalLog.AppointmentRecurring)] to: [$($CalLog.AppointmentRecurring)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.HasAttachment -ne $script:PreviousCalLog.HasAttachment) {
+            if (HasMeaningfulChange $script:PreviousCalLog.HasAttachment $CalLog.HasAttachment) {
                 [Array]$TimeLineText = "The Meeting has Attachment changed from [$($script:PreviousCalLog.HasAttachment)] to: [$($CalLog.HasAttachment)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.IsCancelled -ne $script:PreviousCalLog.IsCancelled) {
+            if (HasMeaningfulChange $script:PreviousCalLog.IsCancelled $CalLog.IsCancelled) {
                 [Array]$TimeLineText = "The Meeting is Cancelled changed from [$($script:PreviousCalLog.IsCancelled)] to: [$($CalLog.IsCancelled)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.IsAllDayEvent -ne $script:PreviousCalLog.IsAllDayEvent) {
+            if (HasMeaningfulChange $script:PreviousCalLog.IsAllDayEvent $CalLog.IsAllDayEvent) {
                 [Array]$TimeLineText = "The Meeting is an All Day Event changed from [$($script:PreviousCalLog.IsAllDayEvent)] to: [$($CalLog.IsAllDayEvent)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.IsException -ne $script:PreviousCalLog.IsException) {
+            if (HasMeaningfulChange $script:PreviousCalLog.IsException $CalLog.IsException) {
                 [Array]$TimeLineText = "The Meeting Is Exception changed from [$($script:PreviousCalLog.IsException)] to: [$($CalLog.IsException)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.IsSeriesCancelled -ne $script:PreviousCalLog.IsSeriesCancelled) {
+            if (HasMeaningfulChange $script:PreviousCalLog.IsSeriesCancelled $CalLog.IsSeriesCancelled) {
                 [Array]$TimeLineText = "The Is Series Cancelled changed from [$($script:PreviousCalLog.IsSeriesCancelled)] to: [$($CalLog.IsSeriesCancelled)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.EventEmailReminderTimer -ne $script:PreviousCalLog.EventEmailReminderTimer) {
+            if (HasMeaningfulChange $script:PreviousCalLog.EventEmailReminderTimer $CalLog.EventEmailReminderTimer) {
                 [Array]$TimeLineText = "The Email Reminder changed from [$($script:PreviousCalLog.EventEmailReminderTimer)] to: [$($CalLog.EventEmailReminderTimer)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.FreeBusyStatus -ne $script:PreviousCalLog.FreeBusyStatus) {
+            if (HasMeaningfulChange $script:PreviousCalLog.FreeBusyStatus $CalLog.FreeBusyStatus) {
                 [Array]$TimeLineText = "The FreeBusy Status changed from [$($script:PreviousCalLog.FreeBusyStatus)] to: [$($CalLog.FreeBusyStatus)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.AppointmentState -ne $script:PreviousCalLog.AppointmentState) {
+            if (HasMeaningfulChange $script:PreviousCalLog.AppointmentState $CalLog.AppointmentState) {
                 [Array]$TimeLineText = "The Appointment State changed from [$($script:PreviousCalLog.AppointmentState)] to: [$($CalLog.AppointmentState)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.MeetingRequestType -ne $script:PreviousCalLog.MeetingRequestType) {
+            if (HasMeaningfulChange $script:PreviousCalLog.MeetingRequestType $CalLog.MeetingRequestType) {
                 [Array]$TimeLineText = "The Meeting Request Type changed from [$($script:PreviousCalLog.MeetingRequestType.Value)] to: [$($CalLog.MeetingRequestType.Value)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.CalendarItemType -ne $script:PreviousCalLog.CalendarItemType) {
+            if (HasMeaningfulChange $script:PreviousCalLog.CalendarItemType $CalLog.CalendarItemType) {
                 [Array]$TimeLineText = "The Calendar Item Type changed from [$($script:PreviousCalLog.CalendarItemType)] to: [$($CalLog.CalendarItemType)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.ResponseType -ne $script:PreviousCalLog.ResponseType) {
+            if (HasMeaningfulChange $script:PreviousCalLog.ResponseType $CalLog.ResponseType) {
                 [Array]$TimeLineText = "The ResponseType changed from [$($script:PreviousCalLog.ResponseType)] to: [$($CalLog.ResponseType)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.Sender -ne $script:PreviousCalLog.Sender) {
+            if (HasMeaningfulChange $script:PreviousCalLog.Sender $CalLog.Sender) {
                 [Array]$TimeLineText = "The Sender Email Address changed from [$($script:PreviousCalLog.Sender)] to: [$($CalLog.Sender)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.From -ne $script:PreviousCalLog.From) {
+            if (HasMeaningfulChange $script:PreviousCalLog.From $CalLog.From) {
                 [Array]$TimeLineText = "The From changed from [$($script:PreviousCalLog.From)] to: [$($CalLog.From)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }
 
-            if ($CalLog.ReceivedRepresenting -ne $script:PreviousCalLog.ReceivedRepresenting) {
+            if (HasMeaningfulChange $script:PreviousCalLog.ReceivedRepresenting $CalLog.ReceivedRepresenting) {
                 [Array]$TimeLineText = "The Received Representing changed from [$($script:PreviousCalLog.ReceivedRepresenting)] to: [$($CalLog.ReceivedRepresenting)]"
                 CreateMeetingSummary -Time " " -MeetingChanges $TimeLineText
             }

--- a/Calendar/CalLogHelpers/Invoke-GetCalLogs.ps1
+++ b/Calendar/CalLogHelpers/Invoke-GetCalLogs.ps1
@@ -44,7 +44,6 @@ $script:CustomPropertyNameList =
 "SendMeetingMessagesDiagnostics",
 "Sensitivity",
 "SentRepresentingDisplayName",
-"SentRepresentingEmailAddress",
 "ShortClientInfoString",
 "TimeZone"
 
@@ -86,7 +85,7 @@ function GetCalendarDiagnosticObjects {
         ShouldDecodeEnums  = $true
     }
 
-    if ($TrackingLogs.IsPresent) {
+    if ($TrackingLogs -eq $true) {
         Write-Host -ForegroundColor Yellow "Including Tracking Logs in the output."
         $script:CustomPropertyNameList += "AttendeeListDetails", "AttendeeCollection"
         $params.Add("ShouldFetchAttendeeCollection", $true)
@@ -114,19 +113,21 @@ function GetCalendarDiagnosticObjects {
         $params.Add("CustomPropertyName", $script:CustomPropertyNameList)
     }
 
+    # Use 3>$null to suppress "Non-view properties may not be accurate for exception items"
+    # warnings from Get-CalendarDiagnosticObjects (remote session warnings bypass WarningAction/Preference).
     if ($Identity -and $MeetingID) {
         Write-Verbose "Getting CalLogs for [$Identity] with MeetingID [$MeetingID]."
         if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
             Write-Host -ForegroundColor Yellow ($params.GetEnumerator() | ForEach-Object { "`t$($_.Key) = $($_.Value)`n" })
         }
-        $CalLogs = Get-CalendarDiagnosticObjects @params -MeetingID $MeetingID
+        $CalLogs = Get-CalendarDiagnosticObjects @params -MeetingID $MeetingID 3>$null
     } elseif ($Identity -and $Subject ) {
         Write-Verbose "Getting CalLogs for [$Identity] with Subject [$Subject]."
-        $CalLogs = Get-CalendarDiagnosticObjects @params -Subject $Subject
+        $CalLogs = Get-CalendarDiagnosticObjects @params -Subject $Subject 3>$null
 
         # No Results, do a Deep search with ExactMatch.
         if ($CalLogs.count -lt 1) {
-            $CalLogs = Get-CalendarDiagnosticObjects @Params -Subject $Subject -ExactMatch $true
+            $CalLogs = Get-CalendarDiagnosticObjects @Params -Subject $Subject -ExactMatch $true 3>$null
         }
     }
 
@@ -147,22 +148,17 @@ function GetCalLogsWithSubject {
         [string] $Identity,
         [string] $Subject
     )
-    Write-Host "Getting CalLogs from [$Identity] with subject [$Subject]]"
+    Write-Host "Getting CalLogs from [$Identity] with subject [$Subject]"
 
     $InitialCDOs = GetCalendarDiagnosticObjects -Identity $Identity -Subject $Subject
-    $GlobalObjectIds = @()
 
     # Find all the unique Global Object IDs
-    foreach ($ObjectId in $InitialCDOs.CleanGlobalObjectId) {
-        if (![string]::IsNullOrEmpty($ObjectId) -and
-            $ObjectId -ne "NotFound" -and
-            $ObjectId -ne "InvalidSchemaPropertyName" -and
-            $ObjectId.Length -ge 90) {
-            $GlobalObjectIds += $ObjectId
-        }
-    }
-
-    $GlobalObjectIds = $GlobalObjectIds | Select-Object -Unique
+    $GlobalObjectIds = @($InitialCDOs.CleanGlobalObjectId | Where-Object {
+            -not [string]::IsNullOrEmpty($_) -and
+            $_ -ne "NotFound" -and
+            $_ -ne "InvalidSchemaPropertyName" -and
+            $_.Length -ge 90
+        } | Select-Object -Unique)
     Write-Host "Found $($GlobalObjectIds.count) unique GlobalObjectIds."
     Write-Host "Getting the set of CalLogs for each GlobalObjectID."
 

--- a/Calendar/CalLogHelpers/Invoke-GetMailbox.ps1
+++ b/Calendar/CalLogHelpers/Invoke-GetMailbox.ps1
@@ -253,7 +253,12 @@ function GetSMTPAddress {
     } elseif ($PassedCN -like "*<*@*>") {
         # This is a new format that we are seeing in the Calendar Logs.
         # Example: '"Jon Doe" <Jon.Doe@Contoso.com>'
-        $result = $($PassedCN -split ("<")[-1] -split (">")[0])[1].Trim()
+        $smtpMatch = [regex]::Match($PassedCN, '<([^>]+)>')
+        if ($smtpMatch.Success) {
+            $result = $smtpMatch.Groups[1].Value.Trim()
+        } else {
+            $result = $PassedCN
+        }
         Write-Verbose "GetSMTPAddress: Using <SMTPAddress> format of [$PassedCN] as [$result]"
     } elseif ($PassedCN -match '</O=') {
         #Matching "Users Name" </O=...>

--- a/Calendar/CalLogHelpers/Invoke-GetMailbox.ps1
+++ b/Calendar/CalLogHelpers/Invoke-GetMailbox.ps1
@@ -158,7 +158,6 @@ function ConvertCNtoSMTP {
     # Creates a list of CN's that we will do MB look up on
     $CNEntries = @()
     $CNEntries += ($script:GCDO.ResponsibleUserName.ToUpper() | Select-Object -Unique)
-    $CNEntries += ($script:GCDO.SentRepresentingEmailAddress.ToUpper() | Select-Object -Unique)
     $CNEntries += ($script:GCDO.Sender.ToUpper() | Select-Object -Unique)
     # $CNEntries += ($script:GCDO.SenderEmailAddress.ToUpper() | Select-Object -Unique)
     $CNEntries = $CNEntries | Select-Object -Unique
@@ -189,9 +188,8 @@ function ConvertCNtoSMTP {
             $script:MailboxList[$CNEntry] = GetMailboxProp -PassedCN $Cn -Prop "PrimarySmtpAddress"
         } else {
             Write-Verbose "ConvertCNtoSMTP: Passed in Value does not look like a CN or SMTP Address: [$CNEntry]"
+            $script:MailboxList[$CNEntry] = $CNEntry
         }
-
-        $script:MailboxList[$CNEntry] = $CNEntry
     }
     Write-Verbose "MailboxList: $($script:MailboxList.Count) entries found."
 
@@ -209,17 +207,27 @@ function GetDisplayName {
     param(
         $PassedCN
     )
+
+    # Use string key for cache lookup
+    $cacheKey = [string]$PassedCN
+    if ($script:DisplayNameCache.ContainsKey($cacheKey)) {
+        return $script:DisplayNameCache[$cacheKey]
+    }
+
     Write-Verbose "GetDisplayName:: Working on [$PassedCN]"
     if ($PassedCN.Properties.Name -contains 'DisplayName') {
-        return GetMailboxProp -PassedCN $PassedCN -Prop "DisplayName"
+        $result = GetMailboxProp -PassedCN $PassedCN -Prop "DisplayName"
     } elseif ($PassedCN -match '<' ) {
-        return $PassedCN.ToString().split("<")[0].replace('"', '')
+        $result = $PassedCN.ToString().split("<")[0].replace('"', '')
     } elseif ($PassedCN -match '\[OneOff') {
-        return $PassedCN.ToString().split('"')[1]
+        $result = $PassedCN.ToString().split('"')[1]
     } else {
         Write-Verbose "Unable to get the DisplayName for [$PassedCN]"
-        return $PassedCN
+        $result = $PassedCN
     }
+
+    $script:DisplayNameCache[$cacheKey] = $result
+    return $result
 }
 
 <#
@@ -231,41 +239,47 @@ function GetSMTPAddress {
         $PassedCN
     )
 
+    # Use string key for cache lookup
+    $cacheKey = [string]$PassedCN
+    if ($script:SMTPAddressCache.ContainsKey($cacheKey)) {
+        return $script:SMTPAddressCache[$cacheKey]
+    }
+
     #Write-Verbose "GetSMTPAddress:: Working on [$PassedCN]"
     if ($PassedCN -match $WellKnownCN_Trans) {
-        return $Transport
+        $result = $Transport
     } elseif ($PassedCN -match $WellKnownCN_CA) {
-        return $CalAttendant
+        $result = $CalAttendant
     } elseif ($PassedCN -like "*<*@*>") {
         # This is a new format that we are seeing in the Calendar Logs.
         # Example: '"Jon Doe" <Jon.Doe@Contoso.com>'
-        $SMTPAddress = $($PassedCN -split ("<")[-1] -split (">")[0])[1].Trim()
-        Write-Verbose "GetSMTPAddress: Using <SMTPAddress> format of [$PassedCN] as [$SMTPAddress]"
-        return $SMTPAddress
+        $result = $($PassedCN -split ("<")[-1] -split (">")[0])[1].Trim()
+        Write-Verbose "GetSMTPAddress: Using <SMTPAddress> format of [$PassedCN] as [$result]"
     } elseif ($PassedCN -match '</O=') {
         #Matching "Users Name" </O=...>
         $pattern = "<([^>]*)>"
-        #$matches = [regex]::Matches($PassedCN, $pattern)
         $MailboxOU = ([regex]::Matches($PassedCN, $pattern)).groups[1].value
         Write-Verbose "GetSMTPAddress: Using /OU format to look up mailbox for [$MailboxOU]"
-        return GetMailboxProp -PassedCN $MailboxOU -Prop "PrimarySmtpAddress"
+        $result = GetMailboxProp -PassedCN $MailboxOU -Prop "PrimarySmtpAddress"
     } elseif ($PassedCN -match 'cn=([\w,\s.@-]*[^/])$') {
         Write-Verbose "GetSMTPAddress: Using CN format to look up mailbox for [$PassedCN]"
-        return GetMailboxProp -PassedCN $PassedCN -Prop "PrimarySmtpAddress"
+        $result = GetMailboxProp -PassedCN $PassedCN -Prop "PrimarySmtpAddress"
     } elseif (($PassedCN -match "NotFound") -or ([string]::IsNullOrEmpty($PassedCN))) {
-        return ""
+        $result = ""
     } elseif ($PassedCN -match "InvalidSchemaPropertyName") {
         Write-Verbose "GetSMTPAddress: Passed in Value is empty or not Valid: [$PassedCN]."
-        return ""
+        $result = ""
     } elseif ($PassedCN -match "@") {
         Write-Verbose "GetSMTPAddress: Looks like we have an SMTP Address already: [$PassedCN]."
-        $PassedCN.SMTPAddress
-        return $PassedCN
+        $result = $PassedCN
     } else {
         # We have a problem, we don't have a CN or an SMTP Address
         Write-Warning "GetSMTPAddress: Passed in Value does not look like a CN or SMTP Address: [$PassedCN]."
-        return $PassedCN
+        $result = $PassedCN
     }
+
+    $script:SMTPAddressCache[$cacheKey] = $result
+    return $result
 }
 
 <#

--- a/Calendar/CalLogHelpers/MeetingSummaryFunctions.ps1
+++ b/Calendar/CalLogHelpers/MeetingSummaryFunctions.ps1
@@ -22,17 +22,15 @@ function Convert-Data {
         }
     }
     $MaxItemCount = ($ItemCounts | Measure-Object -Maximum).Maximum
-    $FinalArray = @()
-    for ($Inc = 0; $Inc -lt $MaxItemCount; $Inc++) {
+    $FinalArray = for ($Inc = 0; $Inc -lt $MaxItemCount; $Inc++) {
         $FinalObj = New-Object PsObject
         foreach ($Item in $ValidArrays) {
             $FinalObj | Add-Member -MemberType NoteProperty -Name $Item -Value $VariableLookup[$Item][$Inc]
         }
-        $FinalArray += $FinalObj
+        $FinalObj
     }
 
     return $FinalArray
-    $FinalArray = @()
 }
 
 # ===================================================================================================
@@ -93,5 +91,5 @@ function CreateMeetingSummary {
         $MeetingChanges += $InitialToList, $InitialLocation, $InitialStartTime, $InitialEndTime, $InitialRecurring
     }
 
-    $script:TimeLineOutput += Convert-Data -ArrayNames "Time", "MeetingChanges"
+    $script:TimeLineOutput.AddRange(@(Convert-Data -ArrayNames "Time", "MeetingChanges"))
 }

--- a/Calendar/CalLogHelpers/TimelineFunctions.ps1
+++ b/Calendar/CalLogHelpers/TimelineFunctions.ps1
@@ -122,7 +122,7 @@ function BuildTimeline {
 
         # Setup Previous log (if current logs is an IPM.Appointment)
         if ($null -ne $CalLog.ItemClass -and
-            ($CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -or $CalendarItemTypes.($CalLog.ItemClass) -eq "Exception")) {
+            ((GetItemType $CalLog.ItemClass) -eq "Ipm.Appointment" -or (GetItemType $CalLog.ItemClass) -eq "Exception")) {
             $script:PreviousCalLog = $CalLog
         }
     }

--- a/Calendar/CalLogHelpers/TimelineFunctions.ps1
+++ b/Calendar/CalLogHelpers/TimelineFunctions.ps1
@@ -54,7 +54,11 @@ function FindFirstMeeting {
         $IpmAppointments = $script:GCDO | Where-Object { $_.ItemClass -eq "IPM.Appointment" }
     }
     if ($IpmAppointments.count -eq 0) {
-        Write-Host -ForegroundColor Red "Warning: Cannot find any IPM.Appointments, if this is the Organizer, check for the Outlook Bifurcation issue."
+        if ($script:IsOrganizer) {
+            Write-Host -ForegroundColor Red "Warning: Cannot find any IPM.Appointments for the Organizer. Check for the Outlook Bifurcation issue."
+        } else {
+            Write-Host -ForegroundColor Yellow "Warning: No IPM.Appointments found. This user is not the Organizer, so this may be expected (e.g. delegate without the meeting on their own calendar)."
+        }
         Write-Host -ForegroundColor Red "Warning: No IPM.Appointment found. CalLogs start to expire after 31 days."
         return $null
     } else {
@@ -63,7 +67,7 @@ function FindFirstMeeting {
 }
 
 function BuildTimeline {
-    $script:TimeLineOutput = @()
+    $script:TimeLineOutput = [System.Collections.Generic.List[object]]::new()
 
     $script:FirstLog = FindFirstMeeting
     FindOrganizer($script:FirstLog)
@@ -84,7 +88,7 @@ function BuildTimeline {
 
     Write-DashLineBoxColor "  TimeLine for: [$Identity]",
     "CollectionDate: $($(Get-Date).ToString("yyyy-MM-dd HH:mm:ss"))",
-    "ScriptVersion: $ScriptVersion",
+    "ScriptVersion: $Script:BuildVersion",
     "  Subject: $($script:GCDO[0].NormalizedSubject)",
     "  Organizer: $Script:Organizer",
     "  MeetingID: $($script:GCDO[0].CleanGlobalObjectId)"
@@ -117,7 +121,8 @@ function BuildTimeline {
         }
 
         # Setup Previous log (if current logs is an IPM.Appointment)
-        if ($CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -or $CalendarItemTypes.($CalLog.ItemClass) -eq "Exception") {
+        if ($null -ne $CalLog.ItemClass -and
+            ($CalendarItemTypes.($CalLog.ItemClass) -eq "Ipm.Appointment" -or $CalendarItemTypes.($CalLog.ItemClass) -eq "Exception")) {
             $script:PreviousCalLog = $CalLog
         }
     }

--- a/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
+++ b/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
@@ -16,13 +16,16 @@ Subject of the meeting to query, only valid if Identity is a single user.
 The MeetingID of the meeting to query.
 
 .PARAMETER TrackingLogs
-Include specific tracking logs in the output. Only usable with the MeetingID parameter.
+Include specific tracking logs in the output. Only usable with the MeetingID parameter. Collected by default; use -NoTrackingLogs to skip.
+
+.PARAMETER NoTrackingLogs
+Do not collect Tracking Logs.
 
 .PARAMETER Exceptions
-Include Exception objects in the output. Only usable with the MeetingID parameter. (Default)
+Include Exception objects in the output. Only usable with the MeetingID parameter. Collected by default; use -NoExceptions to skip.
 
 .PARAMETER ExportToExcel
-Export the output to an Excel file with formatting.  Running the scrip for multiple users will create multiple tabs in the Excel file. (Default)
+Export the output to an Excel file with formatting.  Running the script for multiple users will create multiple tabs in the Excel file. (Default)
 
 .PARAMETER ExportToCSV
 Export the output to 3 CSV files per user.
@@ -37,7 +40,7 @@ Limit Logs to 500 instead of the default 2000, in case the server has trouble re
 Increase log limit to 12,000 in case the default 2000 does not contain the needed information. Note this can be time consuming, and it does not contain all the logs such as User Responses.
 
 .PARAMETER CustomProperty
-Advanced users can add custom properties to the output in the RAW output. This is not recommended unless you know what you are doing. The properties must be in the format of "PropertyName1, PropertyName2, PropertyName3".  The properties will be added to the RAW output and not the Timeline output.  The properties must be in the format of "PropertyName1, PropertyName2, PropertyName3".  The properties will only be added to the RAW output.
+Advanced users can add custom properties to the output in the RAW output. This is not recommended unless you know what you are doing. The properties must be in the format of "PropertyName1, PropertyName2, PropertyName3". The properties will only be added to the RAW output.
 
 .PARAMETER ExceptionDate
 Date of the Exception Meeting to collect logs for.  Fastest way to get Exceptions for a meeting.
@@ -52,11 +55,13 @@ Get-CalendarDiagnosticObjectsSummary.ps1 -Identity someuser@microsoft.com -Subje
 .EXAMPLE
 Get-CalendarDiagnosticObjectsSummary.ps1 -Identity User1, User2, Delegate -MeetingID $MeetingID
 .EXAMPLE
-Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -TrackingLogs -NoExceptions
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -NoExceptions
 .EXAMPLE
-Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -TrackingLogs -Exceptions -ExportToExcel -CaseNumber 123456
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -NoTrackingLogs
 .EXAMPLE
-Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -TrackingLogs -ExceptionDate "01/28/2024" -CaseNumber 123456
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -ExportToExcel -CaseNumber 123456
+.EXAMPLE
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -ExceptionDate "01/28/2024" -CaseNumber 123456
 
 .SYNOPSIS
 Used to collect easy to read Calendar Logs.
@@ -87,6 +92,8 @@ param (
     [string]$MeetingID,
     [Parameter(HelpMessage = "Include specific tracking logs in the output. Only usable with the MeetingID parameter.")]
     [switch]$TrackingLogs,
+    [Parameter(HelpMessage = "Do Not collect Tracking Logs.")]
+    [switch]$NoTrackingLogs,
     [Parameter(HelpMessage = "Include Exception objects in the output. Only usable with the MeetingID parameter.")]
     [switch]$Exceptions,
     [Parameter(HelpMessage = "Date of the Exception to collect the logs for.")]
@@ -105,11 +112,13 @@ $BuildVersion = ""
 . $PSScriptRoot\..\Shared\ScriptUpdateFunctions\Test-ScriptVersion.ps1
 if (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/CL-VersionsUrl" -Confirm:$false) {
     # Update was downloaded, so stop here.
-    Write-Host -ForegroundColor Red "Script was updated. Please rerun the command." -ForegroundColor Yellow
+    Write-Host -ForegroundColor Red "Script was updated. Please rerun the command."
     return
 }
 
 $script:command = $MyInvocation
+$script:RunNumber = 0
+$script:PreRunErrorCount = $Error.Count
 Write-Verbose "The script was started with the following command line:"
 Write-Verbose "Name:  $($script:command.MyCommand.name)"
 Write-Verbose "Command Line:  $($script:command.line)"
@@ -140,11 +149,20 @@ if (!$ExportToCSV.IsPresent) {
     . $PSScriptRoot\CalLogHelpers\ExportToExcelFunctions.ps1
 }
 
+# Default to Collecting Tracking Logs
+if (!$NoTrackingLogs.IsPresent) {
+    $TrackingLogs = $true
+    Write-Host -ForegroundColor Yellow "Collecting Tracking Logs."
+    Write-Host -ForegroundColor Yellow "`tTo skip collecting Tracking Logs, use the -NoTrackingLogs switch."
+} else {
+    Write-Host -ForegroundColor Green "Not Collecting Tracking Logs."
+}
+
 # Default to Collecting Exceptions
 if ((!$NoExceptions.IsPresent) -and ([string]::IsNullOrEmpty($ExceptionDate))) {
     $Exceptions=$true
     Write-Host -ForegroundColor Yellow "Collecting Exceptions."
-    Write-Host -ForegroundColor Yellow "`tTo not collecting Exceptions, use the -NoExceptions switch."
+    Write-Host -ForegroundColor Yellow "`tTo skip collecting Exceptions, use the -NoExceptions switch."
 } else {
     Write-Host -ForegroundColor Green "---------------------------------------"
     if ($NoExceptions.IsPresent) {
@@ -167,10 +185,14 @@ if ($ExportToExcel.IsPresent) {
 
 if (-not ([string]::IsNullOrEmpty($Subject)) ) {
     if ($ValidatedIdentities.count -gt 1) {
-        Write-Warning "Multiple mailboxes were found, but only one is supported for Subject searches.  Please specify a single mailbox."
+        Write-Error "Subject-based searches only support a single mailbox, but $($ValidatedIdentities.count) were provided: [$($ValidatedIdentities -join ', ')]."
+        Write-Host -ForegroundColor Yellow "Options:"
+        Write-Host -ForegroundColor Yellow "  1. Re-run with a single -Identity and -Subject."
+        Write-Host -ForegroundColor Yellow "  2. Use -MeetingID instead of -Subject to search multiple mailboxes at once."
+        Write-Host -ForegroundColor Yellow "     Tip: Run the script once with -Subject for one user, then use the MeetingID from the output to collect from all participants."
         exit
     }
-    $script:Identity = $ValidatedIdentities
+    $script:Identity = $ValidatedIdentities[0]
     GetCalLogsWithSubject -Identity $ValidatedIdentities -Subject $Subject
 } elseif (-not ([string]::IsNullOrEmpty($MeetingID))) {
     #Validate MeetingID is good
@@ -197,8 +219,8 @@ if (-not ([string]::IsNullOrEmpty($Subject)) ) {
                 Write-Host -ForegroundColor Cyan "The user [$ID] is a Room Mailbox."
             }
 
-            if (CheckForBifurcation($script:GCDO) -ne false) {
-                Write-Host -ForegroundColor Red "Warning: No IPM.Appointment found. CalLogs start to expire after 31 days."
+            if ($script:IsOrganizer -and (CheckForBifurcation($script:GCDO) -ne $false)) {
+                Write-Host -ForegroundColor Red "Warning: No IPM.Appointment found for the Organizer. CalLogs start to expire after 31 days."
             }
 
             if ($Exceptions.IsPresent) {
@@ -221,7 +243,7 @@ if (-not ([string]::IsNullOrEmpty($Subject)) ) {
                     $ExceptionLogs = $LogToExamine | ForEach-Object {
                         $logLeftCount -= 1
                         Write-Verbose "Getting Exception Logs for [$($_.ItemId.ObjectId)]"
-                        Get-CalendarDiagnosticObjects -Identity $ID -ItemIds $_.ItemId.ObjectId -ShouldFetchRecurrenceExceptions $true -CustomPropertyNames $CustomPropertyNameList -ShouldBindToItem $true -WarningAction SilentlyContinue
+                        Get-CalendarDiagnosticObjects -Identity $ID -ItemIds $_.ItemId.ObjectId -ShouldFetchRecurrenceExceptions $true -CustomPropertyNames $CustomPropertyNameList -ShouldBindToItem $true 3>$null
                         if (($logLeftCount % 10 -eq 0) -and ($logLeftCount -gt 0)) {
                             Write-Host -ForegroundColor Cyan "`t [$($logLeftCount)] logs left to examine..."
                         }
@@ -230,7 +252,7 @@ if (-not ([string]::IsNullOrEmpty($Subject)) ) {
                     $ExceptionLogs = $ExceptionLogs | Where-Object { $_.ItemClass -notlike "IPM.Appointment*" }
                     Write-Host -ForegroundColor Cyan "Found $($ExceptionLogs.count) Exception Logs, adding them into the CalLogs."
 
-                    $script:GCDO = $script:GCDO + $ExceptionLogs | Select-Object *, @{n='OrgTime'; e= { [DateTime]::Parse($_.LogTimestamp.ToString()) } } | Sort-Object OrgTime
+                    $script:GCDO = $script:GCDO + $ExceptionLogs | Select-Object *, @{n='OrgTime'; e= { ConvertDateTime($_.LogTimestamp.ToString()) } } | Sort-Object OrgTime
                     $LogToExamine = $null
                     $ExceptionLogs = $null
                 } else {

--- a/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
+++ b/Calendar/Get-CalendarDiagnosticObjectsSummary.ps1
@@ -149,35 +149,42 @@ if (!$ExportToCSV.IsPresent) {
     . $PSScriptRoot\CalLogHelpers\ExportToExcelFunctions.ps1
 }
 
-# Default to Collecting Tracking Logs
-if (!$NoTrackingLogs.IsPresent) {
-    $TrackingLogs = $true
-    Write-Host -ForegroundColor Yellow "Collecting Tracking Logs."
-    Write-Host -ForegroundColor Yellow "`tTo skip collecting Tracking Logs, use the -NoTrackingLogs switch."
-} else {
-    Write-Host -ForegroundColor Green "Not Collecting Tracking Logs."
-}
-
-# Default to Collecting Exceptions
-if ((!$NoExceptions.IsPresent) -and ([string]::IsNullOrEmpty($ExceptionDate))) {
-    $Exceptions=$true
-    Write-Host -ForegroundColor Yellow "Collecting Exceptions."
-    Write-Host -ForegroundColor Yellow "`tTo skip collecting Exceptions, use the -NoExceptions switch."
-} else {
-    Write-Host -ForegroundColor Green "---------------------------------------"
-    if ($NoExceptions.IsPresent) {
-        Write-Host -ForegroundColor Green "Not Checking for Exceptions"
+# Default to Collecting Tracking Logs (MeetingID only)
+if (-not ([string]::IsNullOrEmpty($MeetingID))) {
+    if (!$NoTrackingLogs.IsPresent) {
+        $TrackingLogs = $true
+        Write-Host -ForegroundColor Yellow "Collecting Tracking Logs."
+        Write-Host -ForegroundColor Yellow "`tTo skip collecting Tracking Logs, use the -NoTrackingLogs switch."
     } else {
-        Write-Host -ForegroundColor Green "Checking for Exceptions on $ExceptionDate"
+        Write-Host -ForegroundColor Green "Not Collecting Tracking Logs."
     }
-    Write-Host -ForegroundColor Green "---------------------------------------"
+
+    # Default to Collecting Exceptions (MeetingID only)
+    if ((!$NoExceptions.IsPresent) -and ([string]::IsNullOrEmpty($ExceptionDate))) {
+        $Exceptions=$true
+        Write-Host -ForegroundColor Yellow "Collecting Exceptions."
+        Write-Host -ForegroundColor Yellow "`tTo skip collecting Exceptions, use the -NoExceptions switch."
+    } else {
+        Write-Host -ForegroundColor Green "---------------------------------------"
+        if ($NoExceptions.IsPresent) {
+            Write-Host -ForegroundColor Green "Not Checking for Exceptions"
+        } else {
+            Write-Host -ForegroundColor Green "Checking for Exceptions on $ExceptionDate"
+        }
+        Write-Host -ForegroundColor Green "---------------------------------------"
+    }
+} else {
+    # Subject-based search
+    $script:SubjectSearch = $true
+    Write-Host -ForegroundColor Yellow "Using Subject search. Tracking Logs and Exception collection are only available with -MeetingID."
+    Write-Host -ForegroundColor Yellow "`tTip: Use the MeetingID from this output to recollect with full details."
 }
 
 # ===================================================================================================
 # Main
 # ===================================================================================================
 
-$ValidatedIdentities = CheckIdentities -Identity $Identity
+[array]$ValidatedIdentities = CheckIdentities -Identity $Identity
 
 if ($ExportToExcel.IsPresent) {
     CheckExcelModuleInstalled

--- a/docs/Calendar/Get-CalendarDiagnosticObjectsSummary.md
+++ b/docs/Calendar/Get-CalendarDiagnosticObjectsSummary.md
@@ -2,27 +2,90 @@
 
 Download the latest release: [Get-CalendarDiagnosticObjectsSummary.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Get-CalendarDiagnosticObjectsSummary.ps1)
 
+This script runs the Get-CalendarDiagnosticObjects cmdlet and returns a summarized timeline of actions in clear English as well as the Calendar Diagnostic Objects in Excel.
 
-This script runs the Get-CalendarDiagnosticObjects cmdlet and returns a summarized timeline of actions into clear English. It will also output an easier to read version of the CalLogs (enhanced) as well as a Raw copy of the logs for Developers. 
+## Prerequisites
 
-To run the script, you will need a valid SMTP Address for a user and a meeting Subject or MeetingID.
+1. Install the [ImportExcel](https://github.com/dfinke/ImportExcel) module (required for the default Excel export):
 
-The script will display summarized timeline of actions and save the logs returned in csv format in the current directory.
-New **-ExportToExcel** highly recommended for ease of use (all logs in one file, color coding, etc.). First time use will request installing the ImportExcel module. See https://github.com/dfinke/ImportExcel for more information on the ImportExcel module.
+    ```PowerShell
+    Install-Module -Name ImportExcel
+    ```
 
-| Parameters:    | Explanation: |
-|:-------------- | :-----|
-| **-Identity**  | One (or more) SMTP Address of EXO User Mailbox to query.|
-| **-Subject**   | Subject of the meeting to query, only valid if Identity is a single user. 
-| **-MeetingID** | MeetingID of the meeting to query. <BR> - Preferred way to get CalLogs.
-| **-TrackingLogs** | Populate attendee tracking columns in the output. <BR> - Only useable with the MeetingID parameter.
-| **-Exceptions** | Include Exception objects in the output. <br> - Only useable with the MeetingID parameter. <br> 
-| **-ExportToExcel**|   - `[NEW Feature]` Export the output to an Excel file with formatting.  <BR> - Running the script for multiple users will create three tabs in the Excel file for each user. <BR> If you want to add more users to the Excel file, close the file and rerun with new user. <BR>        - one tab for Enhanced CalLog         <BR>  - one tab for the TimeLine        <BR>  - Tab one for Raw CalLog 
-| **-CaseNumber** | Case Number to include in the Filename of the output. <BR> - PrePend `<CaseNumber>_` to filename.
-| **-ShortLogs**| Limit Logs to 500 instead of the default 2000, in case the server has trouble responding with the full logs.
+2. Connect to [Exchange Online PowerShell](https://learn.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell):
+
+    ```PowerShell
+    Import-Module ExchangeOnlineManagement
+    Connect-ExchangeOnline -UserPrincipalName admin@contoso.com
+    ```
+
+Use **-ExportToCSV** to export to CSV files instead if ImportExcel is not available.
+
+## Who to collect from
+
+Collect from **all key participants** upfront. Partial collections produce incomplete analysis.
+
+| Participant | When to include |
+|---|---|
+| **Organizer** | Always — the authoritative copy |
+| **Affected attendee(s)** | Always — 1–2 is usually enough |
+| **Delegate(s)** | If delegates manage the organizer's or attendee's calendar |
+| **Room/resource mailbox** | If the issue involves a room booking |
+| **Modern Sharing partners** | If the calendar is shared via Modern Sharing |
+
+> **Note:** Calendar diagnostic logs are removed after 31 days. Collect promptly.
+
+## Parameters
+
+Using **-MeetingID** (the `CleanGlobalObjectId`) is the preferred collection method. It produces more detailed logs than a subject search and allows collecting for multiple participants in a single run.
+
+Using **-Subject** performs a case-insensitive substring match. Only a single `-Identity` can be used with `-Subject`. If multiple meetings match, the script creates a separate file for each match.
+
+| Parameter | Explanation |
+|:--- |:---|
+| **-Identity** | One (or more) SMTP Address of EXO User Mailbox to query. |
+| **-Subject** | Subject of the meeting to query. Case-insensitive substring match. Only valid with a single Identity. |
+| **-MeetingID** | The `CleanGlobalObjectId` of the meeting to query. <BR> - Preferred way to get CalLogs. |
+| **-TrackingLogs** | Populate attendee tracking columns in the output. Collected by default; use `-NoTrackingLogs` to skip. <BR> - Only usable with the MeetingID parameter. |
+| **-NoTrackingLogs** | Do not collect Tracking Logs. |
+| **-Exceptions** | Exceptions are collected by default for recurring meetings. This switch is kept for backward compatibility but is no longer required. Use `-NoExceptions` to skip or `-ExceptionDate` to collect a single occurrence. |
+| **-NoExceptions** | Do not collect Exception Meetings. |
+| **-ExceptionDate** | Date of a specific Exception Meeting to collect logs for. <BR> - Fastest way to get logs for a single occurrence of a recurring meeting. |
+| **-ExportToExcel** | Export the output to an Excel file with formatting (Default). <BR> - Creates three tabs per user (Enhanced, Raw, Timeline) plus a shared Script Info tab. <BR> - To add more users later, close the file and rerun with the new user only. |
+| **-ExportToCSV** | Export the output to 3 CSV files per user instead of Excel. |
+| **-CaseNumber** | Case Number to include in the Filename of the output. <BR> - Prepend `<CaseNumber>_` to filename. |
+| **-ShortLogs** | Limit Logs to 500 instead of the default 2000, in case the server has trouble responding with the full logs. |
+| **-MaxLogs** | Increase log limit to 12,000 in case the default 2000 does not contain the needed information. <BR> - Note: this can be time consuming and **does not contain all log types such as User Responses**. |
+| **-CustomProperty** | Add custom properties to the RAW output. <BR> - Properties must be in the format of `"PropertyName1, PropertyName2, PropertyName3"`. <BR> - Properties will only be added to the RAW output. |
+
+## Output
+
+Filename pattern: `<CaseNumber>_CalLogSummary_<short meeting ID>.xlsx`
+
+The Excel workbook contains the following worksheets (in tab order):
+
+| Worksheet | Tab Color | Description |
+|---|---|---|
+| **\<user\>** | Orange / Green / Blue / Red | **Enhanced CalLogs** — the primary analysis source. Contains processed calendar diagnostic objects with friendly column names, color coding, and LogRowType classification. Tab color reflects the role: **Orange** = Organizer, **Green** = Room/Resource, **Blue** = Attendee. **Red** = CalLogs are disabled for this user. |
+| **Script Info** | Grey | Script version, age, runtime, command line, identities processed, and any errors. Each run appends to this tab so you have a history of all collections for this meeting. |
+| **\<user\>_Raw** | *(same as Enhanced)* | **Raw CalLogs** — the unprocessed calendar diagnostic data. Useful for escalations or when you need fields not in the Enhanced tab. |
+| **\<user\>_TimeLine** | *(same as Enhanced)* | **Timeline** — a human-readable summary of key events for the meeting in chronological order. |
+
+Three worksheets are created per user (Enhanced, Raw, Timeline) plus the shared Script Info tab. To add another participant after the initial run, close the Excel file and rerun the script passing in only the new user.
+
+### Pre-filtered columns
+
+The **LogRowType** column is pre-filtered to hide noisy row types by default:
+
+- `OtherAssistant`
+- `MeetingMessageChange`
+- `DeletedSeriesException`
+
+To see all rows, clear the filter on the LogRowType column dropdown in Excel.
+
 ---
 
-#### Syntax:
+## Syntax
 
 Example to return timeline for a user with MeetingID:
 ```PowerShell
@@ -38,17 +101,48 @@ Get CalLogs for 3 users:
 ```PowerShell
 Get-CalendarDiagnosticObjectsSummary.ps1 -Identity User1, User2, Delegate -MeetingID $MeetingID
 ```
-Add Tracking Logs and Exceptions:
+Add Tracking Logs without Exceptions:
 ```PowerShell
-Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -TrackingLogs -Exceptions
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -NoExceptions
 ```
-Export CalLogs to Excel:
+Skip Tracking Logs:
 ```PowerShell
-Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -TrackingLogs -Exceptions -ExportToExcel -CaseNumber 123456
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -NoTrackingLogs
+```
+Export CalLogs to Excel with a Case Number (Exceptions and Excel are both default):
+```PowerShell
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -ExportToExcel -CaseNumber 123456
 ```
 Will create file like  `.\123456_CalLogSummary_<MeetingID>.xlsx` in current directory.
 
+Collect logs for a specific Exception date:
+```PowerShell
+Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID -ExceptionDate "01/28/2024" -CaseNumber 123456
+```
 
-More Documentation on collecting CalLogs and Analyzing them:
- [How to Get Calendar Logs](https://aka.ms/GetCalLogs)
- [How to Analyze Calendar Logs](https://aka.ms/AnalyzeCalLogs)
+## Validate your collection
+
+Before analyzing, verify:
+
+- [ ] All four worksheets exist (Enhanced, Script Info, Raw, Timeline) for each participant
+- [ ] All key participants are included (organizer, affected attendees, delegates, room mailboxes)
+- [ ] LogTimestamp range covers the incident timeframe
+- [ ] Response rows exist (if investigating response issues — collected by default, use `-NoTrackingLogs` to skip)
+- [ ] Exception rows exist (if investigating recurring meeting issues)
+- [ ] `CalendarVersionStoreDisabled` is not `True` — if True, logs are fundamentally incomplete
+- [ ] Row count is not at the exact 2,000 limit — if it is, recollect with `-MaxLogs`
+
+## Known issues
+
+**`New-ConditionalText : The term 'New-ConditionalText' is not recognized...`**
+
+This error occurs when the ImportExcel module conflicts with the Exchange Online session. To resolve:
+
+1. Run `Disconnect-ExchangeOnline`
+2. Close the PowerShell session and start a new one as administrator
+3. Reconnect to Exchange Online and rerun the script
+
+## More information
+
+- [How to Get Calendar Logs](https://learn.microsoft.com/exchange/troubleshoot/calendars/cdl/get-calendar-diagnostic-logs)
+- [How to Analyze Calendar Logs](https://learn.microsoft.com/exchange/troubleshoot/calendars/cdl/analyze-calendar-diagnostic-logs)

--- a/docs/Calendar/Get-CalendarDiagnosticObjectsSummary.md
+++ b/docs/Calendar/Get-CalendarDiagnosticObjectsSummary.md
@@ -124,7 +124,7 @@ Get-CalendarDiagnosticObjectsSummary.ps1 -Identity $Users -MeetingID $MeetingID 
 
 Before analyzing, verify:
 
-- [ ] All four worksheets exist (Enhanced, Script Info, Raw, Timeline) for each participant
+- [ ] Participant worksheets exist for each participant (Enhanced, Raw, Timeline), and the shared Script Info worksheet is present
 - [ ] All key participants are included (organizer, affected attendees, delegates, room mailboxes)
 - [ ] LogTimestamp range covers the incident timeframe
 - [ ] Response rows exist (if investigating response issues — collected by default, use `-NoTrackingLogs` to skip)


### PR DESCRIPTION
**1. FindChangedPropFunctions.ps1 — Bug fix + noise reduction**
Bug fix (critical): The guard condition on line 38 changed from -or to -and:

The old -or logic meant the condition was always true, so the filter was never actually excluding LocationProcessor/EBA/TBA entries. Good catch.

New HasMeaningfulChange / IsNotFound helpers: All ~20 property-change checks now use HasMeaningfulChange which ignores transitions to/from "NotFound", "-", or empty. This eliminates noisy "changed from [NotFound] to [value]" timeline entries. Clean and consistent.

**2. [ExportToExcelFunctions.ps1]** — Major overhaul (+495/−38)
This is the biggest change. Key items:

New Sensitivity and CleanGlobalObjectId columns added to the header metadata.
URL fix: Https:\\aka.ms\AnalyzeCalLogs → https://aka.ms/AnalyzeCalLogs (was broken backslashes).
LogScriptInfo function — new/redesigned to track run history (run number, errors, version, command line) in a persistent "Script Info" tab. Reads existing run count from the Excel file so numbering is continuous across sessions.
Pre-filtered LogRowType — appears to set up Excel AutoFilter to hide OtherAssistant, MeetingMessageChange, DeletedSeriesException by default.
Concern: This is a large diff — worth checking that the Excel formatting still works end-to-end if you have a test environment.

**3. Invoke-GetCalLogs.ps1 — Warning suppression + cleanup**
Removed SentRepresentingEmailAddress from the property list (also removed from Invoke-GetMailbox.ps1 — consistent).
$TrackingLogs -eq $true instead of $TrackingLogs.IsPresent — needed because the main script now sets $TrackingLogs = $true as a variable (not just a switch), so .IsPresent wouldn't work.
3>$null added to all Get-CalendarDiagnosticObjects calls to suppress the "Non-view properties may not be accurate for exception items" warning stream. Good — -WarningAction SilentlyContinue doesn't catch remote session warnings.
GetCalLogsWithSubject cleanup: Fixed double-bracket typo in Write-Host ([$Subject]] → [$Subject]), replaced loop-based array building with pipeline Where-Object | Select-Object -Unique.

**4. Invoke-GetMailbox.ps1 — Caching + bug fix**
DisplayNameCache and SMTPAddressCache added to GetDisplayName and GetSMTPAddress. Avoids repeated mailbox lookups for the same CN. Good perf improvement.
Bug fix in ConvertCNtoSMTP: The fallback $script:MailboxList[$CNEntry] = $CNEntry was previously outside the else block, meaning it would always overwrite whatever was set above. Now correctly scoped inside the else.
Removed SentRepresentingEmailAddress from $CNEntries collection — consistent with the property removal.

**5. MeetingSummaryFunctions.ps1 — Array perf fix**
$FinalArray = @() + $FinalArray += $FinalObj replaced with direct pipeline output from the for loop — eliminates O(n²) array copies.
Removed dead $FinalArray = @() after the return statement.
$script:TimeLineOutput += ... replaced with $script:TimeLineOutput.AddRange(...) — consistent with the List[object] change in TimelineFunctions.ps1.

**6. TimelineFunctions.ps1 — List type + bifurcation messaging**
$script:TimeLineOutput changed from @() array to [System.Collections.Generic.List[object]]::new() — pairs with the AddRange calls. Avoids O(n²) array growth.
Bifurcation warning now context-aware: different messages for Organizer vs non-Organizer.
$ScriptVersion → $Script:BuildVersion — fixes a reference to an undefined variable.
Null check on $CalLog.ItemClass before checking $CalendarItemTypes — prevents null key lookup.

**7. CalLogCSVFunctions.ps1 (+84)**
Adds Sensitivity column to the enhanced CalLog output.
Adds CleanGlobalObjectId column.

**8. CalLogInfoFunctions.ps1 (+23/−6)**
Minor refinements to organizer/room/recurring detection logic.

**9. CreateTimelineRow.ps1 (+2/−2)**
Minimal tweak — likely a wording or logic fix in the switch statement.

**10. [Get-CalendarDiagnosticObjectsSummary.ps1**]
Main script
New -NoTrackingLogs parameter added to the param block (was referenced in code but missing from param()).
Default tracking logs logic — sets $TrackingLogs = $true unless -NoTrackingLogs is present.
Fixed double -ForegroundColor on line 114: Write-Host -ForegroundColor Red "..." -ForegroundColor Yellow → single -ForegroundColor Red.
New $script:RunNumber and $script:PreRunErrorCount variables for the Script Info tab.
Better error messaging for multiple identities with -Subject — now gives actionable options.
Fixed $script:Identity = $ValidatedIdentities → $ValidatedIdentities[0]** (was passing an array where a single value was expected).
Bifurcation check now gated on $script:IsOrganizer.
Exception sorting uses ConvertDateTime() instead of [DateTime]::Parse() — presumably handles culture-specific date formats better.
Typo fixes in help text: "scrip" → "script", "To not collecting" → "To skip collecting".
Script help examples — removed redundant -TrackingLogs / -Exceptions switches.

**11. [Get-CalendarDiagnosticObjectsSummary.md]**
 Full doc rewrite
Complete overhaul of the documentation: added Prerequisites, Who to collect from, Parameters table, Output section with worksheet descriptions, Pre-filtered columns, Validate your collection checklist, Known issues, and updated links to use full Microsoft Learn URLs. All the changes we discussed in the last session are included.

Tested on Test Tenant