### PR TITLE
Fix EOMT CVE-2026-42897 code fix build number to July 2026 SU

### DIFF
--- a/Security/src/EOMT/Mitigations/CVE-2026-42897.ps1
+++ b/Security/src/EOMT/Mitigations/CVE-2026-42897.ps1
@@ -140,7 +140,11 @@ function Get-CVE202642897-MitigationDefinition {
                 throw ("Failed to get Exchange Server build number. The error was: {0}." -f $_)
             }
 
-            $result.CodeFixApplied = ($fullBuildNumber -ge "15.2.2562.99")
+            # EOMT treats CVE-2026-42897 as addressed by the July 2026 SU (build 15.2.2562.45), per
+            # "Released: July 2026 Exchange Server Security Updates". Note this differs from Exchange
+            # Health Checker, which reports the CVE-2026-42897 code fix against the June 2026 SU.
+            # https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146
+            $result.CodeFixApplied = ($fullBuildNumber -ge "15.2.2562.45")
 
             return $result
         }

--- a/Security/src/EOMT/Mitigations/Tests/CVE-2026-42897.Tests.ps1
+++ b/Security/src/EOMT/Mitigations/Tests/CVE-2026-42897.Tests.ps1
@@ -74,7 +74,7 @@ BeforeAll {
 
     # Helper: builds a mock ExSetup FileVersionInfo object
     function Get-MockExSetupInfo {
-        param([string]$Version = "15.2.2562.99")
+        param([string]$Version = "15.2.2562.45")
         return [PSCustomObject]@{
             FileVersion = $Version
         }
@@ -291,7 +291,7 @@ Describe "Testing CVE-2026-42897 TestVulnerable" {
 
         It "Should report CodeFixApplied true when build is at or above threshold" {
             Mock Get-WebConfiguration { return $null }
-            Mock Get-Command { return [PSCustomObject]@{ FileVersionInfo = (Get-MockExSetupInfo -Version "15.2.2562.99") } }
+            Mock Get-Command { return [PSCustomObject]@{ FileVersionInfo = (Get-MockExSetupInfo -Version "15.2.2562.45") } }
 
             $result = & $definition.TestVulnerable
 
@@ -309,7 +309,7 @@ Describe "Testing CVE-2026-42897 TestVulnerable" {
 
         It "Should report CodeFixApplied false when build is below threshold" {
             Mock Get-WebConfiguration { return $null }
-            Mock Get-Command { return [PSCustomObject]@{ FileVersionInfo = (Get-MockExSetupInfo -Version "15.2.2562.98") } }
+            Mock Get-Command { return [PSCustomObject]@{ FileVersionInfo = (Get-MockExSetupInfo -Version "15.2.2562.43") } }
 
             $result = & $definition.TestVulnerable
 


### PR DESCRIPTION
### Summary

Fixes the EOMT `CVE-2026-42897` code-fix detection so servers patched with the July 2026 SU are correctly reported as `Code Fix Applied: True`.

The `CodeFixApplied` check used a pre-release placeholder build (`15.2.2562.99`) that was higher than the actual Exchange Server SE July 2026 SU build (`15.2.2562.45`). As a result, even patched servers were reported as `Code Fix Applied: False`.

### Changes

- `Security/src/EOMT/Mitigations/CVE-2026-42897.ps1` — corrected the threshold from `15.2.2562.99` to `15.2.2562.45`, and added a comment noting that EOMT intentionally tracks this CVE against the July 2026 SU (per the [Released: July 2026 Exchange Server Security Updates](https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146) article), which differs from Exchange Health Checker reporting the code fix against the June 2026 SU.
- `Security/src/EOMT/Mitigations/Tests/CVE-2026-42897.Tests.ps1` — adjusted the code-fix boundary tests to the corrected build number.

### Validation

- Pester: 14/14 passing
- `Invoke-CodeFormatterOnFiles`: no issues
- `SpellCheck.ps1`: 0 issues

### Notes

- Exchange Health Checker was reviewed and requires no changes — it already lists `CVE-2026-42897` under the June 2026 SU for Exchange 2016/2019/SE.

Fixes #2568

This will be fixed and the issue will be automatically closed once this PR is merged.
