### PR TITLE
HealthChecker: Add outbound IIS URL rewrite rule detection

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Get-URLRewriteRule.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-URLRewriteRule.ps1
@@ -3,9 +3,10 @@
 
 <#
 .SYNOPSIS
- Pulls out URL Rewrite Rules from the web.config and applicationHost.config file to return a Hashtable of those settings.
+ Pulls out URL Rewrite Rules from the web.config and applicationHost.config file to return inbound and outbound rules.
 .DESCRIPTION
  This is a function that is designed to pull out the URL Rewrite Rules that are set on a location of IIS.
+ It extracts both inbound rules (from rewrite/rules) and outbound rules (from rewrite/outboundRules).
  Because you can set it on an individual web.config file or the parent site(s), or the ApplicationHostConfig file for the location
  We need to check all locations to properly determine what is all set.
  The ApplicationHostConfig file must be able to be converted to Xml, but the web.config file doesn't.
@@ -14,11 +15,12 @@
     2. ApplicationHost.config file for the same location
     3. Then move up one level (Default Web Site/mapi -> Default Web Site) and repeat 1 and 2 till no more locations.
         a. If the 'clear' flag was set at any point, we stop at that location in the process.
+        b. Inbound and outbound rules track the 'clear' flag independently.
     4. Then there is a global setting in the ApplicationHost.config file.
 #>
 function Get-URLRewriteRule {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory = $true)]
         [System.Xml.XmlNode]$ApplicationHostConfig,
