### PR TITLE
Fix ManagePublicFolderPermissions.ps1 -Export: Folder string inputs, Mailbox coercion, and loop variable shadow

### DIFF
--- a/PublicFolders/ManagePublicFolderPermissions.ps1
+++ b/PublicFolders/ManagePublicFolderPermissions.ps1
@@ -187,10 +187,34 @@ end {
 
         if (-not $Mailbox) {
             Write-Host "No mailbox specified. Using the root public folder mailbox."
-            $Mailbox = Get-Mailbox -PublicFolder (Get-OrganizationConfig -ErrorAction Stop).RootPublicFolderMailbox -ErrorAction Stop
+            $rootPublicFolderMailbox = (Get-OrganizationConfig -ErrorAction Stop).RootPublicFolderMailbox
+            $resolvedMailbox = Get-Mailbox -PublicFolder -Identity $rootPublicFolderMailbox -ErrorAction Stop
         } else {
-            $Mailbox = Get-Mailbox -PublicFolder -Identity $Mailbox -ErrorAction Stop
+            $resolvedMailbox = Get-Mailbox -PublicFolder -Identity $Mailbox -ErrorAction Stop
         }
+
+        # Get-Mailbox in ExchangeOnlineManagement returns a Microsoft.Exchange.Data.Directory.Management.Mailbox
+        # whose ToString() returns an empty string. Assigning it back into the [string]-typed $Mailbox
+        # parameter triggers PowerShell coercion that falls back to a property-bag dump
+        # (@{Prop=Val; ...}) when ToString() is empty, and that malformed string breaks downstream
+        # cmdlets. Extract a stable identifier explicitly instead.
+        $mailboxForCmdlet = if ($resolvedMailbox.ExchangeGuid -and $resolvedMailbox.ExchangeGuid.Guid) {
+            $resolvedMailbox.ExchangeGuid.Guid.ToString()
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$resolvedMailbox.PrimarySmtpAddress)) {
+            [string]$resolvedMailbox.PrimarySmtpAddress
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$resolvedMailbox.Identity)) {
+            [string]$resolvedMailbox.Identity
+        } else {
+            throw "Resolved public folder mailbox does not expose an ExchangeGuid, PrimarySmtpAddress, or Identity that can be used."
+        }
+
+        $exportedFromValue = if (-not [string]::IsNullOrWhiteSpace([string]$resolvedMailbox.PrimarySmtpAddress)) {
+            [string]$resolvedMailbox.PrimarySmtpAddress
+        } else {
+            $mailboxForCmdlet
+        }
+
+        $Mailbox = $mailboxForCmdlet
 
         if ($foldersToProcess.Count -lt 1) {
             Write-Host "Retrieving all public folders..."
@@ -206,26 +230,38 @@ end {
         $exportBatch = New-Object System.Collections.ArrayList
         $progressCount = 0
 
-        foreach ($folder in $foldersToProcess) {
+        # NOTE: Use $currentFolder (not $folder) as the loop variable. The script parameter
+        # is declared [object[]]$Folder, and PowerShell variable names are case-insensitive,
+        # so assigning to $folder inside the loop re-coerces the iteration value back into
+        # [object[]] - turning a string element into Object[1]{ "<string>" } on every iteration.
+        foreach ($currentFolder in $foldersToProcess) {
             $progressCount++
 
-            if ($folder.Identity -eq "\" -or $folder.Identity -eq "\non_ipm_subtree") {
+            # -Folder accepts public folder objects or identity strings. Resolve string inputs to
+            # full folder objects so the rest of the loop can rely on Identity/EntryId/ContentMailboxName.
+            if ($currentFolder -is [string]) {
+                $currentFolder = Get-PublicFolder -Identity $currentFolder -ErrorAction Stop
+            } elseif ($null -eq $currentFolder.Identity) {
+                throw "Folder input must be a public folder object with an Identity property or a public folder identity string. Received an object of type '$($currentFolder.GetType().FullName)'."
+            }
+
+            if ($currentFolder.Identity -eq "\" -or $currentFolder.Identity -eq "\non_ipm_subtree") {
                 continue
             }
 
-            if ($alreadyExported.Contains($folder.Identity.ToString())) {
+            if ($alreadyExported.Contains($currentFolder.Identity.ToString())) {
                 continue
             }
 
             Write-Progress -Activity "Processing public folders" -Status "Folder $progressCount of $($foldersToProcess.Count)" -PercentComplete (($progressCount / $foldersToProcess.Count) * 100)
 
-            $permissions = Get-PublicFolderClientPermission -Identity "$($folder.Identity)" -Mailbox $mailbox
+            $permissions = Get-PublicFolderClientPermission -Identity "$($currentFolder.Identity)" -Mailbox $mailbox
             foreach ($perm in $permissions) {
                 $exportBatch.Add([PSCustomObject]@{
-                        EntryId            = $folder.EntryId
-                        FolderPath         = $folder.Identity
-                        ContentMailboxName = $folder.ContentMailboxName
-                        ExportedFrom       = $Mailbox.ToString()
+                        EntryId            = $currentFolder.EntryId
+                        FolderPath         = $currentFolder.Identity
+                        ContentMailboxName = $currentFolder.ContentMailboxName
+                        ExportedFrom       = $exportedFromValue
                         DisplayName        = $perm.User.DisplayName
                         PrimarySmtpAddress = $perm.User.RecipientPrincipal.PrimarySmtpAddress
                         Guid               = $perm.User.RecipientPrincipal.Guid


### PR DESCRIPTION
## Summary

Fixes three bugs in the `-Export` path of `PublicFolders/ManagePublicFolderPermissions.ps1`. All three reproduced cleanly against Exchange Online (ExchangeOnlineManagement 3.9.2, PowerShell 7.6.2) before the fix.

## Bugs fixed

### 1. `-Folder` string inputs crashed with a null-method error

```powershell
.\ManagePublicFolderPermissions.ps1 -Export -Folder \FolderA
# InvalidOperation: You cannot call a method on a null-valued expression.
#   at: if ($alreadyExported.Contains($folder.Identity.ToString())) { ...
```

The `-Folder` parameter is declared `[object[]]` and is documented to accept both public folder objects and identity strings. The loop body assumed `.Identity` always existed, so any string element triggered a null-method exception.

**Fix:** Resolve string elements to full folder objects via `Get-PublicFolder` inside the loop, and throw a clear, actionable error for any element that is neither a string nor exposes `.Identity`.

### 2. `-Mailbox` parameter coercion produced a property-bag dump

```powershell
Get-PublicFolder "\FolderA" | .\ManagePublicFolderPermissions.ps1 -Export
# Get-PublicFolderClientPermission: ||Failed to convert name format for
#   "@{AcceptMessagesOnlyFromWithDisplayNames=System.Collections.ArrayList; ...}"
```

The script declares `[string]$Mailbox` and then did `$Mailbox = Get-Mailbox -PublicFolder ...`. In `ExchangeOnlineManagement` 3.x, `Get-Mailbox` returns a `Microsoft.Exchange.Data.Directory.Management.Mailbox` whose `ToString()` returns an empty string. Reassigning that object back into the `[string]`-typed `$Mailbox` parameter triggered PowerShell's coercion fallback to a property-bag dump (`@{Prop=Val; ...}`), and that malformed string was then passed to `Get-PublicFolderClientPermission -Mailbox`, breaking the cmdlet.

**Fix:** Extract a stable identifier explicitly. Prefer `ExchangeGuid.Guid` (matches existing repo precedent at `PublicFolders/ValidateEXOPFDumpster.ps1:244-245`), falling back to `PrimarySmtpAddress`, then `Identity`. Keep a separate `$exportedFromValue` for the CSV column so the report still shows the SMTP address when available.

### 3. Loop variable `$folder` shadowed the `[object[]]$Folder` parameter

After fixing bug 1, the script still failed with:

```text
Folder input must be a public folder object with an Identity property or a public folder identity string.
Received an object of type 'System.Object[]'.
```

The diagnostic was confusing because the ArrayList contained a single `String` element — verified by both indexer access (`$foldersToProcess[0]`) and direct `GetEnumerator()` iteration. Only the `foreach` keyword produced an `Object[]`.

Root cause: **PowerShell variable names are case-insensitive**, so the loop variable `$folder` in `foreach ($folder in $foldersToProcess)` was the *same variable* as the `[object[]]$Folder` script parameter. PowerShell's typed-parameter coercion re-ran on every iteration assignment, wrapping the `String` element back into `Object[1]{ "<string>" }`. The `-is [string]` check then failed.

**Fix:** Rename the loop variable (and all loop-body references) to `$currentFolder`, and add a comment explaining the trap so it does not get reintroduced.

## Validation

- Reproduced all three bugs against EXO before fixing
- Verified each fix individually by running the script with the failing invocations
- Reproduced the foreach/parameter-shadow case in a stub harness (no EXO required) to confirm the diagnosis
- Code formatter (`Invoke-CodeFormatterOnFiles`): clean
- Spell check (`SpellCheck.ps1`): clean
- Two independent code reviews (Claude Opus + GPT-5.5): no significant findings

## User-facing behavior

| Invocation                                                              | Before   | After |
| ----------------------------------------------------------------------- | -------- | ----- |
| `.\ManagePublicFolderPermissions.ps1 -Export -Folder \FolderA`          | crashed  | works |
| `.\ManagePublicFolderPermissions.ps1 -Export -Folder \FolderA, \FolderB` | crashed  | works |
| `Get-PublicFolder "\FolderA" \| .\ManagePublicFolderPermissions.ps1 -Export` | malformed | works |
