### PR TITLE
Add formatter check for backtick line continuation

### DIFF
--- a/.build/CodeFormatterChecks/CheckBacktickLineContinuation.ps1
+++ b/.build/CodeFormatterChecks/CheckBacktickLineContinuation.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function CheckBacktickLineContinuation {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo,
+
+        [Parameter()]
+        [boolean]
+        $Save
+    )
+
+    if ($FileInfo.Extension -ne ".ps1" -and $FileInfo.Extension -ne ".psm1") {
+        return $false
+    }
+
+    $content = Get-Content -Path $FileInfo.FullName -Raw
+    $errorsReturned = $null
+    $tokens = [System.Management.Automation.PSParser]::Tokenize($content, [ref]$errorsReturned)
+    if ($errorsReturned.Count -gt 0) {
+        Write-Warning "Failed to tokenize script: $($FileInfo.FullName)."
+        return $true
+    }
+
+    $lineContinuations = @($tokens | Where-Object { $_.Type -eq "LineContinuation" })
+    foreach ($token in $lineContinuations) {
+        Write-Warning "Backtick line continuation at line $($token.StartLine) in file $($FileInfo.FullName)."
+    }
+
+    return $lineContinuations.Count -gt 0
+}

--- a/.build/Invoke-CodeFormatterOnFiles.ps1
+++ b/.build/Invoke-CodeFormatterOnFiles.ps1
@@ -5,6 +5,7 @@
 
 . $PSScriptRoot\Load-Module.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckContainsCurlyQuotes.ps1
+. $PSScriptRoot\CodeFormatterChecks\CheckBacktickLineContinuation.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckFileHasNewlineAtEndOfFile.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckMarkdownFileHasNoBOM.ps1
 . $PSScriptRoot\CodeFormatterChecks\CheckMultipleEmptyLines.ps1
@@ -59,6 +60,7 @@ function Invoke-CodeFormatterOnFiles {
         $errorCount += (CheckTokenTypeCasing $fileInfo $Save "Operator") ? 1 : 0
         $errorCount += (CheckMultipleEmptyLines $fileInfo $Save) ?  1 : 0
         $errorCount += (CheckContainsCurlyQuotes $fileInfo $Save) ? 1 : 0
+        $errorCount += (CheckBacktickLineContinuation $fileInfo $Save) ? 1 : 0
 
         $results = @(CheckScriptFormat $fileInfo $Save)
         if ($results.Length -gt 0 -and $results[0] -eq $true) {


### PR DESCRIPTION
## Summary

Adds a token-based formatter check for PowerShell backtick line continuations. It reports each offending file and line, and intentionally does not modify source when -Save is used.

Closes #2573.

## Validation

- Parsed both changed PowerShell files with scriptblock::Create
- Ran focused fixtures: a real continuation is reported; escaped backticks in strings, comments, and here-strings are ignored
- Ran git diff --check

AI assistance: OpenAI Codex helped implement and validate this focused change.