@@ -31,51 +33,82 @@ function Get-URLRewriteRule {
     begin {
         Write-Verbose "Calling: $($MyInvocation.MyCommand)"
         $urlRewriteRules = @{}
+        $urlOutboundRewriteRules = @{}
         $appHostConfigLocations = $ApplicationHostConfig.configuration.Location.path
     }
     process {
         foreach ($key in $WebConfigContent.Keys) {
             Write-Verbose "Working on key: $key"
             $continue = $true
-            $clear = $false
+            $clearInbound = $false
+            $clearOutbound = $false
             $currentKey = $key
             $urlRewriteRules.Add($key, (New-Object System.Collections.Generic.List[object]))
+            $urlOutboundRewriteRules.Add($key, (New-Object System.Collections.Generic.List[object]))
 
             do {
                 Write-Verbose "Working on currentKey: $currentKey"
                 try {
                     # the Web.config is looked at first
                     [xml]$content = $WebConfigContent[$currentKey]
-                    $rules = $content.configuration.'system.webServer'.rewrite.rules
 
-                    if ($null -ne $rules) {
-                        $clear = $null -ne $rules.clear
-                        $urlRewriteRules[$key].Add($rules)
-                    } else {
-                        Write-Verbose "No rewrite rules in the config file"
+                    if (-not $clearInbound) {
+                        $rules = $content.configuration.'system.webServer'.rewrite.rules
+
+                        if ($null -ne $rules) {
+                            $clearInbound = $null -ne $rules.clear
+                            $urlRewriteRules[$key].Add($rules)
+                        } else {
+                            Write-Verbose "No inbound rewrite rules in the config file"
+                        }
+                    }
+
+                    if (-not $clearOutbound) {
+                        $outboundRules = $content.configuration.'system.webServer'.rewrite.outboundRules
+
+                        if ($null -ne $outboundRules) {
+                            $clearOutbound = $null -ne $outboundRules.clear
+                            $urlOutboundRewriteRules[$key].Add($outboundRules)
+                        } else {
+                            Write-Verbose "No outbound rewrite rules in the config file"
+                        }
                     }
                 } catch {
                     Write-Verbose "Failed to convert to xml"
                     Invoke-CatchActions
                 }
 
-                if (-not $clear) {
+                if (-not $clearInbound -or -not $clearOutbound) {
                     # Now need to look at the applicationHost.config file to determine what is set at that location.
                     # need to do this because of the case sensitive query to get the xmlNode
-                    Write-Verbose "clear not set on config. Looking at the applicationHost.config file"
+                    Write-Verbose "Looking at the applicationHost.config file"
                     $appKey = $appHostConfigLocations | Where-Object { $_ -eq $currentKey }
 
                     if ($appKey.Count -eq 1) {
                         $location = $ApplicationHostConfig.SelectNodes("/configuration/location[@path = '$appKey']")
 
                         if ($null -ne $location) {
-                            $rules = $location.'system.webServer'.rewrite.rules
 
-                            if ($null -ne $rules) {
-                                $clear = $null -ne $rules.clear
-                                $urlRewriteRules[$key].Add($rules)
-                            } else {
-                                Write-Verbose 'No rewrite rules in the applicationHost.config file'
+                            if (-not $clearInbound) {
+                                $rules = $location.'system.webServer'.rewrite.rules
+
+                                if ($null -ne $rules) {
+                                    $clearInbound = $null -ne $rules.clear
+                                    $urlRewriteRules[$key].Add($rules)
+                                } else {
+                                    Write-Verbose "No inbound rewrite rules in the applicationHost.config file"
+                                }
+                            }
+
+                            if (-not $clearOutbound) {
+                                $outboundRules = $location.'system.webServer'.rewrite.outboundRules
+
+                                if ($null -ne $outboundRules) {
+                                    $clearOutbound = $null -ne $outboundRules.clear
+                                    $urlOutboundRewriteRules[$key].Add($outboundRules)
+                                } else {
+                                    Write-Verbose "No outbound rewrite rules in the applicationHost.config file"
+                                }
                             }
                         } else {
                             Write-Verbose "We didn't find the location for '$appKey' in the applicationHostConfig. This shouldn't occur."
@@ -85,21 +118,34 @@ function Get-URLRewriteRule {
                     }
                 }
 
-                if ($clear) {
-                    Write-Verbose "Clear was set, don't need to know what else was set."
+                if ($clearInbound -and $clearOutbound) {
+                    Write-Verbose "Clear was set for both inbound and outbound, don't need to know what else was set."
                     $continue = $false
                 } else {
                     $index = $currentKey.LastIndexOf("/")
 
                     if ($index -eq -1) {
                         $continue = $false
-                        # look at the global configuration of the applicationHost.config file
-                        $rules = $ApplicationHostConfig.configuration.'system.webServer'.rewrite.rules
 
-                        if ($null -ne $rules) {
-                            $urlRewriteRules[$key].Add($rules)
-                        } else {
-                            Write-Verbose "No global configuration for rewrite rules."
+                        if (-not $clearInbound) {
+                            # look at the global configuration of the applicationHost.config file
+                            $rules = $ApplicationHostConfig.configuration.'system.webServer'.rewrite.rules
+
+                            if ($null -ne $rules) {
+                                $urlRewriteRules[$key].Add($rules)
+                            } else {
+                                Write-Verbose "No global configuration for inbound rewrite rules."
+                            }
+                        }
+
+                        if (-not $clearOutbound) {
+                            $outboundRules = $ApplicationHostConfig.configuration.'system.webServer'.rewrite.outboundRules
+
+                            if ($null -ne $outboundRules) {
+                                $urlOutboundRewriteRules[$key].Add($outboundRules)
+                            } else {
+                                Write-Verbose "No global configuration for outbound rewrite rules."
+                            }
                         }
                     } else {
                         $currentKey = $currentKey.Substring(0, $index)
@@ -111,6 +157,9 @@ function Get-URLRewriteRule {
         }
     }
     end {
-        return $urlRewriteRules
+        return [PSCustomObject]@{
+            Inbound  = $urlRewriteRules
+            Outbound = $urlOutboundRewriteRules
+        }
     }
 }

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -720,6 +720,20 @@ function Invoke-AnalyzerIISInformation {
         Add-AnalyzedResultInformation @params
     }
 
+    $globalRules = ([xml]$applicationHostConfig).configuration.'system.webServer'.rewrite.globalRules
+
+    if ($null -ne $globalRules -and
+        $null -ne $globalRules.rule) {
+        $params = $baseParams + @{
+            Name             = "Global IIS Rewrite Rules Detected"
+            Details          = "Global URL Rewrite rules are defined in applicationHost.config and apply to all sites on this server." +
+            "`r`n`t`tReview these rules to ensure they are expected and not interfering with Exchange traffic."
+            DisplayWriteType = "Yellow"
+            TestingName      = "Global IIS Rewrite Rules"
+        }
+        Add-AnalyzedResultInformation @params
+    }
+
     foreach ($webApp in $iisWebApplications) {
         if ($correctLocations.ContainsKey($webApp.FriendlyName)) {
             if ($webApp.PhysicalPath -notlike "*$($correctLocations[$webApp.FriendlyName])") {

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -416,10 +416,12 @@ function Invoke-AnalyzerIISInformation {
         WebConfigContent      = $iisWebConfigContent
     }
 
-    $urlRewriteRules = $null
+    $urlRewriteResult = $null
     $ipFilterSettings = $null
     $authTypeSettings = $null
-    Get-URLRewriteRule @ruleParams | Invoke-RemotePipelineHandler -Result ([ref]$urlRewriteRules)
+    Get-URLRewriteRule @ruleParams | Invoke-RemotePipelineHandler -Result ([ref]$urlRewriteResult)
+    $urlRewriteRules = $urlRewriteResult.Inbound
+    $urlOutboundRewriteRules = $urlRewriteResult.Outbound
     Get-IPFilterSetting -ApplicationHostConfig ([xml]$applicationHostConfig) | Invoke-RemotePipelineHandler -Result ([ref]$ipFilterSettings)
     Get-IISAuthenticationType -ApplicationHostConfig ([xml]$applicationHostConfig) | Invoke-RemotePipelineHandler -Result ([ref]$authTypeSettings)
     $failedLocationsForAuth = @()
@@ -440,6 +442,7 @@ function Invoke-AnalyzerIISInformation {
         $epValue = "None"
         $ep = $extendedProtectionConfiguration | Where-Object { $_.VirtualDirectoryName -eq $location.Path }
         $currentRewriteRules = $urlRewriteRules[$location.Path]
+        $currentOutboundRewriteRules = $urlOutboundRewriteRules[$location.Path]
         $authentication = $authTypeSettings[$location.Path]
 
         if ($currentRewriteRules.Count -ne 0) {
@@ -455,7 +458,23 @@ function Invoke-AnalyzerIISInformation {
             }
 
             $displayRewriteRules = ($currentRewriteRules.rule | Where-Object { $_.enabled -ne "false" }).name |
-                Where-Object { $_ -notcontains $excludeRules }
+                Where-Object { $_ -notin $excludeRules }
+        }
+
+        $displayOutboundRewriteRules = [string]::Empty
+
+        if ($currentOutboundRewriteRules.Count -ne 0) {
+            $excludeOutboundRules = @()
+            foreach ($rule in $currentOutboundRewriteRules) {
+                $remove = $rule.Remove
+
+                if ($null -ne $remove) {
+                    $excludeOutboundRules += $remove.Name
+                }
+            }
+
+            $displayOutboundRewriteRules = ($currentOutboundRewriteRules.rule | Where-Object { $_.enabled -ne "false" }).name |
+                Where-Object { $_ -notin $excludeOutboundRules }
         }
 
         if ($null -ne $ep) {
@@ -484,7 +503,8 @@ function Invoke-AnalyzerIISInformation {
                 ExtendedProtection = $epValue
                 SslFlags           = $sslFlag
                 IPFilteringEnabled = $ipFilterEnabled
-                URLRewrite         = $displayRewriteRules
+                InURLRewrite       = $displayRewriteRules
+                OutURLRewrite      = $displayOutboundRewriteRules
                 Authentication     = $authentication
             })
     }
@@ -635,6 +655,7 @@ function Invoke-AnalyzerIISInformation {
                     IndentSpaces  = 8
                 })
             AddHtmlDetailRow = $false
+            TestingName      = "Inbound URL Rewrite Rules"
         }
         Add-AnalyzedResultInformation @params
 
@@ -649,6 +670,54 @@ function Invoke-AnalyzerIISInformation {
 
             Add-AnalyzedResultInformation @params
         }
+    }
+
+    # Display Outbound URL Rewrite Rules.
+    # Same deduplication pattern as inbound - don't display rules on multiple vDirs by same name.
+    $alreadyDisplayedOutboundRules = @{}
+    $outboundDisplayKey = "DisplayKey"
+    $alreadyDisplayedOutboundRules.Add($outboundDisplayKey, (New-Object System.Collections.Generic.List[object]))
+
+    foreach ($key in $urlOutboundRewriteRules.Keys) {
+        $currentSection = $urlOutboundRewriteRules[$key]
+
+        if ($currentSection.Count -ne 0) {
+            foreach ($rule in $currentSection.rule) {
+
+                if ($null -eq $rule) {
+                    Write-Verbose "Outbound rule is NULL skipping."
+                    continue
+                } elseif ($rule.enabled -eq "false") {
+                    Write-Verbose "skipping over disabled outbound rule: $($rule.Name) for vDir '$key'"
+                    continue
+                }
+
+                $displayObject = [PSCustomObject]@{
+                    RewriteRuleName = $rule.name
+                    ServerVariable  = $rule.match.serverVariable
+                    MatchPattern    = $rule.match.pattern
+                    PreCondition    = $rule.preCondition
+                    ActionType      = $rule.action.type
+                }
+
+                if (-not ($alreadyDisplayedOutboundRules.ContainsKey((($displayObject.RewriteRuleName))))) {
+                    $alreadyDisplayedOutboundRules.Add($displayObject.RewriteRuleName, $displayObject)
+                    $alreadyDisplayedOutboundRules[$outboundDisplayKey].Add($displayObject)
+                }
+            }
+        }
+    }
+
+    if ($alreadyDisplayedOutboundRules[$outboundDisplayKey].Count -gt 0) {
+        $params = $baseParams + @{
+            OutColumns       = ([PSCustomObject]@{
+                    DisplayObject = $alreadyDisplayedOutboundRules[$outboundDisplayKey]
+                    IndentSpaces  = 8
+                })
+            AddHtmlDetailRow = $false
+            TestingName      = "Outbound URL Rewrite Rules"
+        }
+        Add-AnalyzedResultInformation @params
     }
 
     foreach ($webApp in $iisWebApplications) {

--- a/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
@@ -29,13 +29,13 @@ Describe "Get-URLRewriteRule" {
     Context "Rule extraction from web.config" {
 
         It "Should find inbound rule from Default Web Site web.config" {
-            $siteRules = $Script:result["Default Web Site"]
+            $siteRules = $Script:result.Inbound["Default Web Site"]
             $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
         }
 
         It "Should collect remove entry from MAPI web.config" {
-            $mapiRules = $Script:result["Default Web Site/mapi"]
+            $mapiRules = $Script:result.Inbound["Default Web Site/mapi"]
             # First entry is from web.config which contains the <remove> element
             $removeNames = @($mapiRules[0].remove.name)
             $removeNames | Should -Contain "Global Block Bad User Agents"
@@ -45,13 +45,13 @@ Describe "Get-URLRewriteRule" {
     Context "Rule extraction from applicationHost.config per-location" {
 
         It "Should find disabled inbound rule from appHost Default Web Site location" {
-            $siteRules = $Script:result["Default Web Site"]
+            $siteRules = $Script:result.Inbound["Default Web Site"]
             $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Contain "Disable HTTP - Redirect to HTTPS"
         }
 
         It "Should preserve disabled attribute on appHost rule" {
-            $siteRules = $Script:result["Default Web Site"]
+            $siteRules = $Script:result.Inbound["Default Web Site"]
             $disabledRule = $siteRules | ForEach-Object { $_.rule } |
                 Where-Object { $_.name -eq "Disable HTTP - Redirect to HTTPS" }
             $disabledRule.enabled | Should -Be "false"
@@ -61,7 +61,7 @@ Describe "Get-URLRewriteRule" {
     Context "Rule extraction from applicationHost.config global section" {
 
         It "Should find global inbound rule" {
-            $siteRules = $Script:result["Default Web Site"]
+            $siteRules = $Script:result.Inbound["Default Web Site"]
             $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Contain "Global Block Bad User Agents"
         }
@@ -71,15 +71,15 @@ Describe "Get-URLRewriteRule" {
 
         It "Should collect rules from all 3 levels for Default Web Site" {
             # web.config (CVE-2022-41040) + appHost location (disabled HTTPS redirect) + global (Block Bad User Agents)
-            $Script:result["Default Web Site"].Count | Should -Be 3
+            $Script:result.Inbound["Default Web Site"].Count | Should -Be 3
         }
 
         It "Should inherit parent and global rules for Default Web Site/owa" {
-            # OWA web.config has no inbound rules (only outbound which the function cannot see yet)
+            # OWA web.config has no inbound rules (only outbound)
             # OWA appHost location has no inbound rules (only outbound)
             # Walks up to Default Web Site: web.config has CVE-2022-41040, appHost has disabled HTTPS redirect
             # Then global has Block Bad User Agents
-            $owaRules = $Script:result["Default Web Site/owa"]
+            $owaRules = $Script:result.Inbound["Default Web Site/owa"]
             $allRuleNames = @($owaRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
             $allRuleNames | Should -Contain "Disable HTTP - Redirect to HTTPS"
@@ -89,7 +89,7 @@ Describe "Get-URLRewriteRule" {
         It "Should inherit rules for vDir with no rewrite config" {
             # EWS web.config has no rewrite section at all
             # Should inherit from parent Default Web Site and global
-            $ewsRules = $Script:result["Default Web Site/EWS"]
+            $ewsRules = $Script:result.Inbound["Default Web Site/EWS"]
             $allRuleNames = @($ewsRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
             $allRuleNames | Should -Contain "Global Block Bad User Agents"
@@ -102,7 +102,7 @@ Describe "Get-URLRewriteRule" {
             # MAPI web.config has <remove> (collected but no clear)
             # MAPI appHost location has <clear/> which stops inheritance
             # Should NOT contain parent Default Web Site rules or global rules
-            $mapiRules = $Script:result["Default Web Site/mapi"]
+            $mapiRules = $Script:result.Inbound["Default Web Site/mapi"]
             $mapiRules.Count | Should -Be 2
             $allRuleNames = @($mapiRules.rule.name | Where-Object { $null -ne $_ })
             $allRuleNames | Should -Not -Contain "CVE-2022-41040 Mitigation"
@@ -122,14 +122,94 @@ Describe "Get-URLRewriteRule" {
             $result = Get-URLRewriteRule -ApplicationHostConfig $Script:appHost -WebConfigContent $webConfigs
 
             # Should only have 1 entry (the clear node from web.config) - nothing from appHost or parent
-            $result["Default Web Site/owa"].Count | Should -Be 1
-            $null -ne $result["Default Web Site/owa"][0].clear | Should -Be $true
+            $result.Inbound["Default Web Site/owa"].Count | Should -Be 1
+            $null -ne $result.Inbound["Default Web Site/owa"][0].clear | Should -Be $true
+        }
+    }
+
+    Context "Outbound rule extraction from web.config" {
+
+        It "Should find outbound rule from OWA web.config" {
+            $owaOutbound = $Script:result.Outbound["Default Web Site/owa"]
+            $allRuleNames = @($owaOutbound.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "EOMT OWA CSP - outbound"
+        }
+    }
+
+    Context "Outbound rule extraction from applicationHost.config per-location" {
+
+        It "Should find outbound rule from appHost OWA location" {
+            $owaOutbound = $Script:result.Outbound["Default Web Site/owa"]
+            $allRuleNames = @($owaOutbound.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "AppHost OWA Outbound Test"
+        }
+    }
+
+    Context "Outbound rule structure" {
+
+        It "Should preserve preCondition attribute on outbound rule" {
+            $owaOutbound = $Script:result.Outbound["Default Web Site/owa"]
+            $outboundRule = $owaOutbound | ForEach-Object { $_.rule } |
+                Where-Object { $_.name -eq "EOMT OWA CSP - outbound" }
+            $outboundRule.preCondition | Should -Be "EOMT OWA SPA HTML shell - precondition"
+        }
+
+        It "Should have serverVariable on outbound match" {
+            $owaOutbound = $Script:result.Outbound["Default Web Site/owa"]
+            $outboundRule = $owaOutbound | ForEach-Object { $_.rule } |
+                Where-Object { $_.name -eq "EOMT OWA CSP - outbound" }
+            $outboundRule.match.serverVariable | Should -Be "RESPONSE_Content_Security_Policy"
+        }
+    }
+
+    Context "Outbound inheritance and independent clear tracking" {
+
+        It "Should have empty outbound for vDir with no outbound rules at any level" {
+            $ewsOutbound = $Script:result.Outbound["Default Web Site/EWS"]
+            $ewsOutbound.Count | Should -Be 0
+        }
+
+        It "Should continue outbound walk-up when only inbound has clear" {
+            # Inbound clear at child level should not block outbound from inheriting parent rules
+            $childConfig = '<configuration><system.webServer><rewrite><rules><clear /></rules></rewrite></system.webServer></configuration>'
+            $parentConfig = @"
+<configuration><system.webServer><rewrite><outboundRules>
+    <rule name="Parent Outbound Rule">
+        <match serverVariable="RESPONSE_X_Test" pattern="(.*)" />
+        <action type="Rewrite" value="test" />
+    </rule>
+</outboundRules></rewrite></system.webServer></configuration>
+"@
+            [xml]$testAppHost = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer />
+    <location path="Default Web Site/test">
+        <system.webServer />
+    </location>
+    <location path="Default Web Site">
+        <system.webServer />
+    </location>
+</configuration>
+"@
+            $webConfigs = @{
+                "Default Web Site/test" = $childConfig
+                "Default Web Site"      = $parentConfig
+            }
+
+            $result = Get-URLRewriteRule -ApplicationHostConfig $testAppHost -WebConfigContent $webConfigs
+
+            # Inbound: should have 1 entry (the clear node) - walk-up stopped
+            $result.Inbound["Default Web Site/test"].Count | Should -Be 1
+            # Outbound: should have inherited from parent - walk-up NOT blocked by inbound clear
+            $outboundNames = @($result.Outbound["Default Web Site/test"].rule.name | Where-Object { $null -ne $_ })
+            $outboundNames | Should -Contain "Parent Outbound Rule"
         }
     }
 
     Context "Empty rewrite sections" {
 
-        It "Should return empty list when no rewrite rules exist at any level" {
+        It "Should return empty lists when no rewrite rules exist at any level" {
             $emptyWebConfig = '<configuration><system.webServer><modules /></system.webServer></configuration>'
             [xml]$emptyAppHost = @"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -146,8 +226,10 @@ Describe "Get-URLRewriteRule" {
 
             $result = Get-URLRewriteRule -ApplicationHostConfig $emptyAppHost -WebConfigContent $webConfigs
 
-            $result.ContainsKey("Default Web Site/test") | Should -Be $true
-            $result["Default Web Site/test"].Count | Should -Be 0
+            $result.Inbound.ContainsKey("Default Web Site/test") | Should -Be $true
+            $result.Inbound["Default Web Site/test"].Count | Should -Be 0
+            $result.Outbound.ContainsKey("Default Web Site/test") | Should -Be $true
+            $result.Outbound["Default Web Site/test"].Count | Should -Be 0
         }
     }
 }

--- a/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
@@ -1,0 +1,153 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'Pester testing file')]
+[CmdletBinding()]
+param()
+
+BeforeAll {
+    . $PSScriptRoot\..\..\..\..\Shared\PesterLoadFunctions.NotPublished.ps1
+    $scriptContent = Get-PesterScriptContent -FilePath "$PSScriptRoot\..\Get-URLRewriteRule.ps1"
+    Invoke-Expression $scriptContent
+    function Invoke-CatchActions { throw "Called Invoke-CatchActions" }
+
+    $Script:mockDataRoot = "$PSScriptRoot\..\..\Tests\DataCollection\E19\Exchange\IIS"
+    [xml]$Script:appHost = Get-Content "$Script:mockDataRoot\applicationHost.config" -Raw -Encoding UTF8
+
+    $Script:webConfigContent = @{
+        "Default Web Site"      = (Get-Content "$Script:mockDataRoot\DefaultWebSite_web.config" -Raw -Encoding UTF8)
+        "Default Web Site/owa"  = (Get-Content "$Script:mockDataRoot\DefaultWebSite-OWA_web.config" -Raw -Encoding UTF8)
+        "Default Web Site/mapi" = (Get-Content "$Script:mockDataRoot\DefaultWebSite-MAPI_web.config" -Raw -Encoding UTF8)
+        "Default Web Site/EWS"  = (Get-Content "$Script:mockDataRoot\DefaultWebSite-EWS_web.config" -Raw -Encoding UTF8)
+    }
+
+    $Script:result = Get-URLRewriteRule -ApplicationHostConfig $Script:appHost -WebConfigContent $Script:webConfigContent
+}
+
+Describe "Get-URLRewriteRule" {
+
+    Context "Rule extraction from web.config" {
+
+        It "Should find inbound rule from Default Web Site web.config" {
+            $siteRules = $Script:result["Default Web Site"]
+            $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
+        }
+
+        It "Should collect remove entry from MAPI web.config" {
+            $mapiRules = $Script:result["Default Web Site/mapi"]
+            # First entry is from web.config which contains the <remove> element
+            $removeNames = @($mapiRules[0].remove.name)
+            $removeNames | Should -Contain "Global Block Bad User Agents"
+        }
+    }
+
+    Context "Rule extraction from applicationHost.config per-location" {
+
+        It "Should find disabled inbound rule from appHost Default Web Site location" {
+            $siteRules = $Script:result["Default Web Site"]
+            $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "Disable HTTP - Redirect to HTTPS"
+        }
+
+        It "Should preserve disabled attribute on appHost rule" {
+            $siteRules = $Script:result["Default Web Site"]
+            $disabledRule = $siteRules | ForEach-Object { $_.rule } |
+                Where-Object { $_.name -eq "Disable HTTP - Redirect to HTTPS" }
+            $disabledRule.enabled | Should -Be "false"
+        }
+    }
+
+    Context "Rule extraction from applicationHost.config global section" {
+
+        It "Should find global inbound rule" {
+            $siteRules = $Script:result["Default Web Site"]
+            $allRuleNames = @($siteRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "Global Block Bad User Agents"
+        }
+    }
+
+    Context "Inheritance walk-up" {
+
+        It "Should collect rules from all 3 levels for Default Web Site" {
+            # web.config (CVE-2022-41040) + appHost location (disabled HTTPS redirect) + global (Block Bad User Agents)
+            $Script:result["Default Web Site"].Count | Should -Be 3
+        }
+
+        It "Should inherit parent and global rules for Default Web Site/owa" {
+            # OWA web.config has no inbound rules (only outbound which the function cannot see yet)
+            # OWA appHost location has no inbound rules (only outbound)
+            # Walks up to Default Web Site: web.config has CVE-2022-41040, appHost has disabled HTTPS redirect
+            # Then global has Block Bad User Agents
+            $owaRules = $Script:result["Default Web Site/owa"]
+            $allRuleNames = @($owaRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
+            $allRuleNames | Should -Contain "Disable HTTP - Redirect to HTTPS"
+            $allRuleNames | Should -Contain "Global Block Bad User Agents"
+        }
+
+        It "Should inherit rules for vDir with no rewrite config" {
+            # EWS web.config has no rewrite section at all
+            # Should inherit from parent Default Web Site and global
+            $ewsRules = $Script:result["Default Web Site/EWS"]
+            $allRuleNames = @($ewsRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
+            $allRuleNames | Should -Contain "Global Block Bad User Agents"
+        }
+    }
+
+    Context "Clear stops inheritance" {
+
+        It "Should stop at clear in appHost location for Default Web Site/mapi" {
+            # MAPI web.config has <remove> (collected but no clear)
+            # MAPI appHost location has <clear/> which stops inheritance
+            # Should NOT contain parent Default Web Site rules or global rules
+            $mapiRules = $Script:result["Default Web Site/mapi"]
+            $mapiRules.Count | Should -Be 2
+            $allRuleNames = @($mapiRules.rule.name | Where-Object { $null -ne $_ })
+            $allRuleNames | Should -Not -Contain "CVE-2022-41040 Mitigation"
+            $allRuleNames | Should -Not -Contain "Global Block Bad User Agents"
+        }
+
+        It "Should stop at clear in web.config and not check appHost or parent" {
+            # Edge case: clear in web.config is a different code path (line 52) than clear in appHost (line 75)
+            # Our mock data only has clear in appHost, so use inline XML for this specific path
+            $clearWebConfig = '<configuration><system.webServer><rewrite><rules><clear /></rules></rewrite></system.webServer></configuration>'
+            $emptyWebConfig = '<configuration><system.webServer><modules /></system.webServer></configuration>'
+            $webConfigs = @{
+                "Default Web Site/owa" = $clearWebConfig
+                "Default Web Site"     = $emptyWebConfig
+            }
+
+            $result = Get-URLRewriteRule -ApplicationHostConfig $Script:appHost -WebConfigContent $webConfigs
+
+            # Should only have 1 entry (the clear node from web.config) - nothing from appHost or parent
+            $result["Default Web Site/owa"].Count | Should -Be 1
+            $null -ne $result["Default Web Site/owa"][0].clear | Should -Be $true
+        }
+    }
+
+    Context "Empty rewrite sections" {
+
+        It "Should return empty list when no rewrite rules exist at any level" {
+            $emptyWebConfig = '<configuration><system.webServer><modules /></system.webServer></configuration>'
+            [xml]$emptyAppHost = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer />
+    <location path="Default Web Site/test">
+        <system.webServer />
+    </location>
+</configuration>
+"@
+            $webConfigs = @{
+                "Default Web Site/test" = $emptyWebConfig
+            }
+
+            $result = Get-URLRewriteRule -ApplicationHostConfig $emptyAppHost -WebConfigContent $webConfigs
+
+            $result.ContainsKey("Default Web Site/test") | Should -Be $true
+            $result["Default Web Site/test"].Count | Should -Be 0
+        }
+    }
+}

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite-MAPI_web.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite-MAPI_web.config
@@ -46,6 +46,11 @@
     </security>
     <directoryBrowse enabled="false" />
     <defaultDocument enabled="true" />
+    <rewrite>
+      <rules>
+        <remove name="Global Block Bad User Agents" />
+      </rules>
+    </rewrite>
     <httpProtocol>
       <customHeaders>
         <add name="X-FEServer" value="SOLO-E19A" />

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite-OWA_web.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite-OWA_web.config
@@ -93,6 +93,23 @@
       </customErrors>
     </system.web>
   </location>
+  <system.webServer>
+    <rewrite>
+      <outboundRules>
+        <rule name="EOMT OWA CSP - outbound" preCondition="EOMT OWA SPA HTML shell - precondition" patternSyntax="ECMAScript" stopProcessing="false">
+          <match serverVariable="RESPONSE_Content_Security_Policy" pattern="(.*)" />
+          <action type="Rewrite" value="{R:1}; script-src-attr 'none'" />
+        </rule>
+        <preConditions>
+          <!-- cspell:ignore popout -->
+          <preCondition name="EOMT OWA SPA HTML shell - precondition" logicalGrouping="MatchAll" patternSyntax="ECMAScript">
+            <add input="{RESPONSE_CONTENT_TYPE}" pattern="^text/html" />
+            <add input="{REQUEST_URI}" pattern="^/owa/?($|\?|default\.aspx|projection\.aspx|readingPane\.aspx|popout\.aspx)" />
+          </preCondition>
+        </preConditions>
+      </outboundRules>
+    </rewrite>
+  </system.webServer>
   <appSettings>
     <add key="HttpProxy.ProtocolType" value="Owa" />
   </appSettings>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web.config
@@ -40,6 +40,19 @@
       </compilation>
     </system.web>
   </location>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="CVE-2022-41040 Mitigation" stopProcessing="true" patternSyntax="ECMAScript" enabled="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{UrlDecode:{REQUEST_URI}}" pattern="(?=.*autodiscover)(?=.*powershell)" />
+          </conditions>
+          <action type="AbortRequest" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
   <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <linkedConfiguration href="file://C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\SharedWebConfig.config"/>
   </assemblyBinding>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
@@ -1192,6 +1192,15 @@
         <validation />
 
         <rewrite>
+            <globalRules>
+                <rule name="HTTP to HTTPS Redirect" stopProcessing="true">
+                    <match url="(.*)" />
+                    <conditions>
+                        <add input="{HTTPS}" pattern="off" />
+                    </conditions>
+                    <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+                </rule>
+            </globalRules>
             <rules>
                 <rule name="Global Block Bad User Agents" stopProcessing="true" patternSyntax="ECMAScript" enabled="true">
                     <match url=".*" />

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
@@ -1191,6 +1191,18 @@
 
         <validation />
 
+        <rewrite>
+            <rules>
+                <rule name="Global Block Bad User Agents" stopProcessing="true" patternSyntax="ECMAScript" enabled="true">
+                    <match url=".*" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{HTTP_USER_AGENT}" pattern="BadBot" />
+                    </conditions>
+                    <action type="AbortRequest" />
+                </rule>
+            </rules>
+        </rewrite>
+
     </system.webServer>
     <location path="" overrideMode="Allow">
         <system.webServer>
@@ -1304,6 +1316,17 @@
                     <iisClientCertificateMappingAuthentication enabled="false" />
                 </authentication>
             </security>
+            <rewrite>
+                <rules>
+                    <rule name="Disable HTTP - Redirect to HTTPS" stopProcessing="true" enabled="false">
+                        <match url="(.*)" />
+                        <conditions logicalGrouping="MatchAll">
+                            <add input="{HTTPS}" pattern="^OFF$" />
+                        </conditions>
+                        <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+                    </rule>
+                </rules>
+            </rewrite>
             <isapiFilters>
                 <clear />
                 <filter name="Exchange OWA Cookie Authentication ISAPI Filter" path="C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\bin\owaauth.dll" enabled="true" />
@@ -1962,6 +1985,19 @@
         <system.webServer>
             <directoryBrowse enabled="false" showFlags="Date, Size, Extension, LongDate" />
             <handlers accessPolicy="Read, Script" />
+            <rewrite>
+                <outboundRules>
+                    <rule name="AppHost OWA Outbound Test" preCondition="AppHost OWA PreCond" patternSyntax="ECMAScript">
+                        <match serverVariable="RESPONSE_X_Custom_Header" pattern="(.*)" />
+                        <action type="Rewrite" value="{R:1}; custom-value" />
+                    </rule>
+                    <preConditions>
+                        <preCondition name="AppHost OWA PreCond" logicalGrouping="MatchAll" patternSyntax="ECMAScript">
+                            <add input="{RESPONSE_CONTENT_TYPE}" pattern="^text/html" />
+                        </preCondition>
+                    </preConditions>
+                </outboundRules>
+            </rewrite>
             <staticContent>
                 <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" cacheControlCustom="public" />
             </staticContent>
@@ -2369,6 +2405,11 @@
                     <basicAuthentication enabled="false" />
                 </authentication>
             </security>
+            <rewrite>
+                <rules>
+                    <clear />
+                </rules>
+            </rewrite>
             <urlCompression doDynamicCompression="false" />
         </system.webServer>
     </location>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -187,6 +187,10 @@ Describe "Testing Health Checker by Mock Data Imports" {
             $outboundRuleNames = $outboundRules.RewriteRuleName.Value
             $outboundRuleNames | Should -Contain "EOMT OWA CSP - outbound"
             $outboundRuleNames | Should -Contain "AppHost OWA Outbound Test"
+
+            # Verify global IIS rewrite rules warning is displayed
+            $globalRulesWarning = GetObject "Global IIS Rewrite Rules"
+            $globalRulesWarning | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -173,6 +173,20 @@ Describe "Testing Health Checker by Mock Data Imports" {
             SetActiveDisplayGrouping "Exchange IIS Information"
             $tokenCacheModuleInformation = GetObject "TokenCacheModule loaded"
             $tokenCacheModuleInformation | Should -Be $null # null because we are loaded and only display if we aren't loaded.
+
+            # Verify inbound URL rewrite rules are displayed (deduplicated across vDirs)
+            $inboundRules = GetObject "Inbound URL Rewrite Rules"
+            $inboundRules.Count | Should -Be 2
+            $inboundRuleNames = $inboundRules.RewriteRuleName.Value
+            $inboundRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
+            $inboundRuleNames | Should -Contain "Global Block Bad User Agents"
+
+            # Verify outbound URL rewrite rules are displayed (deduplicated across vDirs)
+            $outboundRules = GetObject "Outbound URL Rewrite Rules"
+            $outboundRules.Count | Should -Be 2
+            $outboundRuleNames = $outboundRules.RewriteRuleName.Value
+            $outboundRuleNames | Should -Contain "EOMT OWA CSP - outbound"
+            $outboundRuleNames | Should -Contain "AppHost OWA Outbound Test"
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #2539

HealthChecker previously only detected **inbound** IIS URL Rewrite rules but completely missed **outbound** rules. This PR adds full outbound rule support across extraction, display, and testing.

## Changes

### Get-URLRewriteRule.ps1
- Extract outbound rules (`.rewrite.outboundRules`) alongside inbound rules at all 3 inheritance levels (web.config, appHost per-location, appHost global)
- Independent `\` / `\` tracking so a `<clear/>` on inbound doesn't block outbound inheritance walk-up (and vice versa)
- Return type changed from `[hashtable]` to `[PSCustomObject]@{ Inbound; Outbound }`

### Invoke-AnalyzerIISInformation.ps1
- Destructure composite return into separate inbound/outbound hashtables
- Add **OutURLRewrite** column to vDir summary table (alongside renamed **InURLRewrite**)
- Add detailed outbound rule display section (ServerVariable, MatchPattern, PreCondition, ActionType)
- Add yellow warning when **global IIS rewrite rules** are detected in applicationHost.config
- **Bugfix:** Fix pre-existing `-notcontains` operator bug (reversed operands) — the `<remove>` exclusion filter was a no-op for both inbound and outbound

### Tests
- **17 new unit tests** in `Get-URLRewriteRule.Tests.ps1` covering inbound extraction, outbound extraction, inheritance walk-up, `<clear/>`, `<remove>`, disabled rules, preCondition, serverVariable, independent clear tracking
- **Scenario test assertions** in `HealthChecker.E19.Main.Tests.ps1` verifying deduplicated inbound/outbound rules and global rules warning
- **Mock data** added to 4 IIS config files with realistic rewrite rule configurations

## Test Results

All 113 tests pass (17 unit + 96 scenario/integration).