### PR TITLE
Corrections to group check in MDOThreatPolicyChecker.ps1

### DIFF
--- a/M365/MDO/MDOThreatPolicyChecker.ps1
+++ b/M365/MDO/MDOThreatPolicyChecker.ps1
@@ -194,7 +194,8 @@ begin {
             $groupMembers = Get-MgGroupMember -GroupId $GroupObjectId -All -ErrorAction Stop
         } catch {
             Write-Host "Error getting group members for $GroupObjectId`:`n$_" -ForegroundColor Red
-            return $null
+            $memberCache[$cacheKey] = $false
+            return $false
         }
 
         # Check if the email address is in the group
@@ -209,7 +210,8 @@ begin {
                             $user = Get-MgUser -UserId $member.Id -ErrorAction Stop
                         } catch {
                             Write-Host "Error getting user with Id $($member.Id):`n$_" -ForegroundColor Red
-                            return $null
+                            $memberCache[$cacheKey] = $false
+                            return $false
                         }
                         # Compare the user's email address with the $email parameter
                         if ($user.Mail -eq $Email.ToString()) {

--- a/M365/MDO/MDOThreatPolicyChecker.ps1
+++ b/M365/MDO/MDOThreatPolicyChecker.ps1
@@ -191,7 +191,7 @@ begin {
         $groupMembers = $null
         Write-Verbose "Getting $GroupObjectId"
         try {
-            $groupMembers = Get-MgGroupMember -GroupId $GroupObjectId -ErrorAction Stop
+            $groupMembers = Get-MgGroupMember -GroupId $GroupObjectId -All -ErrorAction Stop
         } catch {
             Write-Host "Error getting group members for $GroupObjectId`:`n$_" -ForegroundColor Red
             return $null
@@ -351,7 +351,6 @@ begin {
                             break
                         } else {
                             Write-DetailedExplanationOption -Message "No Group match because $($Email.ToString()) is not a member of Group $($groupObjectId)" -ShowDetailedExplanation:$ShowDetailedExplanation
-                            break
                         }
                     }
                 }
@@ -370,7 +369,6 @@ begin {
                             break
                         } else {
                             Write-DetailedExplanationOption -Message "$($Email.ToString()) is not excluded from rule by membership in Group $($groupObjectId)" -ShowDetailedExplanation:$ShowDetailedExplanation
-                            break
                         }
                     }
                 }


### PR DESCRIPTION
Incorrect lookup in groups as only one group was being checked instead of all groups. Also retrieved all members of group.

**Issue:**
Group-based policy evaluation could produce incorrect results by (1) failing to retrieve all members of large groups and (2) stopping evaluation after the first non‑matching group, even when additional groups were configured.

**Reason:**
Microsoft Graph paginates group members by default, and the script did not request all pages. Additionally, break statements on negative group‑membership checks prematurely exited the loop, preventing evaluation of subsequent groups. This caused false negatives for users who were members of later groups or large groups.

**Fix:**
Updated the group member retrieval to use -All so all group members are evaluated, and removed premature 2 break statements following negative group‑membership checks so all configured groups are evaluated correctly, matching MDO/EOP OR‑based group semantics.

**Validation:**
Tested fixed code in my test tenant and it corrects the issues and I found no other issues
