### PR TITLE
Test-ExchAVExclusions: add the server name to the output files

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -46,10 +46,10 @@ Just update script version to latest one.
 
 .OUTPUTS
 Log file:
-$PSScriptRoot\Test-ExchAvExclusions-#DataTime#.txt
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-#DataTime#.txt
 
 List of Scanned Folders:
-$PSScriptRoot\BadExclusions-#DataTime#.txt
+$PSScriptRoot\BadExclusions-#ServerName#-#DataTime#.txt
 
 .EXAMPLE
 .\Test-ExchAVExclusions.ps1
@@ -101,7 +101,7 @@ function Write-HostLog ($message) {
     }
 }
 
-$LogFileName = "Test-ExchAvExclusions"
+$LogFileName = "Test-ExchAvExclusions-$env:COMPUTERNAME"
 $StartDate = Get-Date
 $StartDateFormatted = ($StartDate).ToString("yyyyMMddhhmmss")
 $Script:DebugLogger = Get-NewLoggerInstance -LogName "$LogFileName-Debug-$StartDateFormatted" -LogDirectory $PSScriptRoot -AppendDateTimeToFileName $false -ErrorAction SilentlyContinue
@@ -114,7 +114,7 @@ SetWriteWarningAction ${Function:Write-HostLog}
 
 $BuildVersion = ""
 
-Write-Host ("Test-ExchAVExclusions.ps1 script version $($BuildVersion)") -ForegroundColor Green
+Write-Host ("Test-ExchAVExclusions.ps1 script version $($BuildVersion) on server $env:COMPUTERNAME") -ForegroundColor Green
 
 if ($ScriptUpdateOnly) {
     switch (Test-ScriptVersion -AutoUpdate -VersionsUrl "https://aka.ms/Test-ExchAVExclusions-VersionsURL" -Confirm:$false) {
@@ -605,9 +605,9 @@ foreach ($extension in $extensionsList) {
 #Delete Random Folder
 Remove-Item $randomFolder -Confirm:$false -Force -Recurse
 
-$OutputPath = Join-Path $PSScriptRoot BadExclusions-$StartDateFormatted.txt
+$OutputPath = Join-Path $PSScriptRoot "BadExclusions-$env:COMPUTERNAME-$StartDateFormatted.txt"
 "###########################################################################################" | Out-File $OutputPath
-"Exclusions analysis at $((Get-Date).ToString())" | Out-File $OutputPath -Append
+"Exclusions analysis on server $env:COMPUTERNAME at $((Get-Date).ToString())" | Out-File $OutputPath -Append
 "###########################################################################################" | Out-File $OutputPath -Append
 
 # Report what we found

--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -45,11 +45,12 @@ Skip script version verification.
 Just update script version to latest one.
 
 .OUTPUTS
-Log file:
-$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-#DataTime#.txt
+Log files:
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-Results-#DateTime#.txt
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-Debug-#DateTime#.txt
 
 List of Scanned Folders:
-$PSScriptRoot\BadExclusions-#ServerName#-#DataTime#.txt
+$PSScriptRoot\BadExclusions-#ServerName#-#DateTime#.txt
 
 .EXAMPLE
 .\Test-ExchAVExclusions.ps1

--- a/docs/Diagnostics/Test-ExchAVExclusions.md
+++ b/docs/Diagnostics/Test-ExchAVExclusions.md
@@ -61,7 +61,7 @@ ScriptUpdateOnly | Just update script version to latest one.
 ## Outputs
 
 Log file:
-$PSScriptRoot\Test-ExchAvExclusions-#DateTime#.txt
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-#DateTime#.txt
 
 List of Folders, extensions Scanned by AV and List of Non-Default Processes:
-$PSScriptRoot\BadExclusions-#DateTime#.txt
+$PSScriptRoot\BadExclusions-#ServerName#-#DateTime#.txt

--- a/docs/Diagnostics/Test-ExchAVExclusions.md
+++ b/docs/Diagnostics/Test-ExchAVExclusions.md
@@ -60,8 +60,9 @@ ScriptUpdateOnly | Just update script version to latest one.
 
 ## Outputs
 
-Log file:
-$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-#DateTime#.txt
+Log files:
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-Results-#DateTime#.txt
+$PSScriptRoot\Test-ExchAvExclusions-#ServerName#-Debug-#DateTime#.txt
 
 List of Folders, extensions Scanned by AV and List of Non-Default Processes:
 $PSScriptRoot\BadExclusions-#ServerName#-#DateTime#.txt


### PR DESCRIPTION
I want to see the server name in the results.

Engineers often share only one of the output files, and when the data comes from
several servers there is nothing in the file that says which server it belongs to.
The only identifier today is a timestamp, which does not help.

This change stamps the computer name into both the file names and the header line
written inside them:

- `BadExclusions-<SERVER>-<date>.txt` -> `Exclusions analysis on server <SERVER> at ...`
- `Test-ExchAvExclusions-<SERVER>-Results-<date>.txt`
- `Test-ExchAvExclusions-<SERVER>-Debug-<date>.txt`

The Results/Debug logs are covered by a single change to `$LogFileName` plus the
existing version banner, which is written to both loggers.

Docs updated in the script `.OUTPUTS` block and in `docs/Diagnostics/Test-ExchAVExclusions.md`.

Tested on Exchange Server SE (WS2025-SE-DEBUG) with the script built from `dist/`:
all three files are produced with the server name in the name and in the content.
`.build\CodeFormatter.ps1`, cspell and `.build\Build.ps1` all pass.