### PR TITLE
HealthChecker: Fix IIS URL rewrite rule display bugs

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Get-URLRewriteRule.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Get-URLRewriteRule.ps1
@@ -37,7 +37,21 @@ function Get-URLRewriteRule {
         $appHostConfigLocations = $ApplicationHostConfig.configuration.Location.path
     }
     process {
-        foreach ($key in $WebConfigContent.Keys) {
+        # Build combined location list: WebConfigContent keys + appHost-only locations.
+        # Some IIS locations (e.g., EAS/Proxy) exist only in applicationHost.config and have
+        # no web.config entry from Get-WebApplication. We still need to walk up inheritance for them.
+        $allLocations = [System.Collections.Generic.List[string]]::new()
+        foreach ($wcKey in $WebConfigContent.Keys) {
+            $allLocations.Add($wcKey)
+        }
+        foreach ($appHostPath in $appHostConfigLocations) {
+            if (-not [string]::IsNullOrEmpty($appHostPath) -and
+                -not $WebConfigContent.ContainsKey($appHostPath)) {
+                $allLocations.Add($appHostPath)
+            }
+        }
+
+        foreach ($key in $allLocations) {
             Write-Verbose "Working on key: $key"
             $continue = $true
             $clearInbound = $false

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -635,9 +635,18 @@ function Invoke-AnalyzerIISInformation {
                 }
 
                 #multiple match type possibilities, but should only be one per rule.
-                $propertyType = ($rule.match | Get-Member | Where-Object { $_.MemberType -eq "Property" }).Name
-                $isUrlMatchProblem = $propertyType -eq "url" -and $rule.match.$propertyType -eq "*"
-                $matchProperty = "$propertyType - $($rule.match.$propertyType)"
+                $allProperties = @(($rule.match | Get-Member | Where-Object { $_.MemberType -eq "Property" }).Name)
+                # When <match> has extra attributes (negate, ignoreCase), Get-Member returns multiple properties.
+                # Filter to the actual match target property for display and the URL Match Problem check.
+                $propertyType = ($allProperties | Where-Object { $_ -eq "url" -or $_ -eq "serverVariable" } | Select-Object -First 1)
+
+                if ($null -eq $propertyType) {
+                    $propertyType = $allProperties | Select-Object -First 1
+                }
+
+                $matchValue = $rule.match.$propertyType
+                $isUrlMatchProblem = $propertyType -eq "url" -and $matchValue -eq "*"
+                $matchProperty = "$propertyType - $matchValue"
 
                 $displayObject = [PSCustomObject]@{
                     RewriteRuleName = $rule.name

--- a/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Invoke-AnalyzerIISInformation.ps1
@@ -612,6 +612,14 @@ function Invoke-AnalyzerIISInformation {
         $currentSection = $urlRewriteRules[$key]
 
         if ($currentSection.Count -ne 0) {
+            # Collect <remove> entries so inherited rules that are removed at a lower level are excluded.
+            $excludeRules = @()
+            foreach ($section in $currentSection) {
+                if ($null -ne $section.Remove) {
+                    $excludeRules += $section.Remove.Name
+                }
+            }
+
             foreach ($rule in $currentSection.rule) {
 
                 if ($null -eq $rule) {
@@ -620,6 +628,9 @@ function Invoke-AnalyzerIISInformation {
                 } elseif ($rule.enabled -eq "false") {
                     # skip over disabled rules.
                     Write-Verbose "skipping over disabled rule: $($rule.Name) for vDir '$key'"
+                    continue
+                } elseif ($rule.Name -in $excludeRules) {
+                    Write-Verbose "skipping removed rule: $($rule.Name) for vDir '$key'"
                     continue
                 }
 
@@ -682,6 +693,13 @@ function Invoke-AnalyzerIISInformation {
         $currentSection = $urlOutboundRewriteRules[$key]
 
         if ($currentSection.Count -ne 0) {
+            $excludeOutboundRules = @()
+            foreach ($section in $currentSection) {
+                if ($null -ne $section.Remove) {
+                    $excludeOutboundRules += $section.Remove.Name
+                }
+            }
+
             foreach ($rule in $currentSection.rule) {
 
                 if ($null -eq $rule) {
@@ -689,6 +707,9 @@ function Invoke-AnalyzerIISInformation {
                     continue
                 } elseif ($rule.enabled -eq "false") {
                     Write-Verbose "skipping over disabled outbound rule: $($rule.Name) for vDir '$key'"
+                    continue
+                } elseif ($rule.Name -in $excludeOutboundRules) {
+                    Write-Verbose "skipping removed outbound rule: $($rule.Name) for vDir '$key'"
                     continue
                 }
 

--- a/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Tests/Get-URLRewriteRule.Tests.ps1
@@ -96,6 +96,32 @@ Describe "Get-URLRewriteRule" {
         }
     }
 
+    Context "AppHost-only locations (no web.config entry)" {
+
+        It "Should process Proxy location that only exists in appHost" {
+            # EAS/Proxy exists in applicationHost.config but is not returned by Get-WebApplication
+            # so it has no entry in $webConfigContent. The fix adds it from appHost locations.
+            $Script:result.Inbound.ContainsKey("Default Web Site/Microsoft-Server-ActiveSync/Proxy") | Should -Be $true
+            $Script:result.Outbound.ContainsKey("Default Web Site/Microsoft-Server-ActiveSync/Proxy") | Should -Be $true
+        }
+
+        It "Should inherit parent rules for appHost-only Proxy location" {
+            # Proxy has no rules at its own appHost level. Walk-up should reach DWS web.config
+            # (CVE-2022-41040) and DWS appHost (disabled HTTPS redirect, AppHost Only Rule) and global.
+            $proxyRules = $Script:result.Inbound["Default Web Site/Microsoft-Server-ActiveSync/Proxy"]
+            $proxyRuleNames = @($proxyRules.rule.name | Where-Object { $null -ne $_ })
+            $proxyRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
+            $proxyRuleNames | Should -Contain "Global Block Bad User Agents"
+        }
+
+        It "Should not duplicate keys that exist in both WebConfigContent and appHost" {
+            # "Default Web Site" exists in both $webConfigContent and appHost locations.
+            # It should appear exactly once in the result, not duplicated.
+            $dwsCount = @($Script:result.Inbound.Keys | Where-Object { $_ -eq "Default Web Site" }).Count
+            $dwsCount | Should -Be 1
+        }
+    }
+
     Context "Clear stops inheritance" {
 
         It "Should stop at clear in appHost location for Default Web Site/mapi" {

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/DefaultWebSite_web.config
@@ -43,6 +43,7 @@
   <system.webServer>
     <rewrite>
       <rules>
+        <remove name="AppHost Only Rule" />
         <rule name="CVE-2022-41040 Mitigation" stopProcessing="true" patternSyntax="ECMAScript" enabled="true">
           <match url=".*" />
           <conditions logicalGrouping="MatchAll">

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
@@ -1338,6 +1338,10 @@
                         <match url=".*" />
                         <action type="None" />
                     </rule>
+                    <rule name="Negate Match Test Rule" stopProcessing="true">
+                        <match url=".*" negate="true" />
+                        <action type="None" />
+                    </rule>
                 </rules>
             </rewrite>
             <isapiFilters>

--- a/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
+++ b/Diagnostics/HealthChecker/Tests/DataCollection/E19/Exchange/IIS/applicationHost.config
@@ -1334,6 +1334,10 @@
                         </conditions>
                         <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
                     </rule>
+                    <rule name="AppHost Only Rule" stopProcessing="true">
+                        <match url=".*" />
+                        <action type="None" />
+                    </rule>
                 </rules>
             </rewrite>
             <isapiFilters>

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -239,13 +239,18 @@ Describe "Testing Health Checker by Mock Data Imports" {
 
             # Verify inbound URL rewrite rules are displayed (deduplicated across vDirs)
             $inboundRules = GetObject "Inbound URL Rewrite Rules"
-            $inboundRules.Count | Should -Be 2
+            $inboundRules.Count | Should -Be 3
             $inboundRuleNames = $inboundRules.RewriteRuleName.Value
             $inboundRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
             $inboundRuleNames | Should -Contain "Global Block Bad User Agents"
+            $inboundRuleNames | Should -Contain "Negate Match Test Rule"
 
             # Verify rules excluded by <remove> in DWS web.config do not appear in detailed display
             $inboundRuleNames | Should -Not -Contain "AppHost Only Rule"
+
+            # Verify match property resolves correctly when <match> has extra attributes like negate
+            $negateRule = $inboundRules | Where-Object { $_.RewriteRuleName.Value -eq "Negate Match Test Rule" }
+            $negateRule.MatchProperty.Value | Should -Be "url - .*"
 
             # Verify outbound URL rewrite rules are displayed (deduplicated across vDirs)
             $outboundRules = GetObject "Outbound URL Rewrite Rules"

--- a/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
+++ b/Diagnostics/HealthChecker/Tests/HealthChecker.E19.Main.Tests.ps1
@@ -244,6 +244,9 @@ Describe "Testing Health Checker by Mock Data Imports" {
             $inboundRuleNames | Should -Contain "CVE-2022-41040 Mitigation"
             $inboundRuleNames | Should -Contain "Global Block Bad User Agents"
 
+            # Verify rules excluded by <remove> in DWS web.config do not appear in detailed display
+            $inboundRuleNames | Should -Not -Contain "AppHost Only Rule"
+
             # Verify outbound URL rewrite rules are displayed (deduplicated across vDirs)
             $outboundRules = GetObject "Outbound URL Rewrite Rules"
             $outboundRules.Count | Should -Be 2


### PR DESCRIPTION
## Summary

Fixes three display-layer bugs in the HealthChecker IIS URL rewrite rule processing pipeline. These were discovered during server testing as follow-up to #2545 (outbound rewrite rule support).

## Changes

### 1. Detailed display ignores `<remove>` directives (Fixes #2003)

The detailed inbound and outbound URL rewrite rule display loops did not honor `<remove>` entries from inherited configuration sections. Rules explicitly removed via `<remove name='...' />` in a parent web.config still appeared in the detailed rule table and could be incorrectly flagged as misconfigured.

**Fix:** Collect exclude lists from each vDir's `Remove.Name` entries and skip matching rules in both inbound and outbound detailed display loops.

### 2. AppHost-only IIS locations missing from rewrite rule processing

Some IIS locations like `Microsoft-Server-ActiveSync/Proxy` exist only in `applicationHost.config` and are not returned by `Get-WebApplication`. `Get-URLRewriteRule` previously only iterated `WebConfigContent` keys, so these locations were skipped entirely — their inherited rewrite rules never appeared in the summary or detailed display.

**Fix:** Build a combined location list from `WebConfigContent` keys plus any appHost location paths not already present. The existing walk-up logic handles null web.config content gracefully.

### 3. Match property array bug when match has extra attributes (Fixes #2024)

When a rewrite rule `<match>` element has extra attributes like `negate` or `ignoreCase`, `Get-Member` returns multiple properties causing `\` to become an array. This broke the match value resolution, URL Match Problem check, and display — showing `negate url -` instead of `url - .*`.

**Fix:** Filter the property list to known match targets (`url`, `serverVariable`) before resolving the match value.

## Testing

- 20 unit tests for `Get-URLRewriteRule` (3 new for appHost-only locations)
- 34 scenario tests in `Main.Tests.ps1` (updated assertions for remove filtering and match property)
- All fixes verified via stash/unstash TDD: tests fail without fix, pass with fix
- Server-tested on live Exchange 2019 environment

Closes #2003
Closes #2024