### PR TITLE
Fix HKU PSDrive creation failing under -WhatIf in EOMT

### DIFF
--- a/Security/src/EOMT/SharedFunctions/Install-IISUrlRewriteModule.ps1
+++ b/Security/src/EOMT/SharedFunctions/Install-IISUrlRewriteModule.ps1
@@ -64,7 +64,7 @@ function Install-IISUrlRewriteModule {
                 "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
             )
 
-            New-PSDrive -Name HKU -PSProvider Registry -Root Registry::HKEY_USERS -ErrorAction SilentlyContinue | Out-Null
+            New-PSDrive -Name HKU -PSProvider Registry -Root Registry::HKEY_USERS -WhatIf:$false -ErrorAction SilentlyContinue | Out-Null
 
             $UninstallKeys += Get-ChildItem HKU: | Where-Object { $_.Name -match 'S-\d-\d+-(\d+-){1,14}\d+$' } | ForEach-Object {
                 "HKU:\$($_.PSChildName)\Software\Microsoft\Windows\CurrentVersion\Uninstall"


### PR DESCRIPTION
## Problem

When running `EOMT.ps1 -CVE 'CVE-2026-42897' -WhatIf`, the `New-PSDrive` call for HKU is skipped because `New-PSDrive` supports `ShouldProcess` and respects the inherited `False`. The subsequent `Get-ChildItem HKU:` then fails with:

```
Get-ChildItem : Cannot find drive. A drive with the name 'HKU' does not exist.
```

## Root Cause

`EOMT.ps1` declares `SupportsShouldProcess` and when called with `-WhatIf`, `False` propagates to all child calls. `New-PSDrive` (which natively supports `ShouldProcess`) honors this and skips drive creation, causing the downstream `Get-ChildItem HKU:` to fail.

The bug is only observable when `-WhatIf` is the **first invocation** in a fresh PowerShell session. If the script was previously run without `-WhatIf`, the `HKU:` PSDrive persists in the session, masking the issue.

## Fix

Added `-WhatIf:$false` to the `New-PSDrive` call in `Get-InstalledSoftwareVersion`. Creating a read-only PSDrive alias is not a system-changing operation and should always execute regardless of `WhatIfPreference`.