### PR TITLE
Add RESTLogs collection to Exchange Log Collector

### DIFF
--- a/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/Diagnostics/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -44,6 +44,7 @@ param (
     [switch]$PowerShellLogs,
     [switch]$QueueInformation,
     [switch]$ReceiveConnectors,
+    [switch]$RESTLogs,
     [switch]$RPCLogs,
     [switch]$SearchLogs,
     [switch]$SendConnectors,

--- a/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Get-ArgumentList.ps1
@@ -71,6 +71,7 @@ function Get-ArgumentList {
         PopLogs                        = $PopLogs
         PowerShellLogs                 = $PowerShellLogs
         QueueInformation               = $QueueInformation
+        RESTLogs                       = $RESTLogs
         RootFilePath                   = $Script:RootFilePath
         RPCLogs                        = $RPCLogs
         SearchLogs                     = $SearchLogs

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-NoSwitchesProvided.ps1
@@ -29,6 +29,7 @@ function Test-NoSwitchesProvided {
         $ImapLogs -or
         $OABLogs -or
         $PowerShellLogs -or
+        $RESTLogs -or
         $WindowsSecurityLogs -or
         $MailboxAssistantsLogs -or
         $ExchangeServerInformation -or

--- a/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/Diagnostics/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -29,6 +29,7 @@ function Test-PossibleCommonScenarios {
         $Script:ExPerfWiz = $true
         $Script:OABLogs = $true
         $Script:PowerShellLogs = $true
+        $Script:RESTLogs = $true
         $Script:WindowsSecurityLogs = $true
         $Script:CollectFailoverMetrics = $true
         $Script:TransportConnectivityLogs = $true

--- a/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/Diagnostics/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -175,6 +175,17 @@ function Invoke-RemoteMain {
             Add-LogCopyFullTaskAction "$Script:localExInstall`Logging\CmdletInfra" "CmdletInfra_Logs"
         }
 
+        if ($PassedInfo.RESTLogs) {
+
+            if ($Script:localServerObject.Mailbox) {
+                Add-DefaultLogCopyTaskAction "$Script:localExInstall`Logging\Rest" "REST_BE_Logs"
+            }
+
+            if ($Script:localServerObject.CAS) {
+                Add-DefaultLogCopyTaskAction "$Script:localExInstall`Logging\HttpProxy\Rest" "REST_Proxy_Logs"
+            }
+        }
+
         if ($Script:localServerObject.DAGMember -and
             $PassedInfo.DAGInformation) {
             Add-TaskAction "Save-FailoverClusterInformation"

--- a/docs/Diagnostics/ExchangeLogCollector.md
+++ b/docs/Diagnostics/ExchangeLogCollector.md
@@ -98,6 +98,7 @@ PopLogs | Enable to collect POP logging. Location: `(Get-PopSettings -Server $se
 PowerShellLogs | Enable to collect the PowerShell Logs. Location: `V15\Logging\HttpProxy\PowerShell`
 QueueInformation | Enable to collect the historical queue information. Location: `(Get-TransportService $server).QueueLogPath`
 ReceiveConnectors | Enable to collect the Receive Connector information from the server.
+RESTLogs | Enable to collect REST API Logs. Location: `V15\Logging\Rest` and `V15\Logging\HttpProxy\Rest`
 RPCLogs | Enable to collect RPC Logs. Location: `V15\Logging\RPC Client Access`, `V15\Logging\HttpProxy\RpcHttp`, and `V15\Logging\RpcHttp`
 SearchLogs | Enable to collect Search Logs. Location: `V15\Bin\Search\Ceres\Diagnostics\Logs`, `V15\Bin\Search\Ceres\Diagnostics\ETLTraces`, `V15\Logging\Search`. On 2019 only we also include `V15\Logging\BigFunnelMetricsCollectionAssistant`, `V15\Logging\BigFunnelQueryParityAssistant`, and `V15\Logging\BigFunnelRetryFeederTimeBasedAssistant`
 SendConnectors | Enable to collect the send connector information from the environment.


### PR DESCRIPTION
## Summary

Adds a `-RESTLogs` switch to the Exchange Log Collector to collect REST API logs, enabling troubleshooting of Exchange-Teams integration scenarios.

## Log Directories Collected

- **Backend (Mailbox role):** `%ExchangeInstallPath%Logging\Rest`
- **Proxy (CAS role):** `%ExchangeInstallPath%Logging\HttpProxy\Rest`

## Changes

- Added `[switch]$RESTLogs` parameter to `ExchangeLogCollector.ps1`
- Included in `-AllPossibleLogs` scenario
- Added to the no-switches-provided guard check
- Passed through to remote servers via `Get-ArgumentList`
- Collection logic in `Invoke-RemoteMain.ps1` follows the same Mailbox/CAS dual-path pattern as `EWSLogs`
- Updated documentation

Fixes #2123