### PR TITLE
Route pipeline package installs through Azure Artifacts feed

### DIFF
--- a/.build/Load-Module.ps1
+++ b/.build/Load-Module.ps1
@@ -1,8 +1,11 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# cspell:ignore accesstoken
+
 function Load-Module {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Prefer verb usage')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The token is provided at runtime via the pipeline SYSTEM_ACCESSTOKEN environment variable, not a hardcoded secret. A PSCredential is required to authenticate Install-Module against the Azure Artifacts feed.')]
     [CmdletBinding()]
     [OutputType([bool])]
     param (
@@ -39,15 +42,40 @@ function Load-Module {
     }
 
     $params = @{
-        Name = $Name
+        Name  = $Name
+        Force = $true
     }
 
     if (-not [string]::IsNullOrEmpty($MinimumVersion)) {
         $params.MinimumVersion = $MinimumVersion
     }
 
+    # Under Network Isolation the public PowerShell Gallery is blocked, so install
+    # modules from the internal Azure Artifacts feed. These environment variables are
+    # only set by the pipeline; local development continues to use the PowerShell Gallery.
+    if (-not [string]::IsNullOrEmpty($env:CFS_FEED_SOURCE) -and
+        -not [string]::IsNullOrEmpty($env:SYSTEM_ACCESSTOKEN)) {
+        $repositoryName = "CssExchangeCfs"
+        $secureToken = ConvertTo-SecureString $env:SYSTEM_ACCESSTOKEN -AsPlainText -Force
+        $credential = [PSCredential]::new("azdo", $secureToken)
+
+        # Register the feed if it is missing, otherwise normalize it in case a reused
+        # agent left it pointing at a different location or not trusted. Install-Module
+        # is pinned to this repository below, so the public PowerShell Gallery does not
+        # need to be unregistered.
+        $existingRepository = Get-PSRepository -Name $repositoryName -ErrorAction SilentlyContinue
+        if ($null -eq $existingRepository) {
+            Register-PSRepository -Name $repositoryName -SourceLocation $env:CFS_FEED_SOURCE -InstallationPolicy Trusted -Credential $credential
+        } elseif ($existingRepository.SourceLocation -ne $env:CFS_FEED_SOURCE -or $existingRepository.InstallationPolicy -ne "Trusted") {
+            Set-PSRepository -Name $repositoryName -SourceLocation $env:CFS_FEED_SOURCE -InstallationPolicy Trusted -Credential $credential
+        }
+
+        $params.Repository = $repositoryName
+        $params.Credential = $credential
+    }
+
     $errorCount = $Error.Count
-    Install-Module @params -Force
+    Install-Module @params
     if ($Error.Count -gt $errorCount) {
         return $false
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 dist
 .DS_Store
 
+# Generated at pipeline runtime by "Configure CFS npm feed" (see azure-pipeline-merge.yml)
+.build/.npmrc
+
 # Personal Copilot/AI overrides (per-developer, not shared)
 .copilot/
 .claude/

--- a/azure-pipeline-merge.yml
+++ b/azure-pipeline-merge.yml
@@ -9,6 +9,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Okay,CFSClean,CFSClean2
     pool:
       name: MSSecurity-1ES-Build-Agents-Pool
       image: MSSecurity-1ES-Windows-2022
@@ -19,7 +20,20 @@ extends:
     - stage: stage
       jobs:
       - job: job
+        variables:
+          CFS_FEED_SOURCE: 'https://pkgs.dev.azure.com/CSS-Exchange-Tools/$(System.TeamProjectId)/_packaging/$(CfsFeedName)/nuget/v2'
+          NPM_CONFIG_GLOBALCONFIG: '$(Build.SourcesDirectory)/.build/.npmrc'
         steps:
+        - pwsh: |
+            $registry = "https://pkgs.dev.azure.com/CSS-Exchange-Tools/$(System.TeamProjectId)/_packaging/$(CfsFeedName)/npm/registry/"
+            Set-Content -Path "$(Build.SourcesDirectory)/.build/.npmrc" -Value @("registry=$registry", "always-auth=true")
+          displayName: "Configure CFS npm feed"
+        - task: NuGetAuthenticate@1
+          displayName: "Authenticate Azure Artifacts feed (PowerShell modules)"
+        - task: npmAuthenticate@0
+          displayName: "Authenticate Azure Artifacts feed (cspell)"
+          inputs:
+            workingFile: '$(Build.SourcesDirectory)/.build/.npmrc'
         - pwsh: |
             cd .\.build
             .\docs.ps1
@@ -35,6 +49,7 @@ extends:
           condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/release'))
           env:
             TargetBranchName: $(System.PullRequest.TargetBranch)
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         - pwsh: |
             cd .\.build
             .\Build.ps1
@@ -45,6 +60,7 @@ extends:
           displayName: "Running Invoke-Pester"
           env:
             TargetBranchName: $(System.PullRequest.TargetBranch)
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         - pwsh: |
             cd .\.build
             .\ValidateMerge.ps1 -Branch $env:TargetBranchName


### PR DESCRIPTION
## Summary

The merge pipeline was connecting to public package feeds during the build: `registry.npmjs.org` (cspell) and the PowerShell Gallery (Pester, PSScriptAnalyzer, EncodingAnalyzer). This routes those installs through a private Azure Artifacts feed (which has npm and PowerShell Gallery upstreams) and enables build network isolation so the public feeds are blocked.

## Changes

- **`.build/Load-Module.ps1`** — when running under the pipeline (`CFS_FEED_SOURCE` + `SYSTEM_ACCESSTOKEN` set), install modules from the private feed using the build access token. Register the feed if missing, otherwise normalize it with `Set-PSRepository` so a reused agent with a stale registration is corrected. Local development is unchanged (still uses the PowerShell Gallery).
- **`azure-pipeline-merge.yml`** — authenticate to the feed (`NuGetAuthenticate` + `npmAuthenticate`), generate `.build/.npmrc` at runtime pointing to the feed, pass the feed/token variables (`SYSTEM_ACCESSTOKEN` scoped to only the steps that need it), and enable the build network isolation policies. The feed location is parameterized with `$(System.TeamProjectId)` and a per-pipeline `CfsFeedName` variable so the same definition works for both pipelines.
- **`.gitignore`** — ignore the runtime-generated `.build/.npmrc`.

## Network isolation

Network isolation is enabled so the build can no longer reach the public npm registry or the public PowerShell Gallery; those packages are served through the private Azure Artifacts feed instead. Validated on the pipeline — the build succeeds, packages install from the feed, and the isolation policies report compliant.

## Pipeline prerequisite

Each pipeline must define a `CfsFeedName` variable in its Azure DevOps settings pointing at that project's Azure Artifacts feed (npm + PowerShell Gallery upstreams, with the build service granted access).
