### PR TITLE
Test-ExchAVExclusions: allow icuuc.dll and icuin.dll

### DIFF
--- a/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
+++ b/Diagnostics/AVTester/Test-ExchAVExclusions.ps1
@@ -445,6 +445,9 @@ while ($currentDiff -gt 0) {
         #Windows
         $ModuleAllowList.Add("prxyqry.DLL")
         $ModuleAllowList.Add("icu.dll")
+        # ICU component libraries shipped next to icu.dll, still present in Windows Server 2025
+        $ModuleAllowList.Add("icuuc.dll")
+        $ModuleAllowList.Add("icuin.dll")
         $ModuleAllowList.Add("TextShaping.dll")
 
         #Windows Fraunhofer IIS MPEG Audio Layer-3 ACM codec - MPEG Audio Layer-3 Codec for MSACM


### PR DESCRIPTION
The allow list carries `icu.dll` but not the two ICU component libraries that Windows ships next to it, `icuuc.dll` and `icuin.dll`. All three are present in System32 through Windows Server 2025.

Because of that, the FIP-FS processes that do text extraction and scanning, ParserServer and scanningprocess, report both libraries as unexpected modules on every run, which is noise that hides the findings that matter.

Sample output before the change:

```
PROCESS: ParserServer PID(51008) UNEXPECTED MODULE: icuin.dll COMPANY: The ICU Project
        PATH: C:\Windows\SYSTEM32\icuin.dll
        FileVersion: 61, 1, 0, 0
PROCESS: scanningprocess PID(30240) UNEXPECTED MODULE: icuuc.dll COMPANY: The ICU Project
        PATH: C:\Windows\SYSTEM32\icuuc.dll
        FileVersion: 61, 1, 0, 0
```

`.build\CodeFormatter.ps1`, cspell and `.build\Build.ps1` all pass.