### PR TITLE
Fix TLS 1.3 support detection in Health Checker

### DIFF
--- a/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
+++ b/Diagnostics/HealthChecker/Analyzer/Security/Invoke-AnalyzerSecuritySettings.ps1
@@ -60,13 +60,17 @@ function Invoke-AnalyzerSecuritySettings {
     Test-ExchangeBuildGreaterOrEqualThanBuild -CurrentExchangeBuild $HealthServerObject.ExchangeInformation.BuildInformation.VersionInformation -Version "ExchangeSE" -CU "RTM" |
         Invoke-RemotePipelineHandler -Result ([ref]$tls13SupportedExSE)
     $tls13SupportedExchange = $tls13SupportedEx2019 -or $tls13SupportedExSE
+    Write-Verbose "TLS 1.3 Support - OS MajorVersion: '$($osInformation.BuildInformation.MajorVersion)' tls13SupportedOS: $tls13SupportedOS"
+    Write-Verbose "TLS 1.3 Support - Exchange MajorVersion: '$($HealthServerObject.ExchangeInformation.BuildInformation.VersionInformation.MajorVersion)' CU: '$($HealthServerObject.ExchangeInformation.BuildInformation.VersionInformation.CU)'"
+    Write-Verbose "TLS 1.3 Support - tls13SupportedEx2019: $tls13SupportedEx2019 tls13SupportedExSE: $tls13SupportedExSE tls13SupportedExchange: $tls13SupportedExchange"
     $currentNetVersion = $osInformation.TLSSettings.Registry.NET["NETv4"]
 
     $tlsSettings = $osInformation.TLSSettings.Registry.TLS
     $misconfiguredClientServerSettings = ($tlsSettings.Values | Where-Object { $_.TLSMisconfigured -eq $true }).Count -ne 0
-    $displayLinkToDocsPage = ($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Enabled" -and $_.TLSConfiguration -ne "Disabled" }).Count -ne 0
-    $lowerTlsVersionDisabled = ($tlsSettings.Values | Where-Object { $_.TLSVersionDisabled -eq $true -and ($_.TLSVersion -ne "1.2" -and $_.TLSVersion -ne "1.3") }).Count -ne 0
-    $tls13NotDisabled = ($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Disabled" -and $_.TLSVersion -eq "1.3" }).Count -gt 0
+    $displayLinkToDocsPage = @($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Enabled" -and $_.TLSConfiguration -ne "Disabled" }).Count -ne 0
+    $lowerTlsVersionDisabled = @($tlsSettings.Values | Where-Object { $_.TLSVersionDisabled -eq $true -and ($_.TLSVersion -ne "1.2" -and $_.TLSVersion -ne "1.3") }).Count -ne 0
+    $tls13NotDisabled = @($tlsSettings.Values | Where-Object { $_.TLSConfiguration -ne "Disabled" -and $_.TLSVersion -eq "1.3" }).Count -gt 0
+    Write-Verbose "TLS 1.3 Support - tls13NotDisabled: $tls13NotDisabled TLS 1.3 TLSConfiguration: '$(($tlsSettings['1.3']).TLSConfiguration)'"
 
     $sbValue = {
         param ($o, $p)
@@ -226,7 +230,7 @@ function Invoke-AnalyzerSecuritySettings {
         Add-AnalyzedResultInformation @params
     }
 
-    if ($tls13NotDisabled) {
+    if ($tls13NotDisabled -and (-not $tls13SupportedOS -or -not $tls13SupportedExchange)) {
         $displayLinkToDocsPage = $true
         $params = $baseParams + @{
             Details                = "Error: TLS 1.3 is not disabled and not supported currently on Exchange and is known to cause issues within the cluster."


### PR DESCRIPTION
## Summary

Fixes TLS 1.3 support detection in `Invoke-AnalyzerSecuritySettings` so that the warning message is only displayed when the OS/Exchange version does not support TLS 1.3.

## Changes

- **PS 5.1 `.Count` fix**: Wrapped `Where-Object` filter results in `@()` array subexpression to ensure `.Count` returns a reliable value in PowerShell 5.1 (single objects don't have a `.Count` property in 5.1, causing the filter to silently return `\`).
- **TLS 1.3 warning guard**: Added `(-not \ -or -not \)` check to the TLS 1.3 warning block (line 233) so the error message only fires when TLS 1.3 is not supported on the current OS and Exchange version combination. Previously this warning fired unconditionally whenever TLS 1.3 was not disabled, even on supported configurations (e.g., Exchange SE RTM on Windows Server 2025).
- **Write-Verbose**: Added debug logging for key TLS 1.3 support variables to assist with future troubleshooting.