### PR TITLE
Add TERRL external recipient estimator

### DIFF
--- a/Transport/Get-TerrlExternalRecipientEstimate.ps1
+++ b/Transport/Get-TerrlExternalRecipientEstimate.ps1
@@ -1,0 +1,911 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# cspell:ignore TERRL Terrl pscustomobject microsoftexchange
+
+<#
+.SYNOPSIS
+    Measure a tenant's Tenant External Recipient Rate Limit (TERRL) consumption over a 24-hour
+    window using Get-MessageTraceV2, and rank the senders/domains contributing most.
+
+.DESCRIPTION
+    The Tenant External Recipient Rate Limit (TERRL) limits how many external recipients an
+    Exchange Online tenant can send to during a rolling 24-hour period. An external recipient is
+    an address whose domain is not an accepted domain in the tenant. The tenant's limit is based
+    on its Exchange Online license count.
+
+    This script uses Get-MessageTraceV2 data to estimate TERRL usage and identify the senders and
+    recipient domains contributing most to it. It can query message trace directly, accept trace
+    rows from the pipeline, or analyze a previously exported CSV.
+
+    Message trace does not contain every property used by TERRL enforcement, so the result is an
+    estimate and may be higher than the live count. Use Get-LimitsEnforcementStatus for the
+    current enforcement status and observed value.
+
+.PARAMETER StartDate
+    Start of the window. Default: EndDate - 24h.
+
+.PARAMETER EndDate
+    End of the window. Default: now (local). Get-MessageTraceV2 filters on Received time.
+
+.PARAMETER AcceptedDomain
+    The tenant's accepted (internal) SMTP domains. A recipient is EXTERNAL when its domain is not
+    in this list. If omitted, the script calls Get-AcceptedDomain from the active EXO session.
+
+.PARAMETER ExcludeNullSender
+    Exclude NDR/DSN/system mail identified by a null/blank ("<>") or postmaster/mailer-daemon
+    sender. Default $true (approximates the MessageIsNdr filter).
+
+.PARAMETER JournalRecipient
+    Additional EXO journal-rule destination addresses. The script also discovers enabled Exchange
+    Online journal rules with Get-JournalRule. A row is classified as an EXO journal report only
+    when the sender matches the tenant's journal-report sender configuration and the recipient is
+    a configured destination.
+    On-premises-generated journal reports are not detectable from EXO journal-rule configuration.
+
+.PARAMETER JournalReportSender
+    Additional EXO journal-report envelope sender addresses. The script normally discovers the
+    sender from Get-TransportConfig.JournalingReportNdrTo. If that setting is empty, it follows
+    Transport behavior and constructs the Microsoft Exchange Recipient address from the fixed
+    MicrosoftExchange329e... local-part and the tenant's default accepted domain.
+
+.PARAMETER PageSize
+    Get-MessageTraceV2 -ResultSize per request. Default and maximum 5000. Use 1 to exercise
+    request pacing.
+
+.PARAMETER TopSenders
+    Number of top contributing senders/domains to return. Default 25.
+
+.PARAMETER CompareToEnforcementStatus
+    Also call Get-LimitsEnforcementStatus and print the live ObservedValue/Threshold next to the
+    script's estimate.
+
+.PARAMETER InputObject
+    Get-MessageTraceV2 rows received from the PowerShell pipeline. When rows are piped in, the
+    script measures only those rows and does not perform its own live trace query.
+
+.PARAMETER MessageTraceCsv
+    Path to a CSV previously exported from a trace run. Bypasses the live call.
+
+.PARAMETER CsvPath
+    Optional path to export the top-sender table.
+
+.PARAMETER DefineFunctionsOnly
+    Load the functions without running the live report (for dot-sourcing in tests).
+
+.EXAMPLE
+    .\Get-TerrlExternalRecipientEstimate.ps1 -AcceptedDomain "contoso.com" -CompareToEnforcementStatus
+
+    Queries the previous 24 hours and compares the estimate with the live enforcement status.
+
+.EXAMPLE
+    .\Get-TerrlExternalRecipientEstimate.ps1 -MessageTraceCsv ".\trace.csv" -AcceptedDomain "contoso.com"
+
+    Analyzes a previously exported message trace without querying message trace.
+
+.EXAMPLE
+    Get-MessageTraceV2 -StartDate (Get-Date).AddHours(-4) -EndDate (Get-Date) -ResultSize 5000 |
+        .\Get-TerrlExternalRecipientEstimate.ps1 -AcceptedDomain "contoso.com"
+
+    Analyzes message trace rows supplied through the pipeline.
+
+.NOTES
+    TERRL overview:
+    https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797
+#>
+[CmdletBinding()]
+[OutputType([pscustomobject])]
+param(
+    [Parameter()]
+    [datetime]$EndDate = (Get-Date),
+
+    [Parameter()]
+    [datetime]$StartDate,
+
+    [Parameter()]
+    [string[]]$AcceptedDomain,
+
+    [Parameter()]
+    [bool]$ExcludeNullSender = $true,
+
+    [Parameter()]
+    [string[]]$JournalRecipient,
+
+    [Parameter()]
+    [string[]]$JournalReportSender,
+
+    [Parameter()]
+    [ValidateRange(1, 5000)]
+    [int]$PageSize = 5000,
+
+    [Parameter()]
+    [ValidateRange(1, 2147483647)]
+    [int]$TopSenders = 25,
+
+    [Parameter()]
+    [switch]$CompareToEnforcementStatus,
+
+    [Parameter(ValueFromPipeline)]
+    [object]$InputObject,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$MessageTraceCsv,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CsvPath,
+
+    [Parameter()]
+    [switch]$DefineFunctionsOnly
+)
+
+begin {
+    $pipelineRows = [System.Collections.Generic.List[object]]::new()
+    $pipelineWasConnected = $MyInvocation.ExpectingInput
+
+    # ==================================================================================================
+    # Pure helpers (testable)
+    # ==================================================================================================
+
+    function Get-TerrlAddressDomain {
+        <# Returns the lower-cased domain of an SMTP address, or $null if unparsable / null sender. #>
+        [OutputType([string])]
+        param([string]$Address)
+        if ([string]::IsNullOrWhiteSpace($Address)) { return $null }
+        $a = $Address.Trim().Trim('<', '>').Trim()
+        if ([string]::IsNullOrWhiteSpace($a)) { return $null }
+        $at = $a.LastIndexOf('@')
+        if ($at -lt 0 -or $at -eq ($a.Length - 1)) { return $null }
+        return $a.Substring($at + 1).Trim().ToLowerInvariant()
+    }
+
+    function ConvertTo-TerrlDomainSet {
+        <# Builds a case-insensitive HashSet of bare domains from a list. #>
+        [OutputType([System.Collections.Generic.HashSet[string]])]
+        param([string[]]$Domain)
+        $set = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($d in $Domain) {
+            if (-not [string]::IsNullOrWhiteSpace($d)) {
+                [void]$set.Add($d.Trim().TrimStart('@').ToLowerInvariant())
+            }
+        }
+        return $set
+    }
+
+    function Test-TerrlInternalRecipientDomain {
+        <# True when the recipient domain is internal (accepted), i.e. NOT counted by TERRL. #>
+        [OutputType([bool])]
+        param(
+            [string]$Domain,
+            [System.Collections.Generic.HashSet[string]]$AcceptedSet
+        )
+        if ([string]::IsNullOrWhiteSpace($Domain)) { return $false }
+        $d = $Domain.Trim().ToLowerInvariant()
+        if ($AcceptedSet -and $AcceptedSet.Contains($d)) { return $true }
+        return $false
+    }
+
+    function Test-TerrlNullSender {
+        [OutputType([bool])]
+        param([string]$SenderAddress)
+        if ([string]::IsNullOrWhiteSpace($SenderAddress)) { return $true }
+        $s = $SenderAddress.Trim()
+        return ($s -eq '<>' -or $s -eq '<' -or $s -eq '>')
+    }
+
+    function Test-TerrlSystemSender {
+        [OutputType([bool])]
+        param([string]$SenderAddress)
+        if ([string]::IsNullOrWhiteSpace($SenderAddress)) { return $false }
+        $s = $SenderAddress.Trim().Trim('<', '>').ToLowerInvariant()
+        if ([string]::IsNullOrWhiteSpace($s)) { return $false }
+        $local = if ($s.Contains('@')) { $s.Substring(0, $s.IndexOf('@')) } else { $s }
+        if ($local -eq 'postmaster' -or $local -eq 'mailer-daemon') { return $true }
+        # Well-known Exchange system mailbox used for system-generated mail.
+        if ($s.StartsWith('microsoftexchange329e71ec88ae4615bbc36ab6ce41109e@')) { return $true }
+        return $false
+    }
+
+    function Test-TerrlExchangeOnlineJournalReport {
+        [OutputType([bool])]
+        param(
+            [string]$SenderAddress,
+            [string]$Recipient,
+            [System.Collections.Generic.HashSet[string]]$JournalSet,
+            [System.Collections.Generic.HashSet[string]]$JournalSenderSet
+        )
+
+        if ($null -eq $JournalSet -or $JournalSet.Count -eq 0 -or
+            $null -eq $JournalSenderSet -or $JournalSenderSet.Count -eq 0) {
+            return $false
+        }
+        if ([string]::IsNullOrWhiteSpace($SenderAddress) -or
+            [string]::IsNullOrWhiteSpace($Recipient)) {
+            return $false
+        }
+
+        $normalizedSender = $SenderAddress.Trim().Trim('<', '>').ToLowerInvariant()
+        $normalizedRecipient = $Recipient.Trim().Trim('<', '>').ToLowerInvariant()
+        $senderLocalPart = if ($normalizedSender.Contains('@')) {
+            $normalizedSender.Substring(0, $normalizedSender.IndexOf('@'))
+        } else {
+            $normalizedSender
+        }
+        $isMicrosoftExchangeRecipient =
+        $senderLocalPart -eq 'microsoftexchange329e71ec88ae4615bbc36ab6ce41109e'
+
+        return (
+            ($JournalSenderSet.Contains($normalizedSender) -or $isMicrosoftExchangeRecipient) -and
+            $JournalSet.Contains($normalizedRecipient)
+        )
+    }
+
+    # ==================================================================================================
+    # Core classifier (PURE -- this is the primary unit-test surface)
+    # ==================================================================================================
+
+    function Measure-TerrlFromTraceRows {
+        <#
+    .SYNOPSIS
+        Classify Get-MessageTraceV2 rows against the TERRL rules and return a structured estimate.
+    .OUTPUTS
+        pscustomobject with ExternalRecipientsCounted, DistinctExternalRecipients,
+        DistinctOutboundMessages, AcceptedRecipientRows, TopSenders, TopRecipientDomains,
+        and Exclusions.
+    #>
+        [CmdletBinding()]
+        [OutputType([pscustomobject])]
+        param(
+            [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Rows,
+            [Parameter(Mandatory)][string[]]$AcceptedDomain,
+            [bool]$ExcludeNullSender = $true,
+            [string[]]$JournalRecipient,
+            [string[]]$JournalReportSender,
+            [int]$TopSenders = 25
+        )
+
+        $acceptedSet = ConvertTo-TerrlDomainSet -Domain $AcceptedDomain
+
+        $journalSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($j in $JournalRecipient) { if ($j) { [void]$journalSet.Add($j.Trim().Trim('<', '>').ToLowerInvariant()) } }
+
+        $journalSenderSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($s in $JournalReportSender) { if ($s) { [void]$journalSenderSet.Add($s.Trim().Trim('<', '>').ToLowerInvariant()) } }
+
+        $countedUnitKeys = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $distinctRecipientSet = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $distinctMessageSet = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $senderMessageSet = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $senderRecipientCounts = [System.Collections.Generic.Dictionary[string, int]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $senderMessageCounts = [System.Collections.Generic.Dictionary[string, int]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $domainCounts = [System.Collections.Generic.Dictionary[string, int]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        $exclusionCounts = [System.Collections.Generic.Dictionary[string, int]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+
+        $total = 0
+        $acceptedRows = 0
+        $exchangeOnlineJournalRows = 0
+
+        # This is the only full pass over the trace rows. Classification, deduplication, and all
+        # report aggregates are updated here to avoid retaining a second classified-row collection.
+        foreach ($r in $Rows) {
+            $senderAddress = [string]$r.SenderAddress
+            $recipient = [string]$r.RecipientAddress
+            $status = [string]$r.Status
+            $recipientDomain = Get-TerrlAddressDomain -Address $recipient
+
+            $reason = 'Counted'
+            if ($null -eq $recipientDomain) {
+                $reason = 'UnparsableRecipient'
+            } elseif (Test-TerrlExchangeOnlineJournalReport `
+                    -SenderAddress $senderAddress `
+                    -Recipient $recipient `
+                    -JournalSet $journalSet `
+                    -JournalSenderSet $journalSenderSet) {
+                $reason = 'ExchangeOnlineJournalReport'            # IsJournal
+            } elseif (Test-TerrlInternalRecipientDomain -Domain $recipientDomain -AcceptedSet $acceptedSet) {
+                $reason = 'InternalRecipient'                      # THE ONE RULE / IsRoutedOnlyToAcceptedDomains
+            } elseif ($status.Trim() -eq 'Expanded') {
+                $reason = 'ExpandedDistributionGroup'              # DL placeholder; members have rows
+            } elseif ($ExcludeNullSender -and (Test-TerrlNullSender -SenderAddress $senderAddress)) {
+                $reason = 'NullSender (NDR/DSN/system)'            # MessageIsNdr
+            } elseif (Test-TerrlSystemSender -SenderAddress $senderAddress) {
+                $reason = 'SystemSender (NDR/DSN)'
+            }
+
+            if ($reason -ne 'Counted') {
+                if ($exclusionCounts.ContainsKey($reason)) {
+                    $exclusionCounts[$reason]++
+                } else {
+                    $exclusionCounts[$reason] = 1
+                }
+
+                if ($reason -eq 'InternalRecipient') {
+                    $acceptedRows++
+                } elseif ($reason -eq 'ExchangeOnlineJournalReport') {
+                    $exchangeOnlineJournalRows++
+                }
+                continue
+            }
+
+            $messageKey = '{0}|{1}' -f [string]$r.MessageTraceId, [string]$r.MessageId
+            $countedUnitKey = '{0}|{1}' -f $messageKey, $recipient
+            if (-not $countedUnitKeys.Add($countedUnitKey)) {
+                continue
+            }
+
+            $total++
+            [void]$distinctRecipientSet.Add($recipient)
+            [void]$distinctMessageSet.Add($messageKey)
+
+            $senderKey = if ([string]::IsNullOrWhiteSpace($senderAddress)) {
+                '(null sender)'
+            } else {
+                $senderAddress.Trim().ToLowerInvariant()
+            }
+            if ($senderRecipientCounts.ContainsKey($senderKey)) {
+                $senderRecipientCounts[$senderKey]++
+            } else {
+                $senderRecipientCounts[$senderKey] = 1
+                $senderMessageCounts[$senderKey] = 0
+            }
+
+            if ($senderMessageSet.Add(('{0}|{1}' -f $senderKey, $messageKey))) {
+                $senderMessageCounts[$senderKey]++
+            }
+
+            if ($domainCounts.ContainsKey($recipientDomain)) {
+                $domainCounts[$recipientDomain]++
+            } else {
+                $domainCounts[$recipientDomain] = 1
+            }
+        }
+
+        $senderRanking = @(
+            foreach ($senderKey in $senderRecipientCounts.Keys) {
+                [pscustomobject]@{
+                    Sender             = $senderKey
+                    ExternalRecipients = $senderRecipientCounts[$senderKey]
+                    Messages           = $senderMessageCounts[$senderKey]
+                    PercentOfTotal     = if ($total -gt 0) {
+                        [math]::Round(100.0 * $senderRecipientCounts[$senderKey] / $total, 1)
+                    } else {
+                        0
+                    }
+                }
+            }
+        ) | Sort-Object ExternalRecipients -Descending | Select-Object -First $TopSenders
+
+        $domainRanking = @(
+            foreach ($domain in $domainCounts.Keys) {
+                [pscustomobject]@{
+                    RecipientDomain    = $domain
+                    ExternalRecipients = $domainCounts[$domain]
+                    PercentOfTotal     = if ($total -gt 0) {
+                        [math]::Round(100.0 * $domainCounts[$domain] / $total, 1)
+                    } else {
+                        0
+                    }
+                }
+            }
+        ) | Sort-Object ExternalRecipients -Descending | Select-Object -First $TopSenders
+
+        $exclusions = @(
+            foreach ($reason in $exclusionCounts.Keys) {
+                [pscustomobject]@{
+                    Reason        = $reason
+                    RecipientRows = $exclusionCounts[$reason]
+                }
+            }
+        ) | Sort-Object RecipientRows -Descending
+
+        [pscustomobject]@{
+            TraceRows                  = $Rows.Count
+            ExternalRecipientsCounted  = $total
+            DistinctExternalRecipients = $distinctRecipientSet.Count
+            DistinctOutboundMessages   = $distinctMessageSet.Count
+            AcceptedRecipientRows      = $acceptedRows
+            ExchangeOnlineJournalRows  = $exchangeOnlineJournalRows
+            JournalRecipients          = @($journalSet)
+            JournalReportSenders       = @($journalSenderSet)
+            TopSenders                 = @($senderRanking)
+            TopRecipientDomains        = @($domainRanking)
+            Exclusions                 = @($exclusions)
+        }
+    }
+
+    # ==================================================================================================
+    # Live fetch: Get-MessageTraceV2 using its documented continuation values
+    # ==================================================================================================
+
+    function Get-TerrlTraceRows {
+        <#
+    .SYNOPSIS
+        Pull all Get-MessageTraceV2 rows for [StartDate,EndDate] using the continuation method
+        documented for Get-MessageTraceV2.
+    .PARAMETER TraceCommand
+        Scriptblock(StartDate,EndDate,PageSize,StartingRecipientAddress) returning rows. Defaults
+        to Get-MessageTraceV2. Injectable so the fetcher can be unit-tested without a live tenant.
+    #>
+        [CmdletBinding()]
+        [OutputType([object[]])]
+        param(
+            [Parameter(Mandatory)][datetime]$StartDate,
+            [Parameter(Mandatory)][datetime]$EndDate,
+            [ValidateRange(1, 5000)]
+            [int]$PageSize = 5000,
+            [ScriptBlock]$TraceCommand
+        )
+
+        if (-not $TraceCommand) {
+            $TraceCommand = {
+                param($s, $e, $size, $startingRecipientAddress)
+                $p = @{ StartDate = $s; EndDate = $e; ResultSize = $size; ErrorAction = 'Stop' }
+                if (-not [string]::IsNullOrWhiteSpace($startingRecipientAddress)) {
+                    $p.StartingRecipientAddress = $startingRecipientAddress
+                }
+                Get-MessageTraceV2 @p -WarningAction SilentlyContinue
+            }
+        }
+
+        $all = [System.Collections.Generic.List[object]]::new()
+        $queryEndDate = $EndDate
+        $startingRecipientAddress = $null
+        $seenCursors = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+
+        while ($true) {
+            Write-Verbose (
+                "Querying {0:u} -> {1:u}; starting recipient '{2}'" -f
+                $StartDate,
+                $queryEndDate,
+                $startingRecipientAddress
+            )
+            $rows = @(
+                & $TraceCommand $StartDate $queryEndDate $PageSize $startingRecipientAddress
+            )
+
+            [void]$all.AddRange([object[]]$rows)
+
+            if ($rows.Count -lt $PageSize) {
+                break
+            }
+
+            $lastRow = $rows[-1]
+            $nextRecipient = [string]$lastRow.RecipientAddress
+            if ([string]::IsNullOrWhiteSpace($nextRecipient) -or $null -eq $lastRow.Received) {
+                throw 'A full message-trace page did not contain the continuation values Received and RecipientAddress.'
+            }
+
+            $nextEndDate = [datetime]$lastRow.Received
+            $cursorKey = '{0:o}|{1}' -f $nextEndDate, $nextRecipient
+            if (-not $seenCursors.Add($cursorKey)) {
+                throw "Get-MessageTraceV2 returned the same continuation cursor more than once: $cursorKey"
+            }
+
+            $queryEndDate = $nextEndDate
+            $startingRecipientAddress = $nextRecipient
+        }
+
+        Write-Verbose ("Fetched {0} rows." -f $all.Count)
+        return $all.ToArray()
+    }
+
+    # ==================================================================================================
+    # Orchestration (only runs when invoked as a script, not when dot-sourced for tests)
+    # ==================================================================================================
+
+    function Invoke-TerrlMeasurement {
+        [CmdletBinding()]
+        param()
+
+        if (-not $StartDate) {
+            $script:StartDate = $EndDate.AddDays(-1)
+        }
+
+        if ($StartDate -ge $EndDate) {
+            throw 'StartDate must be earlier than EndDate.'
+        }
+
+        # The service allows 100 requests per rolling five minutes per tenant. Limit this script
+        # to half of that shared budget, including every request made by the built-in fetcher.
+        $originalGetMessageTraceV2 = Get-Command Get-MessageTraceV2 -ErrorAction SilentlyContinue
+        if ($originalGetMessageTraceV2) {
+            $traceRequestLimit = 50
+            $traceRequestWindow = [TimeSpan]::FromMinutes(5)
+            $traceRequestTimes = [System.Collections.Generic.Queue[DateTime]]::new()
+
+            function Get-MessageTraceV2 {
+                [CmdletBinding()]
+                param(
+                    [Parameter()]
+                    [DateTime]$StartDate,
+
+                    [Parameter()]
+                    [DateTime]$EndDate,
+
+                    [Parameter()]
+                    [string]$FromIP,
+
+                    [Parameter()]
+                    [string[]]$MessageId,
+
+                    [Parameter()]
+                    [guid]$MessageTraceId,
+
+                    [Parameter()]
+                    [string[]]$RecipientAddress,
+
+                    [Parameter()]
+                    [string[]]$SenderAddress,
+
+                    [Parameter()]
+                    [string[]]$Status,
+
+                    [Parameter()]
+                    [string]$Subject,
+
+                    [Parameter()]
+                    [string]$SubjectFilterType,
+
+                    [Parameter()]
+                    [string]$ToIP,
+
+                    [Parameter()]
+                    [ValidateRange(1, 5000)]
+                    [int]$ResultSize,
+
+                    [Parameter()]
+                    [string]$StartingRecipientAddress
+                )
+
+                $now = [DateTime]::UtcNow
+                while ($traceRequestTimes.Count -gt 0 -and
+                    ($now - $traceRequestTimes.Peek()) -ge $traceRequestWindow) {
+                    [void]$traceRequestTimes.Dequeue()
+                }
+
+                if ($traceRequestTimes.Count -ge $traceRequestLimit) {
+                    $oldestRequest = $traceRequestTimes.Peek()
+                    $wait = $traceRequestWindow - ($now - $oldestRequest)
+                    $waitSeconds = [Math]::Max(1, [Math]::Ceiling($wait.TotalSeconds) + 1)
+                    Write-Host (
+                        "Trace request budget reached ($traceRequestLimit requests in five minutes). " +
+                        "Waiting $waitSeconds seconds to preserve half of the tenant limit..."
+                    ) -ForegroundColor Yellow
+                    Start-Sleep -Seconds $waitSeconds
+
+                    $now = [DateTime]::UtcNow
+                    while ($traceRequestTimes.Count -gt 0 -and
+                        ($now - $traceRequestTimes.Peek()) -ge $traceRequestWindow) {
+                        [void]$traceRequestTimes.Dequeue()
+                    }
+                }
+
+                $traceRequestTimes.Enqueue([DateTime]::UtcNow)
+                Write-Verbose (
+                    "Get-MessageTraceV2 request {0}/{1} in the current five-minute window." -f
+                    $traceRequestTimes.Count,
+                    $traceRequestLimit
+                )
+
+                $invokeParameters = @{}
+                foreach ($key in $PSBoundParameters.Keys) {
+                    if ($key -notin @(
+                            'Verbose', 'Debug', 'ErrorAction', 'WarningAction',
+                            'InformationAction', 'ErrorVariable', 'WarningVariable',
+                            'InformationVariable', 'OutVariable', 'OutBuffer',
+                            'PipelineVariable'
+                        )) {
+                        $invokeParameters[$key] = $PSBoundParameters[$key]
+                    }
+                }
+
+                & $originalGetMessageTraceV2 @invokeParameters -ErrorAction Stop
+            }
+        }
+
+        # 1. Acquire rows -------------------------------------------------------------------------------
+        if ($pipelineWasConnected) {
+            Write-Verbose "Using $($pipelineRows.Count) message-trace rows from the pipeline."
+            $rows = $pipelineRows.ToArray()
+        } elseif ($MessageTraceCsv) {
+            if (-not (Test-Path -LiteralPath $MessageTraceCsv -PathType Leaf)) {
+                throw "MessageTraceCsv not found: $MessageTraceCsv"
+            }
+            $rows = @(Import-Csv -LiteralPath $MessageTraceCsv -ErrorAction Stop)
+        } else {
+            if (-not (Get-Command Get-MessageTraceV2 -ErrorAction SilentlyContinue)) {
+                throw "Get-MessageTraceV2 is not available. Connect to Exchange Online, pipe trace rows in, or pass -MessageTraceCsv."
+            }
+            Write-Host (
+                "Fetching message trace {0:u} -> {1:u} (PageSize {2}) ..." -f
+                $StartDate.ToUniversalTime(),
+                $EndDate.ToUniversalTime(),
+                $PageSize
+            ) -ForegroundColor Cyan
+            $rows = @(Get-TerrlTraceRows -StartDate $StartDate -EndDate $EndDate -PageSize $PageSize)
+        }
+
+        $rows = @($rows)
+        if ($rows.Count -eq 0) {
+            Write-Warning (
+                'No message-trace rows were returned for the requested window. ' +
+                'The live TERRL counter can still be nonzero because message trace is delayed ' +
+                'and Get-LimitsEnforcementStatus uses a separate rolling enforcement data source.'
+            )
+
+            if ($CompareToEnforcementStatus -and
+                (Get-Command Get-LimitsEnforcementStatus -ErrorAction SilentlyContinue)) {
+                Write-Host ''
+                Write-Host 'Get-LimitsEnforcementStatus (live ground truth):' -ForegroundColor Cyan
+                Get-LimitsEnforcementStatus -ErrorAction Stop |
+                    Format-List Verdict, EnforcementEnabled, Threshold, ObservedValue |
+                    Out-String |
+                    Write-Host
+            }
+
+            return
+        }
+
+        # 2. Resolve accepted domains -------------------------------------------------------------------
+        $accepted = $AcceptedDomain
+        $acceptedDomainObjects = @()
+        if (-not $accepted) {
+            if (-not (Get-Command Get-AcceptedDomain -ErrorAction SilentlyContinue)) {
+                throw "No -AcceptedDomain supplied and Get-AcceptedDomain is unavailable. Pass -AcceptedDomain."
+            }
+            $acceptedDomainObjects = @(Get-AcceptedDomain -ErrorAction Stop)
+            $accepted = @(
+                $acceptedDomainObjects |
+                    Select-Object -ExpandProperty DomainName |
+                    ForEach-Object { $_.ToString() }
+            )
+        } elseif (Get-Command Get-AcceptedDomain -ErrorAction SilentlyContinue) {
+            try {
+                $acceptedDomainObjects = @(Get-AcceptedDomain -ErrorAction Stop)
+            } catch {
+                Write-Verbose (
+                    'Get-AcceptedDomain could not be queried for journal-sender discovery: ' +
+                    $_.Exception.Message
+                )
+            }
+        }
+
+        $resolvedJournalRecipients = [System.Collections.Generic.List[string]]::new()
+        foreach ($address in $JournalRecipient) {
+            if (-not [string]::IsNullOrWhiteSpace($address)) {
+                [void]$resolvedJournalRecipients.Add($address.Trim().Trim('<', '>'))
+            }
+        }
+
+        if (Get-Command Get-JournalRule -ErrorAction SilentlyContinue) {
+            try {
+                foreach ($rule in @(Get-JournalRule -ErrorAction Stop)) {
+                    $enabledProperty = $rule.PSObject.Properties['Enabled']
+                    if ($enabledProperty) {
+                        try {
+                            if (-not [System.Convert]::ToBoolean($enabledProperty.Value)) {
+                                continue
+                            }
+                        } catch {
+                            Write-Verbose (
+                                "Could not parse Enabled='$($enabledProperty.Value)' for journal " +
+                                "rule '$($rule.Name)'; including its destination."
+                            )
+                        }
+                    }
+
+                    $addressProperty = $rule.PSObject.Properties['JournalEmailAddress']
+                    if ($addressProperty -and
+                        -not [string]::IsNullOrWhiteSpace([string]$addressProperty.Value)) {
+                        [void]$resolvedJournalRecipients.Add(
+                            ([string]$addressProperty.Value).Trim().Trim('<', '>')
+                        )
+                    }
+                }
+            } catch {
+                Write-Verbose (
+                    "Get-JournalRule failed; EXO journal destinations will not be auto-discovered: " +
+                    $_.Exception.Message
+                )
+            }
+        } else {
+            Write-Verbose (
+                'Get-JournalRule is unavailable; EXO journal destinations will not be auto-discovered.'
+            )
+        }
+
+        $resolvedJournalRecipients = @(
+            $resolvedJournalRecipients |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                Sort-Object -Unique
+        )
+        if ($resolvedJournalRecipients.Count -gt 0) {
+            Write-Verbose (
+                'EXO journal destinations: ' + ($resolvedJournalRecipients -join ', ')
+            )
+        }
+
+        $resolvedJournalReportSenders = [System.Collections.Generic.List[string]]::new()
+        foreach ($address in $JournalReportSender) {
+            if (-not [string]::IsNullOrWhiteSpace($address)) {
+                [void]$resolvedJournalReportSenders.Add($address.Trim().Trim('<', '>'))
+            }
+        }
+
+        if (Get-Command Get-TransportConfig -ErrorAction SilentlyContinue) {
+            try {
+                $transportConfig = Get-TransportConfig -ErrorAction Stop
+                $ndrProperty = $transportConfig.PSObject.Properties['JournalingReportNdrTo']
+                if ($ndrProperty) {
+                    $ndrAddress = ([string]$ndrProperty.Value).Trim().Trim('<', '>')
+                    if (-not [string]::IsNullOrWhiteSpace($ndrAddress) -and
+                        $ndrAddress.Contains('@')) {
+                        [void]$resolvedJournalReportSenders.Add($ndrAddress)
+                    }
+                }
+            } catch {
+                Write-Verbose (
+                    'Get-TransportConfig failed; the configured journal-report sender could not ' +
+                    'be discovered: ' + $_.Exception.Message
+                )
+            }
+        } else {
+            Write-Verbose (
+                'Get-TransportConfig is unavailable; the configured journal-report sender could ' +
+                'not be discovered.'
+            )
+        }
+
+        $defaultAcceptedDomain = $null
+        foreach ($domainObject in $acceptedDomainObjects) {
+            $defaultProperty = $domainObject.PSObject.Properties['Default']
+            if ($defaultProperty) {
+                try {
+                    if ([System.Convert]::ToBoolean($defaultProperty.Value)) {
+                        $defaultAcceptedDomain = [string]$domainObject.DomainName
+                        break
+                    }
+                } catch {
+                    Write-Verbose (
+                        "Could not parse Default='$($defaultProperty.Value)' for accepted " +
+                        "domain '$($domainObject.DomainName)'."
+                    )
+                }
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($defaultAcceptedDomain)) {
+            $defaultAcceptedDomain = @(
+                $accepted |
+                    Where-Object {
+                        $_ -like '*.onmicrosoft.com' -and
+                        $_ -notlike '*.mail.onmicrosoft.com'
+                    }
+                ) | Select-Object -First 1
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($defaultAcceptedDomain)) {
+                [void]$resolvedJournalReportSenders.Add(
+                    'MicrosoftExchange329e71ec88ae4615bbc36ab6ce41109e@{0}' -f
+                    $defaultAcceptedDomain
+                )
+            } else {
+                Write-Verbose (
+                    'The tenant default accepted domain could not be determined, so the fallback ' +
+                    'Microsoft Exchange Recipient journal sender was not constructed.'
+                )
+            }
+
+            $resolvedJournalReportSenders = @(
+                $resolvedJournalReportSenders |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                    Sort-Object -Unique
+        )
+        if ($resolvedJournalReportSenders.Count -gt 0) {
+            Write-Verbose (
+                'EXO journal-report senders: ' + ($resolvedJournalReportSenders -join ', ')
+            )
+        }
+
+        # 3. Classify -----------------------------------------------------------------------------------
+        $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain $accepted `
+            -ExcludeNullSender $ExcludeNullSender `
+            -JournalRecipient $resolvedJournalRecipients `
+            -JournalReportSender $resolvedJournalReportSenders `
+            -TopSenders $TopSenders
+
+        # 4. Report -------------------------------------------------------------------------------------
+        $acceptedSet = ConvertTo-TerrlDomainSet -Domain $accepted
+        Write-Host ''
+        Write-Host '==================== TERRL external-recipient estimate (Get-MessageTraceV2) ====================' -ForegroundColor Green
+        Write-Host (
+            "Window               : {0:u}  ->  {1:u}" -f
+            $StartDate.ToUniversalTime(),
+            $EndDate.ToUniversalTime()
+        )
+        Write-Host ("Accepted domains     : {0}" -f (($acceptedSet | Select-Object -First 8) -join ', '))
+        Write-Host ("Journal destinations : {0}" -f $(if ($result.JournalRecipients.Count) { $result.JournalRecipients -join ', ' } else { '(none discovered)' }))
+        Write-Host ("Journal senders      : {0}" -f $(if ($result.JournalReportSenders.Count) { $result.JournalReportSenders -join ', ' } else { '(none discovered)' }))
+        Write-Host ("Trace rows evaluated : {0}" -f $result.TraceRows)
+        Write-Host ''
+        Write-Host ("External recipients counted toward limit : {0}" -f $result.ExternalRecipientsCounted) -ForegroundColor Yellow
+        Write-Host ("  distinct external recipients           : {0}" -f $result.DistinctExternalRecipients)
+        Write-Host ("  distinct outbound messages (>=1 ext)   : {0}" -f $result.DistinctOutboundMessages)
+        Write-Host ("  internal-recipient rows (not counted)  : {0}" -f $result.AcceptedRecipientRows)
+        Write-Host ("  EXO journal-report rows (not counted)  : {0}" -f $result.ExchangeOnlineJournalRows)
+        Write-Host ''
+        Write-Host 'Excluded (not counted) by reason:' -ForegroundColor Cyan
+        $result.Exclusions | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Host ("Top {0} senders contributing to the limit:" -f $TopSenders) -ForegroundColor Cyan
+        $result.TopSenders | Format-Table Sender, ExternalRecipients, Messages, PercentOfTotal -AutoSize | Out-String | Write-Host
+        Write-Host ("Top {0} external recipient domains:" -f $TopSenders) -ForegroundColor Cyan
+        $result.TopRecipientDomains | Format-Table RecipientDomain, ExternalRecipients, PercentOfTotal -AutoSize | Out-String | Write-Host
+
+        Write-Host 'NOTE: this is an APPROXIMATION and can run HIGH of the live counter. It detects EXO' -ForegroundColor DarkGray
+        Write-Host '      journal reports from journal-rule destinations, but not on-prem journal reports,' -ForegroundColor DarkGray
+        Write-Host '      cannot identify OOF, and only approximates NDRs from sender information.' -ForegroundColor DarkGray
+        Write-Host '      Use Get-LimitsEnforcementStatus' -ForegroundColor DarkGray
+        Write-Host '      for the exact live ObservedValue.' -ForegroundColor DarkGray
+
+        # 5. Optional reconciliation with the live counter ---------------------------------------------
+        if ($CompareToEnforcementStatus) {
+            if (Get-Command Get-LimitsEnforcementStatus -ErrorAction SilentlyContinue) {
+                try {
+                    $les = Get-LimitsEnforcementStatus -ErrorAction Stop
+                    Write-Host ''
+                    Write-Host 'Get-LimitsEnforcementStatus (live ground truth):' -ForegroundColor Cyan
+                    $les | Format-List Verdict, EnforcementEnabled, Threshold, ObservedValue | Out-String | Write-Host
+                    if ($null -ne $les.ObservedValue) {
+                        $delta = $result.ExternalRecipientsCounted - [double]$les.ObservedValue
+                        Write-Host ("Script estimate {0} vs live ObservedValue {1} (delta {2:+0;-0;0})." -f `
+                                $result.ExternalRecipientsCounted, $les.ObservedValue, $delta) -ForegroundColor Yellow
+                    }
+                } catch {
+                    Write-Warning "Get-LimitsEnforcementStatus failed: $($_.Exception.Message)"
+                }
+            } else {
+                Write-Warning 'Get-LimitsEnforcementStatus is not available in this session.'
+            }
+        }
+
+        if ($CsvPath) {
+            $result.TopSenders |
+                Export-Csv -LiteralPath $CsvPath -NoTypeInformation -Encoding UTF8 -ErrorAction Stop
+            Write-Host "Top-sender table exported to $CsvPath" -ForegroundColor DarkGray
+        }
+
+        return $result
+    }
+}
+
+process {
+    if ($null -ne $InputObject) {
+        [void]$pipelineRows.Add($InputObject)
+    }
+}
+
+end {
+    # Run the live report only when invoked as a script (skip when dot-sourced for tests).
+    if (-not $DefineFunctionsOnly -and $MyInvocation.InvocationName -ne '.') {
+        Invoke-TerrlMeasurement
+    }
+}

--- a/Transport/Get-TerrlExternalRecipientEstimate.ps1
+++ b/Transport/Get-TerrlExternalRecipientEstimate.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# cspell:ignore TERRL Terrl pscustomobject microsoftexchange
+# cspell:ignore TERRL Terrl
 
 <#
 .SYNOPSIS
@@ -94,7 +94,7 @@
     https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797
 #>
 [CmdletBinding()]
-[OutputType([pscustomobject])]
+[OutputType([PSCustomObject])]
 param(
     [Parameter()]
     [datetime]$EndDate = (Get-Date),
@@ -141,6 +141,11 @@ param(
 )
 
 begin {
+    $BuildVersion = ""
+    if ([string]::IsNullOrWhiteSpace($BuildVersion)) {
+        $BuildVersion = 'Development'
+    }
+
     $pipelineRows = [System.Collections.Generic.List[object]]::new()
     $pipelineWasConnected = $MyInvocation.ExpectingInput
 
@@ -198,12 +203,20 @@ begin {
         [OutputType([bool])]
         param([string]$SenderAddress)
         if ([string]::IsNullOrWhiteSpace($SenderAddress)) { return $false }
-        $s = $SenderAddress.Trim().Trim('<', '>').ToLowerInvariant()
+        $s = $SenderAddress.Trim().Trim('<', '>')
         if ([string]::IsNullOrWhiteSpace($s)) { return $false }
         $local = if ($s.Contains('@')) { $s.Substring(0, $s.IndexOf('@')) } else { $s }
-        if ($local -eq 'postmaster' -or $local -eq 'mailer-daemon') { return $true }
+        if ($local.Equals('postmaster', [System.StringComparison]::OrdinalIgnoreCase) -or
+            $local.Equals('mailer-daemon', [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
         # Well-known Exchange system mailbox used for system-generated mail.
-        if ($s.StartsWith('microsoftexchange329e71ec88ae4615bbc36ab6ce41109e@')) { return $true }
+        if ($s.StartsWith(
+                'MicrosoftExchange329e71ec88ae4615bbc36ab6ce41109e@',
+                [System.StringComparison]::OrdinalIgnoreCase
+            )) {
+            return $true
+        }
         return $false
     }
 
@@ -232,8 +245,10 @@ begin {
         } else {
             $normalizedSender
         }
-        $isMicrosoftExchangeRecipient =
-        $senderLocalPart -eq 'microsoftexchange329e71ec88ae4615bbc36ab6ce41109e'
+        $isMicrosoftExchangeRecipient = $senderLocalPart.Equals(
+            'MicrosoftExchange329e71ec88ae4615bbc36ab6ce41109e',
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
 
         return (
             ($JournalSenderSet.Contains($normalizedSender) -or $isMicrosoftExchangeRecipient) -and
@@ -250,12 +265,12 @@ begin {
     .SYNOPSIS
         Classify Get-MessageTraceV2 rows against the TERRL rules and return a structured estimate.
     .OUTPUTS
-        pscustomobject with ExternalRecipientsCounted, DistinctExternalRecipients,
+        PSCustomObject with ExternalRecipientsCounted, DistinctExternalRecipients,
         DistinctOutboundMessages, AcceptedRecipientRows, TopSenders, TopRecipientDomains,
         and Exclusions.
     #>
         [CmdletBinding()]
-        [OutputType([pscustomobject])]
+        [OutputType([PSCustomObject])]
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Rows,
             [Parameter(Mandatory)][string[]]$AcceptedDomain,
@@ -379,7 +394,7 @@ begin {
 
         $senderRanking = @(
             foreach ($senderKey in $senderRecipientCounts.Keys) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     Sender             = $senderKey
                     ExternalRecipients = $senderRecipientCounts[$senderKey]
                     Messages           = $senderMessageCounts[$senderKey]
@@ -394,7 +409,7 @@ begin {
 
         $domainRanking = @(
             foreach ($domain in $domainCounts.Keys) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     RecipientDomain    = $domain
                     ExternalRecipients = $domainCounts[$domain]
                     PercentOfTotal     = if ($total -gt 0) {
@@ -408,14 +423,14 @@ begin {
 
         $exclusions = @(
             foreach ($reason in $exclusionCounts.Keys) {
-                [pscustomobject]@{
+                [PSCustomObject]@{
                     Reason        = $reason
                     RecipientRows = $exclusionCounts[$reason]
                 }
             }
         ) | Sort-Object RecipientRows -Descending
 
-        [pscustomobject]@{
+        [PSCustomObject]@{
             TraceRows                  = $Rows.Count
             ExternalRecipientsCounted  = $total
             DistinctExternalRecipients = $distinctRecipientSet.Count
@@ -832,6 +847,7 @@ begin {
             -JournalRecipient $resolvedJournalRecipients `
             -JournalReportSender $resolvedJournalReportSenders `
             -TopSenders $TopSenders
+        $result | Add-Member -MemberType NoteProperty -Name ScriptVersion -Value $BuildVersion
 
         # 4. Report -------------------------------------------------------------------------------------
         $acceptedSet = ConvertTo-TerrlDomainSet -Domain $accepted
@@ -842,6 +858,7 @@ begin {
             $StartDate.ToUniversalTime(),
             $EndDate.ToUniversalTime()
         )
+        Write-Host ("Script version       : {0}" -f $BuildVersion)
         Write-Host ("Accepted domains     : {0}" -f (($acceptedSet | Select-Object -First 8) -join ', '))
         Write-Host ("Journal destinations : {0}" -f $(if ($result.JournalRecipients.Count) { $result.JournalRecipients -join ', ' } else { '(none discovered)' }))
         Write-Host ("Journal senders      : {0}" -f $(if ($result.JournalReportSenders.Count) { $result.JournalReportSenders -join ', ' } else { '(none discovered)' }))

--- a/Transport/Tests/Get-TerrlExternalRecipientEstimate.Tests.ps1
+++ b/Transport/Tests/Get-TerrlExternalRecipientEstimate.Tests.ps1
@@ -1,0 +1,260 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# cspell:ignore Terrl pscustomobject
+
+[CmdletBinding()]
+param()
+
+BeforeAll {
+    $Script:parentPath = (Split-Path -Parent $PSScriptRoot)
+    . $Script:parentPath\Get-TerrlExternalRecipientEstimate.ps1 -DefineFunctionsOnly
+
+    function Get-TerrlTraceRow {
+        param(
+            [string]$MessageTraceId,
+            [string]$MessageId,
+            [AllowNull()]
+            [string]$SenderAddress,
+            [string]$RecipientAddress,
+            [string]$Status = 'Delivered',
+            [datetime]$Received = [datetime]'2026-08-05T12:00:00Z'
+        )
+
+        [pscustomobject]@{
+            MessageTraceId   = $MessageTraceId
+            MessageId        = $MessageId
+            SenderAddress    = $SenderAddress
+            RecipientAddress = $RecipientAddress
+            Status           = $Status
+            Received         = $Received
+        }
+    }
+}
+
+Describe 'Get-TerrlExternalRecipientEstimate' {
+    Context 'Measure-TerrlFromTraceRows classification' {
+        It 'excludes accepted-domain recipients and counts external rows' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'user@contoso.com'
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'user@example.net'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain @(
+                ' CONTOSO.COM '
+                '@tenant.onmicrosoft.com'
+            )
+
+            $result.TraceRows | Should -Be 2
+            $result.ExternalRecipientsCounted | Should -Be 1
+            $result.AcceptedRecipientRows | Should -Be 1
+            $result.DistinctExternalRecipients | Should -Be 1
+            $result.DistinctOutboundMessages | Should -Be 1
+        }
+
+        It 'deduplicates each message-recipient pair case-insensitively' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'User@Example.net'
+                Get-TerrlTraceRow -MessageTraceId 'TRACE-1' -MessageId 'MESSAGE-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'user@example.NET'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com'
+
+            $result.ExternalRecipientsCounted | Should -Be 1
+            $result.DistinctExternalRecipients | Should -Be 1
+            $result.DistinctOutboundMessages | Should -Be 1
+        }
+
+        It 'counts repeat messages to the same external recipient separately' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'user@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'user@example.net'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com'
+
+            $result.ExternalRecipientsCounted | Should -Be 2
+            $result.DistinctExternalRecipients | Should -Be 1
+            $result.DistinctOutboundMessages | Should -Be 2
+        }
+
+        It 'excludes expanded distribution-group placeholder rows' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'group@example.net' `
+                    -Status ' Expanded '
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'member@example.net'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com'
+
+            $result.ExternalRecipientsCounted | Should -Be 1
+            ($result.Exclusions | Where-Object Reason -EQ 'ExpandedDistributionGroup').RecipientRows |
+                Should -Be 1
+        }
+
+        It 'excludes null and built-in system senders' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress '<>' -RecipientAddress 'one@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                    -SenderAddress 'Postmaster@contoso.com' -RecipientAddress 'two@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-3' -MessageId 'message-3' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'three@example.net'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com' `
+                -ExcludeNullSender $true
+
+            $result.ExternalRecipientsCounted | Should -Be 1
+            ($result.Exclusions | Where-Object Reason -EQ 'NullSender (NDR/DSN/system)').RecipientRows |
+                Should -Be 1
+            ($result.Exclusions | Where-Object Reason -EQ 'SystemSender (NDR/DSN)').RecipientRows |
+                Should -Be 1
+        }
+
+        It 'counts a null sender when null-sender exclusion is disabled' {
+            $row = Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                -SenderAddress $null -RecipientAddress 'user@example.net'
+
+            $result = Measure-TerrlFromTraceRows -Rows @($row) -AcceptedDomain 'contoso.com' `
+                -ExcludeNullSender $false
+
+            $result.ExternalRecipientsCounted | Should -Be 1
+            $result.TopSenders[0].Sender | Should -Be '(null sender)'
+        }
+
+        It 'excludes an EXO journal row only when sender and journal destination match' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress '<JournalSender@contoso.com>' `
+                    -RecipientAddress '<Archive@journal.example>'
+                Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                    -SenderAddress 'journalsender@contoso.com' `
+                    -RecipientAddress 'other@journal.example'
+                Get-TerrlTraceRow -MessageTraceId 'trace-3' -MessageId 'message-3' `
+                    -SenderAddress 'other@contoso.com' `
+                    -RecipientAddress 'archive@journal.example'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com' `
+                -JournalRecipient 'archive@journal.example' `
+                -JournalReportSender 'journalsender@contoso.com'
+
+            $result.ExternalRecipientsCounted | Should -Be 2
+            $result.ExchangeOnlineJournalRows | Should -Be 1
+            ($result.Exclusions | Where-Object Reason -EQ 'ExchangeOnlineJournalReport').RecipientRows |
+                Should -Be 1
+        }
+
+        It 'returns normalized top sender and recipient-domain aggregates' {
+            $rows = @(
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'SenderA@Contoso.com' -RecipientAddress 'one@Example.NET'
+                Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                    -SenderAddress 'SenderA@Contoso.com' -RecipientAddress 'two@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                    -SenderAddress 'senderb@contoso.com' -RecipientAddress 'three@Other.org'
+            )
+
+            $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com'
+
+            $result.TopSenders[0].Sender | Should -Be 'sendera@contoso.com'
+            $result.TopSenders[0].ExternalRecipients | Should -Be 2
+            $result.TopSenders[0].Messages | Should -Be 1
+            $result.TopSenders[0].PercentOfTotal | Should -Be 66.7
+            $result.TopRecipientDomains[0].RecipientDomain | Should -Be 'example.net'
+            $result.TopRecipientDomains[0].ExternalRecipients | Should -Be 2
+            $result.TopRecipientDomains[0].PercentOfTotal | Should -Be 66.7
+        }
+    }
+
+    Context 'Get-TerrlAddressDomain parsing' {
+        It 'normalizes valid addresses and rejects unparsable addresses' {
+            Get-TerrlAddressDomain -Address ' <User@EXAMPLE.NET> ' | Should -Be 'example.net'
+            Get-TerrlAddressDomain -Address 'alias@route@Example.ORG' | Should -Be 'example.org'
+            Get-TerrlAddressDomain -Address $null | Should -BeNullOrEmpty
+            Get-TerrlAddressDomain -Address '<>' | Should -BeNullOrEmpty
+            Get-TerrlAddressDomain -Address 'missing-at-sign' | Should -BeNullOrEmpty
+            Get-TerrlAddressDomain -Address 'user@' | Should -BeNullOrEmpty
+            Get-TerrlAddressDomain -Address 'user@   ' | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Get-TerrlTraceRows continuation' {
+        It 'uses the final row continuation values until a short page is returned' {
+            $Script:traceCalls = [System.Collections.Generic.List[object]]::new()
+            $firstReceived = [datetime]'2026-08-05T11:00:00Z'
+            $traceCommand = {
+                param($startDate, $endDate, $pageSize, $startingRecipientAddress)
+
+                $Script:traceCalls.Add([pscustomobject]@{
+                        StartDate                = $startDate
+                        EndDate                  = $endDate
+                        PageSize                 = $pageSize
+                        StartingRecipientAddress = $startingRecipientAddress
+                    })
+
+                if ($Script:traceCalls.Count -eq 1) {
+                    return @(
+                        Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                            -SenderAddress 'sender@contoso.com' -RecipientAddress 'one@example.net' `
+                            -Received ([datetime]'2026-08-05T11:30:00Z')
+                        Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                            -SenderAddress 'sender@contoso.com' -RecipientAddress 'two@example.net' `
+                            -Received $firstReceived
+                    )
+                }
+
+                return @(
+                    Get-TerrlTraceRow -MessageTraceId 'trace-3' -MessageId 'message-3' `
+                        -SenderAddress 'sender@contoso.com' -RecipientAddress 'three@example.net' `
+                        -Received ([datetime]'2026-08-05T10:30:00Z')
+                )
+            }
+
+            $startDate = [datetime]'2026-08-05T10:00:00Z'
+            $endDate = [datetime]'2026-08-05T12:00:00Z'
+            $result = Get-TerrlTraceRows -StartDate $startDate -EndDate $endDate -PageSize 2 `
+                -TraceCommand $traceCommand
+
+            $result.Count | Should -Be 3
+            $Script:traceCalls.Count | Should -Be 2
+            $Script:traceCalls[0].StartDate | Should -Be $startDate
+            $Script:traceCalls[0].EndDate | Should -Be $endDate
+            $Script:traceCalls[0].PageSize | Should -Be 2
+            $Script:traceCalls[0].StartingRecipientAddress | Should -BeNullOrEmpty
+            $Script:traceCalls[1].EndDate | Should -Be $firstReceived
+            $Script:traceCalls[1].StartingRecipientAddress | Should -Be 'two@example.net'
+        }
+
+        It 'throws instead of looping when the continuation cursor repeats' {
+            $received = [datetime]'2026-08-05T11:00:00Z'
+            $traceCommand = {
+                param($startDate, $endDate, $pageSize, $startingRecipientAddress)
+
+                return @(
+                    Get-TerrlTraceRow -MessageTraceId 'trace-1' -MessageId 'message-1' `
+                        -SenderAddress 'sender@contoso.com' -RecipientAddress 'one@example.net' `
+                        -Received ([datetime]'2026-08-05T11:30:00Z')
+                    Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
+                        -SenderAddress 'sender@contoso.com' -RecipientAddress 'two@example.net' `
+                        -Received $received
+                )
+            }
+
+            {
+                Get-TerrlTraceRows -StartDate ([datetime]'2026-08-05T10:00:00Z') `
+                    -EndDate ([datetime]'2026-08-05T12:00:00Z') -PageSize 2 `
+                    -TraceCommand $traceCommand
+            } | Should -Throw '*same continuation cursor more than once*'
+        }
+    }
+}

--- a/Transport/Tests/Get-TerrlExternalRecipientEstimate.Tests.ps1
+++ b/Transport/Tests/Get-TerrlExternalRecipientEstimate.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# cspell:ignore Terrl pscustomobject
+# cspell:ignore Terrl
 
 [CmdletBinding()]
 param()
@@ -21,7 +21,7 @@ BeforeAll {
             [datetime]$Received = [datetime]'2026-08-05T12:00:00Z'
         )
 
-        [pscustomobject]@{
+        [PSCustomObject]@{
             MessageTraceId   = $MessageTraceId
             MessageId        = $MessageId
             SenderAddress    = $SenderAddress
@@ -107,7 +107,13 @@ Describe 'Get-TerrlExternalRecipientEstimate' {
                 Get-TerrlTraceRow -MessageTraceId 'trace-2' -MessageId 'message-2' `
                     -SenderAddress 'Postmaster@contoso.com' -RecipientAddress 'two@example.net'
                 Get-TerrlTraceRow -MessageTraceId 'trace-3' -MessageId 'message-3' `
-                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'three@example.net'
+                    -SenderAddress 'MicrosoftExchange329e71ec88ae4615bbc36ab6ce41109e@contoso.com' `
+                    -RecipientAddress 'three@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-4' -MessageId 'message-4' `
+                    -SenderAddress 'microsoftexchange329e71ec88ae4615bbc36ab6ce41109e@contoso.com' `
+                    -RecipientAddress 'four@example.net'
+                Get-TerrlTraceRow -MessageTraceId 'trace-5' -MessageId 'message-5' `
+                    -SenderAddress 'sender@contoso.com' -RecipientAddress 'five@example.net'
             )
 
             $result = Measure-TerrlFromTraceRows -Rows $rows -AcceptedDomain 'contoso.com' `
@@ -117,7 +123,7 @@ Describe 'Get-TerrlExternalRecipientEstimate' {
             ($result.Exclusions | Where-Object Reason -EQ 'NullSender (NDR/DSN/system)').RecipientRows |
                 Should -Be 1
             ($result.Exclusions | Where-Object Reason -EQ 'SystemSender (NDR/DSN)').RecipientRows |
-                Should -Be 1
+                Should -Be 3
         }
 
         It 'counts a null sender when null-sender exclusion is disabled' {
@@ -195,7 +201,7 @@ Describe 'Get-TerrlExternalRecipientEstimate' {
             $traceCommand = {
                 param($startDate, $endDate, $pageSize, $startingRecipientAddress)
 
-                $Script:traceCalls.Add([pscustomobject]@{
+                $Script:traceCalls.Add([PSCustomObject]@{
                         StartDate                = $startDate
                         EndDate                  = $endDate
                         PageSize                 = $pageSize

--- a/docs/Transport/Get-TerrlExternalRecipientEstimate.md
+++ b/docs/Transport/Get-TerrlExternalRecipientEstimate.md
@@ -1,0 +1,145 @@
+# Get-TerrlExternalRecipientEstimate
+
+<!-- cspell:ignore TERRL Terrl -->
+
+Download the latest release: [Get-TerrlExternalRecipientEstimate.ps1](https://github.com/microsoft/CSS-Exchange/releases/latest/download/Get-TerrlExternalRecipientEstimate.ps1)
+
+This script estimates Tenant External Recipient Rate Limit (TERRL) consumption from `Get-MessageTraceV2` data and identifies the senders and recipient domains contributing most to that estimate.
+
+TERRL counts outbound recipients whose domain is not an accepted domain in the tenant. The count is per message-recipient pair, not per unique recipient. The script can query message trace directly, analyze an exported CSV, or accept message trace rows from the pipeline.
+
+## Limitations
+
+The result is an **estimate**, not the live TERRL counter. Message trace does not expose every property used by TERRL enforcement. The script detects Exchange Online journal reports when it can discover the journal configuration, excludes expanded distribution-group placeholder rows, and approximates NDR/DSN exclusions from sender information. It cannot reliably identify every excluded message type, including automatic replies or on-premises-generated journal reports, so its estimate can be higher than the live count.
+
+`Get-LimitsEnforcementStatus` is the live ground truth for the tenant's current `ObservedValue`, `Threshold`, `Verdict`, and `EnforcementEnabled` state. Use `-CompareToEnforcementStatus` to display those values beside the estimate.
+
+Message trace data can also be delayed. A zero or lower estimate does not prove that the live rolling 24-hour counter is zero or below its threshold.
+
+## Prerequisites
+
+- Windows PowerShell or PowerShell.
+- For a live query:
+    - The Exchange Online PowerShell module.
+    - An active Exchange Online PowerShell session.
+    - Permissions to run `Get-MessageTraceV2` and `Get-AcceptedDomain`.
+- To compare with enforcement, permission to run `Get-LimitsEnforcementStatus`.
+- For automatic journal-report discovery, permission to run `Get-JournalRule` and `Get-TransportConfig`.
+- For offline or pipeline analysis without `Get-AcceptedDomain`, provide `-AcceptedDomain`.
+
+The built-in live fetch uses no more than 50 `Get-MessageTraceV2` requests in a rolling five-minute period so that it consumes no more than half of the tenant's shared 100-request limit.
+
+## Parameters
+
+### `-StartDate`
+
+Start of the analysis window. The default is 24 hours before `EndDate`.
+
+### `-EndDate`
+
+End of the analysis window. The default is the current time.
+
+### `-AcceptedDomain`
+
+One or more accepted SMTP domains for the tenant. Recipients on these domains are internal and are not included in the TERRL estimate. If omitted, the script queries `Get-AcceptedDomain`.
+
+### `-ExcludeNullSender`
+
+Controls whether null senders are excluded as an approximation for NDR, DSN, and system traffic. The default is `$true`.
+
+### `-JournalRecipient`
+
+Additional Exchange Online journal-rule destination addresses to exclude. The script also attempts to discover destinations from enabled journal rules.
+
+### `-JournalReportSender`
+
+Additional Exchange Online journal-report envelope sender addresses. The script normally discovers or constructs the tenant's Microsoft Exchange Recipient address.
+
+### `-PageSize`
+
+Number of message trace rows requested per call. The valid range is 1 through 5000, and the default is 5000.
+
+### `-TopSenders`
+
+Maximum number of senders and external recipient domains returned in each ranking. The default is 25.
+
+### `-CompareToEnforcementStatus`
+
+Queries `Get-LimitsEnforcementStatus` and displays the live enforcement values beside the estimate.
+
+### `-InputObject`
+
+Message trace rows received from the PowerShell pipeline. When pipeline input is present, the script does not run its own message trace query.
+
+### `-MessageTraceCsv`
+
+Path to a CSV containing previously exported message trace rows. This bypasses the live message trace query.
+
+### `-CsvPath`
+
+Optional path for exporting the top-sender ranking as CSV.
+
+## Output
+
+The script writes a summary to the host and returns an object with these principal properties:
+
+- `TraceRows`: Number of message trace rows evaluated.
+- `ExternalRecipientsCounted`: Estimated count of external message-recipient pairs.
+- `DistinctExternalRecipients`: Number of distinct external recipient addresses.
+- `DistinctOutboundMessages`: Number of distinct messages with at least one counted external recipient.
+- `AcceptedRecipientRows`: Rows excluded because the recipient domain is accepted.
+- `ExchangeOnlineJournalRows`: Rows identified and excluded as Exchange Online journal reports.
+- `TopSenders`: Sender ranking with estimated external recipients, distinct messages, and percentage of the estimate.
+- `TopRecipientDomains`: External recipient-domain ranking.
+- `Exclusions`: Counts grouped by exclusion reason.
+
+When `-CsvPath` is specified, only the `TopSenders` table is exported.
+
+## Examples
+
+### Live query
+
+Connect to Exchange Online, then estimate the previous 24 hours. Accepted domains and Exchange Online journal settings are discovered automatically.
+
+```powershell
+Connect-ExchangeOnline
+.\Get-TerrlExternalRecipientEstimate.ps1
+```
+
+### Compare the estimate with live enforcement
+
+```powershell
+.\Get-TerrlExternalRecipientEstimate.ps1 -CompareToEnforcementStatus
+```
+
+The estimate helps attribute volume. The `Get-LimitsEnforcementStatus` values remain authoritative for the current live TERRL state.
+
+### Analyze an offline CSV
+
+```powershell
+.\Get-TerrlExternalRecipientEstimate.ps1 `
+    -MessageTraceCsv ".\MessageTrace.csv" `
+    -AcceptedDomain "contoso.com", "contoso.onmicrosoft.com"
+```
+
+### Analyze pipeline input
+
+```powershell
+Get-MessageTraceV2 `
+    -StartDate (Get-Date).AddHours(-4) `
+    -EndDate (Get-Date) `
+    -ResultSize 5000 |
+    .\Get-TerrlExternalRecipientEstimate.ps1 `
+        -AcceptedDomain "contoso.com", "contoso.onmicrosoft.com"
+```
+
+### Export the top-sender ranking
+
+```powershell
+$result = .\Get-TerrlExternalRecipientEstimate.ps1 `
+    -AcceptedDomain "contoso.com", "contoso.onmicrosoft.com" `
+    -CsvPath ".\TerrlTopSenders.csv"
+
+$result.TopRecipientDomains |
+    Export-Csv -LiteralPath ".\TerrlTopRecipientDomains.csv" -NoTypeInformation
+```

--- a/docs/Transport/Get-TerrlExternalRecipientEstimate.md
+++ b/docs/Transport/Get-TerrlExternalRecipientEstimate.md
@@ -14,7 +14,7 @@ The result is an **estimate**, not the live TERRL counter. Message trace does no
 
 `Get-LimitsEnforcementStatus` is the live ground truth for the tenant's current `ObservedValue`, `Threshold`, `Verdict`, and `EnforcementEnabled` state. Use `-CompareToEnforcementStatus` to display those values beside the estimate.
 
-Message trace data can also be delayed. A zero or lower estimate does not prove that the live rolling 24-hour counter is zero or below its threshold.
+Message trace data can also be delayed. A zero or low estimate does not prove that the live rolling 24-hour counter is zero or below its threshold.
 
 ## Prerequisites
 

--- a/docs/Transport/Get-TerrlExternalRecipientEstimate.md
+++ b/docs/Transport/Get-TerrlExternalRecipientEstimate.md
@@ -83,6 +83,7 @@ Optional path for exporting the top-sender ranking as CSV.
 
 The script writes a summary to the host and returns an object with these principal properties:
 
+- `ScriptVersion`: Build-stamped script version.
 - `TraceRows`: Number of message trace rows evaluated.
 - `ExternalRecipientsCounted`: Estimated count of external message-recipient pairs.
 - `DistinctExternalRecipients`: Number of distinct external recipient addresses.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
   - Transport:
     - Compute-TopExoRecipientsFromMessageTrace: Transport/Compute-TopExoRecipientsFromMessageTrace.md
     - Get-AllMessageTraceResults: Transport/Get-AllMessageTraceResults.md
+    - Get-TerrlExternalRecipientEstimate: Transport/Get-TerrlExternalRecipientEstimate.md
     - ReplayQueueDatabases: Transport/ReplayQueueDatabases.md
     - Measure-EmailDelayInMTL: Transport/Measure-EmailDelayInMTL.md
 theme:


### PR DESCRIPTION
## Summary
- add a Transport script that estimates TERRL external-recipient usage from Get-MessageTraceV2 data
- add offline classification and pagination tests
- add the documentation landing page and Transport navigation entry

## Notes
The estimate is intentionally identified as approximate; Get-LimitsEnforcementStatus remains the live enforcement source of truth.