### PR TITLE
Fix CodeFormatter strict mode error when processing a single file

### DIFF
--- a/.build/Invoke-CodeFormatterOnFiles.ps1
+++ b/.build/Invoke-CodeFormatterOnFiles.ps1
@@ -35,16 +35,17 @@ function Invoke-CodeFormatterOnFiles {
 
     $repoRoot = Get-Item "$PSScriptRoot\.."
     $errorCount = 0
+    $filesToCheck = New-Object System.Collections.Generic.List[object]
 
-    $filesToCheck = foreach ($path in $FilePaths) {
+    foreach ($path in $FilePaths) {
         if (Test-Path -Path $path) {
-            Get-Item -Path $path
+            $filesToCheck.Add((Get-Item -Path $path))
         } else {
             Write-Warning "File not found, skipping: $path"
         }
     }
 
-    if ($null -eq $filesToCheck -or $filesToCheck.Count -eq 0) {
+    if ($filesToCheck.Count -eq 0) {
         Write-Host "No valid files to check."
         return 0
     }


### PR DESCRIPTION
## Problem

`Invoke-CodeFormatterOnFiles.ps1` throws a `PropertyNotFoundException` on `.Count` when called through `CodeFormatter.ps1 -Branch` with exactly one changed `.ps1`/`.psm1`/`.md` file:

`
PropertyNotFoundException: .build\Invoke-CodeFormatterOnFiles.ps1:47
Line |
  47 |      if ($null -eq $filesToCheck -or $filesToCheck.Count -eq 0) {
     | The property 'Count' cannot be found on this object.
`

## Root Cause

This was introduced in b04eb8f8e (Refactor CodeFormatter: extract Invoke-CodeFormatterOnFiles). When the formatting logic was extracted from `CodeFormatter.ps1` into `Invoke-CodeFormatterOnFiles.ps1`, the `foreach` assignment pattern was preserved:

`powershell
$filesToCheck = foreach ($path in $FilePaths) { ... }
`

In `CodeFormatter.ps1`, `Set-StrictMode -Version Latest` is active (line 14). Under strict mode, when the `foreach` yields a single `FileInfo` object, PowerShell assigns it as a scalar — not an array. A scalar `FileInfo` has no `.Count` property, so the guard check on line 47 throws.

**Why it wasn't caught during the refactor**: The original `CodeFormatter.ps1` had separate code paths for single-file vs multi-file — the `Get-ChildItem -Include` call with `-Recurse` in the non-optimized path always returned an array. When the logic was extracted into a standalone function, the caller controls the input, and the function lost that implicit array guarantee. The strict mode interaction only manifests when the branch diff has exactly one qualifying file, which is an uncommon but valid scenario.

## Fix

Use a typed `List[object]` with explicit `.Add()` calls instead of bare `foreach` assignment. The `List` always has a `.Count` property regardless of how many items it contains.

`powershell
$filesToCheck = New-Object System.Collections.Generic.List[object]

foreach ($path in $FilePaths) {
    if (Test-Path -Path $path) {
        $filesToCheck.Add((Get-Item -Path $path))
    } else {
        Write-Warning "File not found, skipping: $path"
    }
}

if ($filesToCheck.Count -eq 0) { ... }
`

Tested under `Set-StrictMode -Version Latest` with 0, 1, and multiple files.